### PR TITLE
Possible fix for account activitation username is false (#3060)

### DIFF
--- a/pootle/templates/registration/activate.html
+++ b/pootle/templates/registration/activate.html
@@ -11,7 +11,7 @@
 {% block content %}
 <div class="form message success">
     <h2>{% trans "Account Activated" %}</h2>
-    <p>{% blocktrans %}The account has been activated for username "{{ account }}". You can now proceed to log in.{% endblocktrans %}
+    <p>{% blocktrans %}The account has been activated for username "{{ user }}". You can now proceed to log in.{% endblocktrans %}
     </p>
 </div>
 {% endblock %}


### PR DESCRIPTION
The activate page show the username as 'false'. This is a possible fix. Needs further testing.
