### PR TITLE
new about contributors page

### DIFF
--- a/pootle/apps/pootle_app/templates/index/contributors.html
+++ b/pootle/apps/pootle_app/templates/index/contributors.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% get_current_language as LANGUAGE_CODE %}
+
+{% block title %}
+{{ block.super }} » {% trans "Contributors" %}
+{% endblock %}
+
+{% block breadcrumb_content %}
+{{ block.super }} » <span>{% trans "Contributors" %}</span>
+{% endblock %}
+
+{% block css %}
+{{ block.super }}
+<style type="text/css">
+#contributors li { padding-left:25px; }
+#contributors li.lang { font-weight:bold; font-size: 120%; margin-top:12px; }
+#contributors li.proj { font-weight:bold; font-size: 80%; }
+#contributors li.user { font-weight:normal; font-size: 100%; }
+</style>
+{% endblock %}
+
+{% block body.id %}about{% endblock body.id %}
+
+{% block content %}
+
+<ul id="contributors">
+  {% for language, projects in contributors %}
+  <li class="lang">{{ language }}
+    <ul>
+      {% for project, users in projects %}
+      <li class="proj">{{ project }}
+        <ul>
+          {% for user in users %}
+          <li class="user">{{ user }}</li>
+          {% endfor %}
+        </ul>
+      </li>
+      {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>
+
+
+{% endblock content%}

--- a/pootle/apps/pootle_app/views/index/contributors.py
+++ b/pootle/apps/pootle_app/views/index/contributors.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2009 Zuza Software Foundation
+#
+# This file is part of Pootle.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from django.contrib.auth.models import User
+from pootle_statistics.models import Submission
+from pootle_translationproject.models import TranslationProject
+from pootle_project.models import Project
+from pootle_language.models import Language
+from pootle_app.models import Suggestion
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+from django.conf import settings
+
+# get versions
+
+
+def view(request):
+    """render a nested list like this::
+
+        contributors = [
+          ('french', [
+            ('Hackaraus', ['Auser Name', 'username2', ...]),
+            ('Project 2', ['username1', 'usernameX', ...]),
+            ...
+            ]),
+          ('spanish', [
+            ('Project 1', ['User 1', 'User2', ...]),
+            ('Project 2', ['User 1', 'UserX', ...]),
+            ]
+
+        }
+    """
+
+    exclude_project_names = getattr(
+        settings,
+        'CONTRIBUTORS_EXCLUDED_PROJECT_NAMES',
+        []
+    )
+    excluded_names = set(getattr(
+        settings,
+        'CONTRIBUTORS_EXCLUDED_NAMES',
+        []
+    ))
+
+    user_names = {}  # user id -> name
+    _skip_users = set()
+    for user in (User.objects.all()
+                 .values('id', 'first_name', 'last_name', 'username')):
+        if excluded_names:
+            names = [user[e] for e in ['username', 'first_name', 'last_name']]
+            if set(names) & excluded_names:
+                _skip_users.add(user['id'])
+                continue
+        name = ('%s %s' % (user['first_name'], user['last_name'])).strip()
+        if not name:
+            name = user['username']
+        user_names[user['id']] = name
+
+    language_names = {}  # language id -> name
+    for language in Language.objects.all().values('id', 'fullname'):
+        language_names[language['id']] = language['fullname']
+
+    project_names = {}  # project id -> name
+    for project in (Project.objects
+                    .exclude(fullname__in=exclude_project_names)
+                    .values('id', 'fullname')):
+        project_names[project['id']] = project['fullname']
+
+    # map users to projects per language across:
+    # submitters, suggesters and reviewers
+    languages = {}
+    tp_to_lang_id = {}
+    tp_to_proj_id = {}
+
+    # prepare a map of TranslationProject IDs to
+    # language and project to save queries for later
+    for tp in (TranslationProject.objects.all()
+               .values('id', 'language_id', 'project_id')):
+        tp_to_lang_id[tp['id']] = tp['language_id']
+        tp_to_proj_id[tp['id']] = tp['project_id']
+
+    for model, user_key in ((Submission, 'submitter_id'),
+                            (Suggestion, 'suggester_id'),
+                            (Suggestion, 'reviewer_id')):
+        for item in (model.objects.all()
+                     .values('translation_project_id', user_key)
+                     .distinct()):
+            lang_id = tp_to_lang_id[item['translation_project_id']]
+            proj_id = tp_to_proj_id[item['translation_project_id']]
+            user_id = item[user_key]
+            if not user_id:  # bad paste on_delete cascades
+                continue
+            if lang_id not in languages:
+                languages[lang_id] = {}
+            if proj_id not in languages[lang_id]:
+                languages[lang_id][proj_id] = set()
+            languages[lang_id][proj_id].add(user_id)
+
+    # finally, turn this massive dict into a list of lists of lists
+    # to be used in the template to loop over.
+    # also change from IDs to real names
+    contributors = []
+    for lang_id, projectsmap in languages.items():
+        language = language_names[lang_id]
+        projects = []
+        users = None
+        for proj_id, user_ids in projectsmap.items():
+            usersset = [user_names[x] for x in user_ids
+                                      if x not in _skip_users]
+            users = sorted(usersset, lambda x, y: cmp(x.lower(), y.lower()))
+            try:
+                projectname = project_names[proj_id]
+            except KeyError:
+                # some legacy broken project or excluded
+                continue
+            if users:
+                projects.append((projectname, users))
+        if projects:
+            contributors.append((language, projects))
+    contributors.sort()
+
+    data = {'contributors': contributors}
+
+    return render_to_response(
+        'index/contributors.html',
+        data,
+        context_instance=RequestContext(request)
+    )

--- a/pootle/apps/pootle_app/views/index/urls.py
+++ b/pootle/apps/pootle_app/views/index/urls.py
@@ -24,4 +24,5 @@ urlpatterns = patterns('pootle_app.views.index',
     (r'^robots.txt$',      'robots.view'),
     (r'^about.html$',      'about.view'),
     (r'^/?$|^index.html$', 'index.view'),
+    (r'^about/contributors$', 'contributors.view'),
 )

--- a/pootle/settings/90-local.conf.sample
+++ b/pootle/settings/90-local.conf.sample
@@ -142,3 +142,15 @@ MT_BACKENDS = [
 LOOKUP_BACKENDS = [
 #        'wikipedia',
 ]
+
+
+# Certain username and names should not be included in the contributors page
+CONTRIBUTORS_EXCLUDED_NAMES = (
+#        'sorryjusttesting',
+#        'testest',
+)
+
+# Certain projects should not be included in the contributors page
+CONTRIBUTORS_EXCLUDED_PROJECT_NAMES = (
+#        "Testing, please don't work here",
+)

--- a/pootle/templates/base.html
+++ b/pootle/templates/base.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html  PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+<!DOCTYPE html  PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
           "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 {% load i18n assets baseurl cache legalpage_tags %}
 
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{{ LANGUAGE_CODE }}" 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{{ LANGUAGE_CODE }}"
       lang="und" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <title>{% block title %}{{ settings.TITLE }}{% endblock title %}</title>
@@ -160,6 +160,7 @@
                     {% if settings.CAN_CONTACT %}
                     <li><a href='{{ "/contact/"|l }}'>{% trans "Contact Us" %}</a></li>
                     {% endif %}
+                    <li><a href='{{ "/about/contributors"|l }}'>{% trans "Contributors" %}</a></li>
                     <li><a href='{{ "/about.html"|l }}'>{% trans "About this Pootle Server" %}</a></li>
                     {% cache settings.CACHE_TIMEOUT legalpages LANGUAGE_CODE %}
                     {% get_legalpages as legalpages %}


### PR DESCRIPTION
This is as per our email discussion recently. I don't expect you to necessarily just merge this in as is. More work is most definitely needed. 
1. Sorry about my editor fixing your trailing whitespace
2. I made the template by copying another one and hopefully just adding my relevant changes
3. The view code _is_ complex and kinda messy but it's like that for the sake of optimization
   (see https://blog.mozilla.org/webdev/2011/12/15/django-optimization-story-thousand-times-faster/)
   but perhaps you have some new better ideas. 
4. I wanted to make the URL `/about/contributors/` but couldn't. If I add a `/$` it gets trapped by the legalpags fallback handler. 
5. I have no idea how to make the necessary admin option for making this optionally appear in the footer or not. 
