### PR TITLE
Language names truncated 

### DIFF
--- a/pootle/static/css/select2.css
+++ b/pootle/static/css/select2.css
@@ -89,7 +89,6 @@ Version: @@ver@@ Timestamp: @@timestamp@@
 .select2-container .select2-choice span {
     margin-right: 26px;
     display: block;
-    overflow: hidden;
 
     white-space: nowrap;
 


### PR DESCRIPTION
Removed 'overflow: hidden' rule to prevent language names from getting truncated replaced with ellipsis.
