### PR TITLE
'/usr/bin/python' => '/usr/bin/env python'

### DIFF
--- a/pootle/apps/pootle_app/views/admin/adminpages.py
+++ b/pootle/apps/pootle_app/views/admin/adminpages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #  Copyright 2006-2012 Zuza Software Foundation
 #

--- a/pootle/apps/pootle_misc/siteconfig.py
+++ b/pootle/apps/pootle_misc/siteconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2004-2009 Zuza Software Foundation

--- a/pootle/apps/pootle_misc/util.py
+++ b/pootle/apps/pootle_misc/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2004-2012 Zuza Software Foundation

--- a/pootle/apps/pootle_store/util.py
+++ b/pootle/apps/pootle_store/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2004-2012 Zuza Software Foundation

--- a/pootle/scripts/history/amo.py
+++ b/pootle/scripts/history/amo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Verbatim script for managing the addons.mozilla.org project.  More
 # information at https://wiki.mozilla.org/Verbatim

--- a/pootle/scripts/hooks.py
+++ b/pootle/scripts/hooks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 

--- a/pootle/scripts/sumo.py
+++ b/pootle/scripts/sumo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Verbatim script for managing the SUMO (support.mozilla.com) project.  More information at
 # https://wiki.mozilla.org/Verbatim


### PR DESCRIPTION
Unifying shebang lines, those were the only ones not using `env`.
