### PR TITLE
Revert "Bundle wikipedia.js into editor bundle"

### DIFF
--- a/pootle/apps/pootle_app/assets.py
+++ b/pootle/apps/pootle_app/assets.py
@@ -65,7 +65,6 @@ js_editor = Bundle(
     'js/models.js',
     'js/collections.js',
     'js/editor.js',
-    'js/lookup/wikipedia.js',
     filters='rjsmin', output='js/editor.min.%(version)s.js')
 register('js_editor', js_editor)
 


### PR DESCRIPTION
This reverts commit 80bd1021e3fdf09b5f71e2cde817132a4482a163. Better solution is provided by Ajax JavaScript caching. https://github.com/translate/pootle/pull/160
