### PR TITLE
Fix breadcrumb alignment issue in chrome (fixes #2766)

### DIFF
--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1843,7 +1843,7 @@ html[dir="rtl"] .breadcrumb li
 
 .breadcrumb li:first-child:before
 {
-    content: "";
+    content: " ";
     margin: 0;
 }
 


### PR DESCRIPTION
Simple fix for bug 2766. Tested on Chrome. 
