### PR TITLE
Bundle wikipedia.js into editor bundle

### DIFF
--- a/pootle/apps/pootle_app/assets.py
+++ b/pootle/apps/pootle_app/assets.py
@@ -63,6 +63,7 @@ js_editor = Bundle(
     'js/models.js',
     'js/collections.js',
     'js/editor.js',
+    'js/lookup/wikipedia.js',
     filters='rjsmin', output='js/editor.min.%(version)s.js')
 register('js_editor', js_editor)
 


### PR DESCRIPTION
Bundle wikipedia.js into editor. One less HTTP request when loading translator UI.
