### PR TITLE
Make manage.py respect --verbosity

### DIFF
--- a/local_apps/pootle_app/management/commands/__init__.py
+++ b/local_apps/pootle_app/management/commands/__init__.py
@@ -69,6 +69,12 @@ class PootleCommand(NoArgsCommand):
                     logging.error(u"failed to run %s over %s:\n%s", self.name, store.pootle_path, e)
 
     def handle_noargs(self, **options):
+        # adjust debug level to the verbosity option
+        verbosity = int(options.get('verbosity', 1))
+        debug_levels = {0:logging.ERROR, 1:logging.WARNING, 2:logging.DEBUG}
+        debug_level = debug_levels.get(verbosity, logging.DEBUG)
+        logging.getLogger().setLevel(debug_level)
+        
         # reduce size of parse pool early on
         self.name = self.__class__.__module__.split('.')[-1]
         from pootle_store.fields import  TranslationStoreFieldFile


### PR DESCRIPTION
--verbosity is a standard option for the django manangement tool and indicates how much output the user wants to see (0 = minimal output, 1 = normal output (default), 2 = all output). Pootle outputs all kind of INFO notices to STDERR regardless of the verbosity option which is annoying.

In this branch the log level is adjusted according to the verbosity setting so this problem is fixed.
