### PR TITLE
Cleanups and fall back to HTML markup when markup configured module is missing

### DIFF
--- a/pootle/apps/pootle_misc/util.py
+++ b/pootle/apps/pootle_misc/util.py
@@ -185,6 +185,9 @@ def get_markup_filter():
 
         * The MARKUP_FILTER option is improperly set.
 
+        * The markup filter name set can't be used because the required
+          package isn't installed.
+
         * The markup filter name set is not one of the acceptable markup
           filter names.
     """
@@ -192,7 +195,13 @@ def get_markup_filter():
         markup_filter, markup_kwargs = settings.MARKUP_FILTER
         if markup_filter is None:
             return (None, "unset")
-        elif markup_filter not in ('textile', 'markdown', 'restructuredtext'):
+        elif markup_filter == 'textile':
+            import textile
+        elif markup_filter == 'markdown':
+            import markdown
+        elif markup_filter == 'restructuredtext':
+            import docutils
+        else:
             raise ValueError()
     except AttributeError:
         logging.error("MARKUP_FILTER is missing. Falling back to HTML.")
@@ -200,6 +209,10 @@ def get_markup_filter():
     except IndexError:
         logging.error("MARKUP_FILTER is misconfigured. Falling back to HTML.")
         return (None, "misconfigured")
+    except ImportError:
+        logging.warning("Can't find the package which provides '%s' markup "
+                        "support. Falling back to HTML.", markup_filter)
+        return (None, "uninstalled")
     except ValueError:
         logging.error("Invalid value '%s' in MARKUP_FILTER. Falling back to "
                       "HTML." % markup_filter)

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -32,6 +32,9 @@ FUZZY_MATCH_MIN_SIMILARITY = 75
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
+# IMPORTANT: If you want to use one of these markup filters you must install on
+# your own the required packages.
+#
 # Examples:
 #    MARKUP_FILTER = (None, {})
 #    MARKUP_FILTER = ('markdown', {'safe_mode': 'escape'})

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -139,6 +139,9 @@ VCS_DIRECTORY = working_path('repos')
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
+# IMPORTANT: If you want to use one of these markup filters you must install on
+# your own the required packages.
+#
 # Examples:
 #    MARKUP_FILTER = (None, {})
 #    MARKUP_FILTER = ('markdown', {'safe_mode': 'escape'})

--- a/pootle/settings/90-local.conf.sample
+++ b/pootle/settings/90-local.conf.sample
@@ -124,6 +124,9 @@ PODIRECTORY = working_path('po')
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
+# IMPORTANT: If you want to use one of these markup filters you must install on
+# your own the required packages.
+#
 # Examples:
 #    MARKUP_FILTER = (None, {})
 #    MARKUP_FILTER = ('markdown', {'safe_mode': 'escape'})


### PR DESCRIPTION
This fixes bug #2380.
