### PR TITLE
Fixes language names truncation in breadcrumbs

### DIFF
--- a/pootle/static/css/select2-pootle.css
+++ b/pootle/static/css/select2-pootle.css
@@ -209,3 +209,7 @@
     max-width: 30em;
 }
 
+.select2-container .select2-choice span {
+    overflow: visible;
+}
+


### PR DESCRIPTION
Override  'overflow: hidden' rule to prevent language names from getting truncated replaced with ellipsis.
