### PR TITLE
Fix bug #2674: add dummy JS file with translation messages

### DIFF
--- a/pootle/static/js/strings.js
+++ b/pootle/static/js/strings.js
@@ -1,0 +1,16 @@
+// These are some strings from jQuery templates that are impossible to extract
+// using django-admin.py makemessages since they are not JavaScript code, nor
+// Python code, nor Django templates, nor any format that Django makemessages
+// is able to parse.
+
+// Translators: from pootle/apps/pootle_store/templates/unit/xhr-edit-ctx.html
+gettext("More");
+
+// Translators: from pootle/apps/pootle_store/templates/unit/xhr-edit-ctx.html
+gettext("Hide");
+
+// Translators: from pootle/apps/pootle_store/templates/unit/xhr-edit-ctx.html
+gettext("Less");
+
+// Translators: from pootle/apps/pootle_store/templates/unit/xhr-edit-ctx.html
+gettext("Show");


### PR DESCRIPTION
Quick and dirty solution for the jQuery templates translation messages
extraction issue (bug #2674).
