### PR TITLE
Django-taggit forbids multiple TaggableManagers (Fixes #3158)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ Django>=1.5.5
 django-voting==0.1
 South>=0.7.6
 django-assets>=0.8
-django-taggit>=0.10,<0.11.2
+django-taggit>=0.10,<0.11.1
 django-registration==1.0
 django-contact-form==1.0
 


### PR DESCRIPTION
Pootle doesn't work with new version of django-taggit. Stop gap measure for developer working on current code base.

http://bugs.locamotion.org/show_bug.cgi?id=3158
