### PR TITLE
Get TITLE and DESCRIPTION from siteconfig directly

### DIFF
--- a/pootle/apps/pootle_app/views/index/about.py
+++ b/pootle/apps/pootle_app/views/index/about.py
@@ -29,13 +29,16 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.translation import ugettext as _
 
+from pootle_misc.siteconfig import load_site_config
+
 
 def view(request):
     from translate import __version__ as toolkitversion
     from pootle import __version__ as pootleversion
 
+    siteconfig = load_site_config()
     data = {
-        'description': _(settings.DESCRIPTION),
+        'description': _(siteconfig.get('DESCRIPTION')),
         'keywords': ['Pootle',
                      'locamotion',
                      'translate',

--- a/pootle/apps/pootle_app/views/index/index.py
+++ b/pootle/apps/pootle_app/views/index/index.py
@@ -33,6 +33,7 @@ from pootle_app.models.permissions import (get_matching_permissions,
 from pootle_app.views.top_stats import gentopstats_root
 from pootle_language.models import Language
 from pootle_misc.browser import get_table_headings
+from pootle_misc.siteconfig import load_site_config
 from pootle_profile.models import get_profile
 from pootle_project.models import Project
 from pootle_statistics.models import Submission
@@ -105,8 +106,9 @@ def view(request, root_dir):
         'items': projects,
     }
 
+    siteconfig = load_site_config()
     templatevars = {
-        'description': _(settings.DESCRIPTION),
+        'description': _(siteconfig.get('DESCRIPTION')),
         'keywords': [
             'Pootle',
             'translate',
@@ -127,9 +129,7 @@ def view(request, root_dir):
     templatevars['moreprojects'] = (len(projects) > len(languages))
 
     if can_edit:
-        from pootle_misc.siteconfig import load_site_config
         from pootle_app.forms import GeneralSettingsForm
-        siteconfig = load_site_config()
         setting_form = GeneralSettingsForm(siteconfig)
         templatevars['form'] = setting_form
 

--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -23,6 +23,7 @@ from django.core.cache import cache
 
 from pootle.__version__ import sver
 from pootle_language.models import Language
+from pootle_misc.siteconfig import load_site_config
 from pootle_project.models import Project
 from staticpages.models import LegalPage
 
@@ -45,11 +46,12 @@ def _agreement_context(request):
 
 def pootle_context(request):
     """Exposes settings to templates."""
+    siteconfig = load_site_config()
     #FIXME: maybe we should expose relevant settings only?
     context = {
         'settings': {
-            'TITLE': settings.TITLE,
-            'DESCRIPTION': settings.DESCRIPTION,
+            'TITLE': siteconfig.get('TITLE'),
+            'DESCRIPTION':  siteconfig.get('DESCRIPTION'),
             'CAN_REGISTER': settings.CAN_REGISTER,
             'CAN_CONTACT': settings.CAN_CONTACT and settings.CONTACT_EMAIL,
             'SCRIPT_NAME': settings.SCRIPT_NAME,

--- a/pootle/apps/pootle_misc/siteconfig.py
+++ b/pootle/apps/pootle_misc/siteconfig.py
@@ -24,8 +24,7 @@ NOTE: Import this file in your urls.py or some place before any code relying on
 
 from django.contrib.sites.models import Site
 
-from djblets.siteconfig.django_settings import (apply_django_settings,
-                                                generate_defaults)
+from djblets.siteconfig.django_settings import generate_defaults
 from djblets.siteconfig.models import SiteConfiguration
 
 
@@ -49,5 +48,4 @@ def load_site_config():
     if not siteconfig.get_defaults():
         siteconfig.add_defaults(generate_defaults(SETTINGS_MAP))
 
-    apply_django_settings(siteconfig, SETTINGS_MAP)
     return siteconfig

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -42,6 +42,7 @@ from pootle.core.url_helpers import get_editor_filter, split_pootle_path
 from pootle_app.models.directory import Directory
 from pootle_language.models import Language
 from pootle_misc.baseurl import l
+from pootle_misc.siteconfig import load_site_config
 from pootle_misc.stats import stats_message_raw
 from pootle_misc.util import cached_property
 from pootle_misc.checks import excluded_filters
@@ -408,8 +409,9 @@ class TranslationProject(models.Model, TreeItem):
 
         if new_files and versioncontrol.hasversioning(project_path):
             from pootle.scripts import hooks
+            siteconfig = load_site_config()
             message = ("New files added from %s based on templates" %
-                       settings.TITLE)
+                       siteconfig.get('TITLE'))
 
             filestocommit = []
             for new_file in new_files:
@@ -662,8 +664,9 @@ class TranslationProject(models.Model, TreeItem):
         fuzzy = directory.get_fuzzy_wordcount()
         author = user.username
 
+        siteconfig = load_site_config()
         message = stats_message_raw("Commit from %s by user %s." %
-                                    (settings.TITLE, author),
+                                    (siteconfig.get('TITLE'), author),
                                     total, translated, fuzzy)
 
         # Try to append email as well, since some VCS does not allow omitting
@@ -740,8 +743,9 @@ class TranslationProject(models.Model, TreeItem):
         fuzzy = store.get_fuzzy_wordcount()
         author = user.username
 
+        siteconfig = load_site_config()
         message = stats_message_raw("Commit from %s by user %s." % \
-                (settings.TITLE, author), total, translated, fuzzy)
+                (siteconfig.get('TITLE'), author), total, translated, fuzzy)
 
         # Try to append email as well, since some VCS does not allow omitting
         # it (ie. Git).

--- a/pootle/middleware/baseurl.py
+++ b/pootle/middleware/baseurl.py
@@ -45,7 +45,9 @@ class BaseUrlMiddleware(object):
             #
             # Poison sites cache using detected domain.
             from django.contrib.sites import models as sites_models
+            from pootle_misc.siteconfig import load_site_config
 
+            siteconfig = load_site_config()
             new_site = sites_models.Site(settings.SITE_ID, request.get_host(),
-                                         settings.TITLE)
+                                         siteconfig.get('TITLE'))
             sites_models.SITE_CACHE[settings.SITE_ID] = new_site


### PR DESCRIPTION
Instead of changing django.conf.settings at runtime which we should not
be doing:
    https://docs.djangoproject.com/en/dev/topics/settings/#altering-settings-at-runtime

Fixes bug 3150.
