### PR TITLE
Change default number of working threads of CherryPy to 5

### DIFF
--- a/pootle/apps/pootle_app/management/commands/run_cherrypy.py
+++ b/pootle/apps/pootle_app/management/commands/run_cherrypy.py
@@ -30,9 +30,9 @@ class Command(BaseRunCommand):
     help = "Runs Pootle with the CherryPy server."
 
     option_list = BaseRunCommand.option_list + (
-        make_option('--threads', action='store', dest='threads', default=1,
+        make_option('--threads', action='store', dest='threads', default=5,
             type=int,
-            help='Number of working threads. Default: 1'),
+            help='Number of working threads. Default: 5'),
         make_option('--name', action='store', dest='server_name', default='',
             help='Name of the worker process.'),
         make_option('--queue', action='store', dest='request_queue_size',


### PR DESCRIPTION
If the number of working threads for CherryPy is only 1, HTTP requests to Pootle server will get stuck as following image shows (it waits about 20 seconds to get CSS and JS files):

![before](https://f.cloud.github.com/assets/23497/484618/164d5fc2-b8dd-11e2-9285-c84b983038ea.png)

This pull request changes the default number of working threads of CherryPy from 1 to 5, and HTTP requests won't get stuck any more as following image shows:

![after](https://f.cloud.github.com/assets/23497/484634/e3735f2e-b8dd-11e2-93cb-7beaf9d3c5d5.png)
