### PR TITLE
Avoid DoesNotExist exception after switching to another language from unit translate page

### DIFF
--- a/pootle/static/js/common.js
+++ b/pootle/static/js/common.js
@@ -126,7 +126,7 @@
 
       var newUrl = curUrl.replace(curLanguage + '/' + curProject,
                                   langCode + '/' + curProject)
-                         .replace(/(\?|&)unit=\d+/, '');
+                         .replace(/(\#|&)unit=\d+/, '');
       window.location.href = newUrl;
     }
 


### PR DESCRIPTION
There was a typo, I think.
We use '#' (not '?') for URL parameterization on translate page.
