### PR TITLE
Change the latest activity message shown inside a TP

### DIFF
--- a/pootle/apps/pootle_misc/stats.py
+++ b/pootle/apps/pootle_misc/stats.py
@@ -117,7 +117,7 @@ def get_translation_stats(path_obj, path_stats):
     return stats
 
 
-def get_path_summary(path_obj, path_stats):
+def get_path_summary(path_obj, path_stats, latest_action):
     """Returns a list of sentences to be displayed for each ``path_obj``."""
     summary = []
     incomplete = []
@@ -198,7 +198,8 @@ def get_path_summary(path_obj, path_stats):
         )
         suggestions.append(u'</a>')
 
-    return [u''.join(summary), u''.join(incomplete), u''.join(suggestions)]
+    return [u''.join(summary), latest_action, u''.join(incomplete),
+            u''.join(suggestions)]
 
 
 def stats_message_raw(version, stats):

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -221,7 +221,7 @@ class TranslationProject(models.Model):
             sub = Submission.objects.filter(translation_project=self).latest()
         except Submission.DoesNotExist:
             return ''
-        return sub.get_as_action_bundle()
+        return sub.get_submission_message()
 
     @getfromcache
     def get_mtime(self):

--- a/pootle/apps/pootle_translationproject/templates/translation_project/overview.html
+++ b/pootle/apps/pootle_translationproject/templates/translation_project/overview.html
@@ -33,17 +33,6 @@
   {% if table %}
   <div class="hd">
     <h2>{% trans "Files and Subfolders" %}</h2>
-    {% if latest_action %}
-    <div class="last-action">
-      <a href="{{ latest_action.by_profile.get_absolute_url }}">
-        <img src="{{ latest_action.by_profile|gravatar:20 }}" />
-        {{ latest_action.by_profile.user.username }}
-      </a>
-      {{ latest_action.action|safe }}
-      <time class="extra-item-meta js-relative-date" title="{{ latest_action.date }}"
-        datetime="{{ latest_action.date.isoformat }}">&nbsp;</time>
-    </div>
-    {% endif %}
   </div>
   <div class="bd">
     <div class="files-subfolders" lang="{{ LANGUAGE_CODE }}">

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -219,8 +219,15 @@ class ProjectIndexView(view_handler.View):
 
         path_obj = store or directory
 
+        latest_action = ''
+        # If current directory is the TP root directory.
+        if not directory.path:
+            latest_action = translation_project.get_latest_submission()
+        elif store is None:  # If this is not a file.
+            latest_action = Submission.get_latest_for_dir(path_obj)
+
         path_stats = get_raw_stats(path_obj, include_suggestions=True)
-        path_summary = get_path_summary(path_obj, path_stats)
+        path_summary = get_path_summary(path_obj, path_stats, latest_action)
         actions = action_groups(request, path_obj, path_stats=path_stats)
 
         template_vars.update({
@@ -252,16 +259,6 @@ class ProjectIndexView(view_handler.View):
                     'items': get_children(translation_project, directory),
                 }
             })
-
-            # If current directory is the TP root directory.
-            if not directory.path:
-                template_vars.update({
-                    'latest_action': translation_project.get_latest_submission()
-                })
-            else:
-                template_vars.update({
-                    'latest_action': Submission.get_latest_for_dir(path_obj)
-                })
 
         if can_edit:
             from pootle_translationproject.forms import DescriptionForm

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -308,12 +308,14 @@ html[dir="rtl"] ul.icons
 /* Hack to avoid ugly underlines in the space between icons and text */
 
 td.stats-name a:hover,
+.last-action > a:hover,
 .overview-actions-content a:hover
 {
     text-decoration: none;
 }
 
 td.stats-name a:hover > i + span,
+.last-action > a:hover > img + span,
 .overview-actions-content a:hover > i + span
 {
     text-decoration: underline;
@@ -782,23 +784,29 @@ html[dir="rtl"] .hd h2
     margin-right: 0.5em;
 }
 
-.hd .last-action
+.last-action
 {
-    margin: 0.5em 0 0 1em;
+    margin: 1em 0 1em 0;
+    padding: 0.5em;
+    background-color: #f8f8f8;
+    border: 1px solid #d9d9d9;
+    border-radius: 3px;
+    -moz-border-radius: 3px;
+    -webkit-border-radius: 3px;
 }
 
-html[dir="rtl"] .hd .last-action
+html[dir="rtl"] .last-action
 {
     margin-left: 0;
     margin-right: 1em;
 }
 
-.hd .last-action img
+.last-action img
 {
     vertical-align: middle;
 }
 
-.hd .last-action .extra-item-meta
+.last-action .extra-item-meta
 {
     color: #999;
 }


### PR DESCRIPTION
Now the message:
- is shown after the folder stats inside a box,
- includes an italiziced snippet from the unit source (or target), if
  applicable,
- the snippet shown might be trimmed to 40 chars, appending an ellipsis if
  trimmed.

Fixes bug 2964
