### PR TITLE
Ui hacks

### DIFF
--- a/pootle/templates/base.html
+++ b/pootle/templates/base.html
@@ -4,10 +4,13 @@
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
   <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>{% block title %}{{ settings.TITLE }}{% endblock title %}</title>
     {% block meta %}
     <meta content="text/html; charset=utf-8" http-equiv="content-type" />
     <meta name="description" content="{{ settings.DESCRIPTION|striptags }}" />
+    <meta name="viewport" content="width=device-width">
     <meta name="keywords" content="{{ keywords|join:", " }}" />
     <meta name="application-name" content="{{ settings.TITLE }}" />
     <link rel="icon" href="{{ "images/app-32x32.png"|s }}" sizes="32x32" />


### PR DESCRIPTION
Charset meta tags before title tag (https://github.com/h5bp/html5-boilerplate/blob/master/doc/html.md#the-order-of-meta-tags-and-title)
X-UA-Compatible meta tag (https://github.com/h5bp/html5-boilerplate/blob/master/doc/html.md#x-ua-compatible)
Added Mobile viewport
