### PR TITLE
Bug 3021 — Don’t send emails to every registered user

### DIFF
--- a/pootle/apps/pootle_app/models/permissions.py
+++ b/pootle/apps/pootle_app/models/permissions.py
@@ -94,12 +94,15 @@ def get_permissions_by_username(username, directory):
     return permissions_cache[pootle_path]
 
 
-def get_matching_permissions(profile, directory):
+def get_matching_permissions(profile, directory, check_default=True):
     if profile.user.is_authenticated():
         permissions = get_permissions_by_username(profile.user.username,
                                                   directory)
         if permissions is not None:
             return permissions
+
+        if not check_default:
+            return {}
 
         permissions = get_permissions_by_username('default', directory)
         if permissions is not None:
@@ -110,13 +113,14 @@ def get_matching_permissions(profile, directory):
     return permissions
 
 
-def check_profile_permission(profile, permission_codename, directory):
+def check_profile_permission(profile, permission_codename, directory,
+                             check_default=True):
     """Checks if the current user has the permission the perform
     ``permission_codename``."""
     if profile.user.is_superuser:
         return True
 
-    permissions = get_matching_permissions(profile, directory)
+    permissions = get_matching_permissions(profile, directory, check_default)
 
     return ("administrate" in permissions or
             permission_codename in permissions)

--- a/pootle/apps/pootle_notifications/views.py
+++ b/pootle/apps/pootle_notifications/views.py
@@ -127,7 +127,8 @@ def get_recipients(restrict_to_active_users, directory):
     recipients = []
     for person in to_list:
         # Check if the User profile has permissions in the directory.
-        if not check_profile_permission(person, 'view', directory):
+        if not check_profile_permission(person, 'view', directory,
+                                        check_default=False):
             continue
 
         if person.user.email:


### PR DESCRIPTION
News emails are sent to every registered user even when sent from a
given project, that is because get_matching_permissions() falls back to
checking the permission of user “default” when the given user has no
explicit permissions for that directory, but this is not desired here.
