### PR TITLE
Force caching of MT and Lookup backend JavaScript files

### DIFF
--- a/pootle/static/js/editor.js
+++ b/pootle/static/js/editor.js
@@ -245,6 +245,7 @@
         url: s(['js/mt/', backend, '.js'].join('')),
         async: false,
         dataType: 'script',
+        cache: 'true',
         success: function () {
           setTimeout(function () {
             PTL.editor.mt[backend].init(key);
@@ -263,6 +264,7 @@
         url: s(['js/lookup/', backend, '.js'].join('')),
         async: false,
         dataType: 'script',
+        cache: 'true',
         success: function () {
           setTimeout(function () {
             PTL.editor.lookup[backend].init();


### PR DESCRIPTION
(Re-issuing a fresh pull request, replaces PR #159)

Adding 'cache:true' to Jquery Ajax request to ensure that JavaScript are cached properly. The default behavior here is adding '?_=[TIMESTAMP]' to forces the browser not to cache the JavaScript files.

@dwaynebailey (Comment from https://github.com/translate/pootle/pull/159#issuecomment-31007679)
"The second part is active on m.l.o - but since we don't have mt engine active I'm not sure there is much gain." 
Currently wikipedia.js is requested constantly from the server due to the query string. This patch makes sure the the browsers caches all JavaScript files loading from editor. Improves the overall web performance of Pootle.

@julen Any other feedback ?
