### PR TITLE
Added delete method to Directory class (see bug 2776)

### DIFF
--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -69,6 +69,12 @@ class Directory(models.Model):
 
         super(Directory, self).save(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        for store in self.stores.iterator():
+            store.delete()
+
+        super(Directory, self).delete(*args, **kwargs)
+
     def get_relative(self, path):
         """Given a path of the form a/b/c, where the path is relative
         to this directory, recurse the path and return the object


### PR DESCRIPTION
Probably linked bug 2776 is fixed. I could reproduce it only when a directory had been removed manually.
If I added, edited or removed files everything worked well (translated project stats was refreshed).
