### PR TITLE
Fixing Google Translate

### DIFF
--- a/pootle/static/js/mt/google_translate.js
+++ b/pootle/static/js/mt/google_translate.js
@@ -69,7 +69,7 @@
 
     init: function (apiKey) {
       /* Prepare URL for requests. */
-      this.url = PTL.editor.settings.secure == false ? this.url : this.url.replace("http", "https");
+      this.url = PTL.editor.settings.secure == true ? this.url : this.url.replace("http", "https");
       this.url += "?callback=?";
       /* Set API key */
       this.apiKey = apiKey;


### PR DESCRIPTION
Fix the Google Translate calls over HTTPS by correcting a misunderstood ternary operator.

Signed-off-by: Hakan Bayindir hakan.bayindir@tubitak.gov.tr
