### PR TITLE
Simple check for account activation  bug 3060

### DIFF
--- a/pootle/templates/registration/activate.html
+++ b/pootle/templates/registration/activate.html
@@ -9,9 +9,16 @@
 {% endblock %}
 
 {% block content %}
+{% if account %}
 <div class="form message success">
     <h2>{% trans "Account Activated" %}</h2>
     <p>{% blocktrans %}The account has been activated for username "{{ account }}". You can now proceed to log in.{% endblocktrans %}
     </p>
 </div>
+    {% else %}
+<div class="form message error">
+  <h2>{% trans "Activation Code Expired" %}</h2>
+    <p>{% blocktrans %}This account activation code has expired.{% endblocktrans %}
+</div>
+    {% endif %}  
 {% endblock %}


### PR DESCRIPTION
Adds checks for invalid activation code and displays an error form. Fixes #3060

http://bugs.locamotion.org/show_bug.cgi?id=3060
