### PR TITLE
ldapauth: fix crash on entering wrong password

### DIFF
--- a/pootle/auth/ldap_backend.py
+++ b/pootle/auth/ldap_backend.py
@@ -78,8 +78,7 @@ class LdapBackend(object):
                 logger.info("First login for LDAP user (%s).  "
                             "Creating new account." % username)
                 user = User(username=username, is_active=True)
-                user.password = ('LDAP_%s' %
-                                 (User.objects.make_random_password(32)))
+                user.set_unusable_password()
                 for i in settings.AUTH_LDAP_FIELDS:
                     if i != 'dn' and len(settings.AUTH_LDAP_FIELDS[i]) > 0:
                         setattr(user, i,


### PR DESCRIPTION
LDAP_ is wrong prefix for unused passwords as it triggers exception
for wrong passwords:
ValueError: Unknown password hashing algorithm 'LDAP_Xnmn9ZRne376RMcSQK6YrUfd2rqmjaZP'.
Did you specify it in the PASSWORD_HASHERS setting?
