### PR TITLE
Fix for corrupted targets when using placeables

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -363,6 +363,7 @@ class Unit(models.Model, base.TranslationUnit):
                     unit.target = strings
                     changed = True
             else:
+                unit.rich_target = self.target
                 unit.target = self.target
                 changed = True
 


### PR DESCRIPTION
Without this, editing a target in an XLIFF with placeholders will result in repeated text that is not fixable within Pootle.