### PR TITLE
Travis-CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,5 @@ notifications:
   email:
     on_failure: always
     on_success: change
+services:
+  - memcached

--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -24,6 +24,13 @@ if os.environ.get("TRAVIS"):
         }
     }
 
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'LOCATION': '127.0.0.1:11211',
+        }
+    }
+
     if DATABASE_BACKEND == "postgres":
         DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
         DATABASES['default']['NAME'] = 'pootle'

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -2,3 +2,4 @@
 
 MySQL-python==1.2.5
 psycopg2==2.5.2
+python-memcached==1.53


### PR DESCRIPTION
We now test mysql and postgres in addition to sqlite on travis-ci. We also always use memcached.

New travis-specific settings should go in settings/91-travis.conf.
