### PR TITLE
Remove border around punctuation text highlight (Fixes #2965)

### DIFF
--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -1206,7 +1206,6 @@ a.editor-specialchar:hover
 a.editor-specialchar,
 .highlight-punctuation
 {
-    border: 1px dotted #999;
     color: #666;
 }
 


### PR DESCRIPTION
Minor CSS patch to remove border around punctuation string 
