### PR TITLE
 Move string permalink to translate-right div fixes bug #2943

### DIFF
--- a/pootle/apps/pootle_store/templates/store/translate.html
+++ b/pootle/apps/pootle_store/templates/store/translate.html
@@ -65,7 +65,6 @@
   <div class="toolbar pull-left">
     {% render_search search_form %}
 
-    <div class="label">{% trans "Filter by:" %}</div>
     <div id="filter-status">
       <select class="js-select2 select2-filter-status" name="filter-status">
         {# Translators: This refers to "All strings" #}


### PR DESCRIPTION
Moving string permalink into the translation panel makes sense. 

![screenshot from 2013-05-29 12 11 34](https://f.cloud.github.com/assets/808895/577087/d540156e-c823-11e2-82db-ae99ab7b1ddd.png)

http://bugs.locamotion.org/show_bug.cgi?id=2943
