### PR TITLE
Sync terminology store when creating or updating

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -45,7 +45,7 @@ from pootle_statistics.models import SubmissionFields, SubmissionTypes
 from pootle_store.fields import (TranslationStoreField, MultiStringField,
                                  PLURAL_PLACEHOLDER, SEPARATOR)
 from pootle_store.filetypes import factory_classes, is_monolingual
-from pootle_store.util import (calculate_stats, empty_quickstats,
+from pootle_store.util import (calculate_stats, empty_quickstats, absolute_real_path,
                                OBSOLETE, UNTRANSLATED, FUZZY, TRANSLATED)
 
 
@@ -1226,10 +1226,10 @@ class Store(models.Model, base.TranslationStore):
 
                 storeclass = self.get_file_class()
                 store_path = os.path.join(
-                    self.translation_project.abs_real_path, self.name
+                    self.translation_project.real_path, self.name
                 )
                 store = self.convert(storeclass)
-                store.savefile(store_path)
+                store.savefile(absolute_real_path(store_path))
 
                 self.file = store_path
                 self.update_store_header(profile=profile)
@@ -1239,7 +1239,8 @@ class Store(models.Model, base.TranslationStore):
                 self.save()
             return
 
-        if conservative and self.translation_project.is_template_project:
+        if conservative and self.translation_project.is_template_project \
+           and not self.name.startswith("pootle-terminology"):
             # don't save to templates
             return
 

--- a/pootle/apps/pootle_terminology/views.py
+++ b/pootle/apps/pootle_terminology/views.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.shortcuts import render_to_response
@@ -108,6 +110,7 @@ def extract(request, translation_project):
         if store.state < PARSED:
             store.state = PARSED
         store.save()
+        store.sync(create=True)
 
         template_vars['store'] = store
         template_vars['termcount'] = len(termunits)
@@ -159,9 +162,11 @@ def manage_store(request, template_vars, language, term_store):
 
             return value
 
-    return util.edit(request, 'terminology/manage.html', Unit, template_vars, None, None,
-                     queryset=term_store.units, can_delete=True, form=TermUnitForm,
-                     exclude=['state', 'target_f', 'id', 'translator_comment'])
+    res = util.edit(request, 'terminology/manage.html', Unit, template_vars, None, None,
+                    queryset=term_store.units, can_delete=True, form=TermUnitForm,
+                    exclude=['state', 'target_f', 'id', 'translator_comment'])
+    term_store.sync(create=True, update_structure=True, update_translation=True)
+    return res
 
 @get_translation_project
 @util.has_permission('administrate')


### PR DESCRIPTION
This way translators get a chance to edit terminology offline.
Also syncing is required for updating terminology translations against
templates.

This patch depends on the pull request #22. So probably you can't merge it before the release of 2.5.0. But it means that the terminology feature doesn't really work in the pre-release. Especially the part "It is also possible to add extra entries".