### PR TITLE
Explicit import of ldap.filter

### DIFF
--- a/pootle/core/auth/ldap_backend.py
+++ b/pootle/core/auth/ldap_backend.py
@@ -19,6 +19,7 @@
 # Pootle; if not, see <http://www.gnu.org/licenses/>.
 
 import ldap
+import ldap.filter  # special needed import
 import logging
 
 from django.conf import settings


### PR DESCRIPTION
`ldap.filter` is it's own module. `ldap` is a binary module and `ldap.filter` is a python package. So you need both.
