### PR TITLE
Add --noinput flag for `pootle init`

### DIFF
--- a/docs/server/installation.rst
+++ b/docs/server/installation.rst
@@ -112,6 +112,8 @@ for it. This is as easy as running::
 By default it writes the configuration file at ``~/.pootle/pootle.conf`` but
 if you want you can pass an alternative path as an argument to the ``init``
 command.
+If the desired path exists, you will be prompted for whether to overwrite the
+old configuration. Passing the ``--noinput`` flag assumes a negative answer.
 
 This default configuration is enough to initially experiment with Pootle but
 **it's highly discouraged and unsupported to use this configuration in a

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -128,6 +128,10 @@ def run_app(project, default_settings_path, settings_template,
         sys.exit(2)
 
     if command == 'init':
+        noinput = '--noinput' in command_args
+        if noinput:
+            command_args.remove('--noinput')
+
         # Determine which config file to write
         try:
             import re
@@ -141,12 +145,14 @@ def run_app(project, default_settings_path, settings_template,
 
         if os.path.exists(config_path):
             resp = None
+            if noinput:
+                resp = 'n'
             while resp not in ('Y', 'n'):
                 resp = raw_input('File already exists at %r, overwrite? [nY] ' \
                                  % config_path)
-                if resp == 'n':
-                    print "Aborted!"
-                    return
+            if resp == 'n':
+                print "File already exists, not overwriting."
+                return
 
         try:
             init_settings(config_path, settings_template)


### PR DESCRIPTION
Required a slight restructuring in program flow and a reworded message.
The "yes" branch may not always be feasible, or at least I would like to confirm overwrite operations.
