### PR TITLE
Bug 1720, set terminology project by checkstyle property

### DIFF
--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -90,6 +90,15 @@ class TranslationProjectManager(RelatedManager):
         #FIXME: should we use Language and Project codes instead?
         return self.get(pootle_path=pootle_path)
 
+    def get_terminology_project(self, language_id):
+        #FIXME: the code below currently uses the same approach
+        # to determine the 'terminology' kind of a project as 'Project.is_terminology()',
+        # which means it checks the value of 'checkstyle' field
+        # (see pootle_project/models.py:240).
+        #
+        # This should probably be replaced in the future with a dedicated project property.  
+        return self.get(language=language_id, 
+                        project__checkstyle='terminology')
 
 class TranslationProject(models.Model):
     _non_db_state_cache = LRUCachingDict(settings.PARSE_POOL_SIZE,
@@ -1011,7 +1020,8 @@ class TranslationProject(models.Model):
 
     @property
     def is_terminology_project(self):
-        return self.pootle_path.endswith('/terminology/')
+        return self.project.checkstyle == 'terminology'
+        # was: self.pootle_path.endswith('/terminology/')
 
     @property
     def is_template_project(self):
@@ -1028,10 +1038,7 @@ class TranslationProject(models.Model):
         else:
             # Get global terminology first
             try:
-                termproject = TranslationProject.objects.get(
-                        language=self.language_id,
-                        project__code='terminology',
-                )
+                termproject = TranslationProject.objects.get_terminology_project(self.language_id)
                 mtime = termproject.get_mtime()
                 terminology_stores = termproject.stores.all()
             except TranslationProject.DoesNotExist:


### PR DESCRIPTION
Started working on bug 1720. 
Set any project as terminology project selecting checkstyle field value as 'terminology'.
This should probably be replaced in the future with a dedicated project property. 
