### PR TITLE
Remove ? character in project overview URL pattern

### DIFF
--- a/pootle/apps/pootle_project/urls.py
+++ b/pootle/apps/pootle_project/urls.py
@@ -27,7 +27,7 @@ urlpatterns = patterns('pootle_project.views',
         'projects_index'),
 
     # Specific project
-    url(r'^(?P<project_code>[^/]*)/?$',
+    url(r'^(?P<project_code>[^/]*)/$',
         'project_language_index', name='project.overview'),
 
     # Admin


### PR DESCRIPTION
This should fix bug 2763.

Yes, touching the urlconf can have undesired effects as Julen said, but there is no way to force appending a / character at the end of the project URL in the breadcrumbs because in tp_base.html the breadcrumbs already uses url tags to create the URLs. So the problem is in the URL in the urlconf.
