### PR TITLE
Change submodule to use https instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/translate/sphinx-themes.git
+	url = https://github.com/translate/sphinx-themes.git


### PR DESCRIPTION
git:// is causing trouble with possible firewalls. Us, mozilla, for example can't check out repos over git:// but we can over https://
