### PR TITLE
Fixes bug 2964: Add a GitHub-like message for latest activity on a given TP

### DIFF
--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -41,6 +41,7 @@ from pootle_misc.baseurl import l
 from pootle_misc.stats import stats_message, stats_message_raw
 from pootle_misc.util import getfromcache, dictsum, deletefromcache
 from pootle_project.models import Project
+from pootle_statistics.models import Submission
 from pootle_store.models import (Store, Suggestion, Unit, QualityCheck, PARSED,
                                  CHECKED)
 from pootle_store.util import (absolute_real_path, calculate_stats,
@@ -213,6 +214,14 @@ class TranslationProject(models.Model):
                        conservative=conservative, create=False,
                        skip_missing=skip_missing,
                        modified_since=modified_since)
+
+    def get_latest_submission(self):
+        """Get the latest submission done in the Translation project"""
+        try:
+            sub = Submission.objects.filter(translation_project=self).latest()
+        except Submission.DoesNotExist:
+            return ''
+        return sub.get_as_action_bundle()
 
     @getfromcache
     def get_mtime(self):

--- a/pootle/apps/pootle_translationproject/templates/translation_project/overview.html
+++ b/pootle/apps/pootle_translationproject/templates/translation_project/overview.html
@@ -1,5 +1,5 @@
 {% extends "tp_base.html" %}
-{% load assets baseurl cache cleanhtml i18n locale progressbar search translation_project_tags common_tags %}
+{% load assets baseurl cache cleanhtml i18n locale progressbar search translation_project_tags common_tags profile_tags %}
 {% get_current_language as LANGUAGE_CODE %}
 
 {% block body_id %}tpoverview{% endblock %}
@@ -33,6 +33,17 @@
   {% if table %}
   <div class="hd">
     <h2>{% trans "Files and Subfolders" %}</h2>
+    {% if latest_action %}
+    <div class="last-action">
+      <a href="{{ latest_action.by_profile.get_absolute_url }}">
+        <img src="{{ latest_action.by_profile|gravatar:20 }}" />
+        {{ latest_action.by_profile.user.username }}
+      </a>
+      {{ latest_action.action|safe }}
+      <time class="extra-item-meta js-relative-date" title="{{ latest_action.date }}"
+        datetime="{{ latest_action.date.isoformat }}">&nbsp;</time>
+    </div>
+    {% endif %}
   </div>
   <div class="bd">
     <div class="files-subfolders" lang="{{ LANGUAGE_CODE }}">
@@ -156,6 +167,10 @@ $(function() {
 
     return false;
   });
+
+  PTL.common.updateRelativeDates();
+  setInterval(PTL.common.updateRelativeDates, 6e4);
+
 {% if upload %}
   $("select#id_upload_to_dir").parent().hide();
   $("input#id_file").change(function() {

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -253,6 +253,16 @@ class ProjectIndexView(view_handler.View):
                 }
             })
 
+            # If current directory is the TP root directory.
+            if not directory.path:
+                template_vars.update({
+                    'latest_action': translation_project.get_latest_submission()
+                })
+            else:
+                template_vars.update({
+                    'latest_action': Submission.get_latest_for_dir(path_obj)
+                })
+
         if can_edit:
             from pootle_translationproject.forms import DescriptionForm
             template_vars['form'] = DescriptionForm(instance=translation_project)

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -782,6 +782,27 @@ html[dir="rtl"] .hd h2
     margin-right: 0.5em;
 }
 
+.hd .last-action
+{
+    margin: 0.5em 0 0 1em;
+}
+
+html[dir="rtl"] .hd .last-action
+{
+    margin-left: 0;
+    margin-right: 1em;
+}
+
+.hd .last-action img
+{
+    vertical-align: middle;
+}
+
+.hd .last-action .extra-item-meta
+{
+    color: #999;
+}
+
 .hd h3
 {
     border-top: 1px solid #eee;


### PR DESCRIPTION
@khaledhosny This probably would need a look for RTL.

Also found several issues on getting the action type for the latest contribution on a given TP, so probably would be better to first fix other bugs, for example http://bugs.locamotion.org/show_bug.cgi?id=3011
