### PR TITLE
bug 3063 - ability to log in with long email addresses

### DIFF
--- a/pootle/apps/pootle_profile/forms.py
+++ b/pootle/apps/pootle_profile/forms.py
@@ -46,6 +46,7 @@ def lang_auth_form_factory(request, **kwargs):
 
     class LangAuthenticationForm(AuthenticationForm):
 
+        username = forms.CharField(label=_("Username"), max_length=75)
         language = forms.ChoiceField(label=_('Interface Language'),
                                      choices=language_list(request),
                                      initial="", required=False,


### PR DESCRIPTION
When you use emails for sign in (for example, using the LDAP authentication backend) it might happen that a 30 character limit on the username field prevents certain email addresses from being entered. 

For example see, https://bugzilla.mozilla.org/show_bug.cgi?id=871921

This happens because you have a `<input name="username" maxlength="30" ...>` on the login template.
