### PR TITLE
Using version placeholder in filename 

### DIFF
--- a/pootle/apps/pootle_app/assets.py
+++ b/pootle/apps/pootle_app/assets.py
@@ -30,12 +30,12 @@ js_common = Bundle(
     'js/common.js', 'js/search.js', 'js/sorttable.js', 'js/spin.js',
     'js/utils.js', 'js/zoom.js',
     'js/shortcut.js',  # Leave shortcut.js as the last one
-    filters='rjsmin', output='js/common.min.js')
+    filters='rjsmin', output='js/common.min.%(version)s.js')
 register('js_common', js_common)
 
 js_admin = Bundle(
     'js/admin.js',
-    filters='rjsmin', output='js/admin.min.js')
+    filters='rjsmin', output='js/admin.min.%(version)s.js')
 register('js_admin', js_admin)
 
 js_editor = Bundle(
@@ -44,27 +44,27 @@ js_editor = Bundle(
     'js/jquery/jquery.fieldselection.js', 'js/jquery/jquery.caret.js',
     'js/jquery/jquery.highlightRegex.js', 'js/jquery/jquery.jsonp.js',
     'js/iso8601.js', 'js/editor.js', 'js/json2.js',
-    filters='rjsmin', output='js/editor.min.js')
+    filters='rjsmin', output='js/editor.min.%(version)s.js')
 register('js_editor', js_editor)
 
 css_common = Bundle(
     'css/style.css', 'css/fancybox.css', 'css/tipsy.css',
     'css/markup.css', 'css/sprite.css', 'css/select2.css',
     'css/select2-pootle.css',
-    filters='cssmin', output='css/common.min.css')
+    filters='cssmin', output='css/common.min.%(version)s.css')
 register('css_common', css_common)
 
 css_admin = Bundle(
     'css/admin.css',
-    filters='cssmin', output='css/admin.min.css')
+    filters='cssmin', output='css/admin.min.%(version)s.css')
 register('css_admin', css_admin)
 
 css_editor = Bundle(
     'css/editor.css',
-    filters='cssmin', output='css/editor.min.css')
+    filters='cssmin', output='css/editor.min.%(version)s.css')
 register('css_editor', css_editor)
 
 css_custom = Bundle(
     'css/custom/custom.css',
-    filters='cssmin', output='css/custom/custom.min.css')
+    filters='cssmin', output='css/custom/custom.min.%(version)s.css')
 register('css_custom', css_custom)


### PR DESCRIPTION
Changed the behavior of how webassets hash is included. Using the assets version as querystring '?de132d' means some UA and proxies fails to cache them properly. 

In this patch I am moving the webassets hash inline into the filename.  
