### PR TITLE
fabfile: create the 'pootle/assets' folder

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -142,6 +142,7 @@ def deploy_static():
     with settings(hide('stdout', 'stderr')):
         with cd('%(project_repo_path)s' % env):
             with prefix('source %(env_path)s/bin/activate' % env):
+                run('mkdir -p pootle/assets')
                 run('python manage.py collectstatic --noinput')
                 run('python manage.py assets build')
 


### PR DESCRIPTION
This folder is not present on a fresh installation and this leads to an error while running deploy_static.
