### PR TITLE
cache: Cache the top stats for a much longer time

### DIFF
--- a/pootle/apps/pootle_app/views/top_stats.py
+++ b/pootle/apps/pootle_app/views/top_stats.py
@@ -40,7 +40,7 @@ def gentopstats_root():
         top_sub    = group_by_sort(User.objects.exclude(pootleprofile__submission=None),
                                    'pootleprofile__submission', ['username'])[:settings.TOPSTAT_SIZE]
         result = map(None, top_sugg, top_review, top_sub)
-        cache.set(key, result, settings.CACHE_MIDDLEWARE_SECONDS * 3)
+        cache.set(key, result, settings.POOTLE_TOP_STATS_CACHE_TIMEOUT)
     return result
 
 
@@ -66,7 +66,7 @@ def gentopstats_language(language):
                                    'pootleprofile__submission', ['username'])[:settings.TOPSTAT_SIZE]
 
         result = map(None, top_sugg, top_review, top_sub)
-        cache.set(key, result, settings.CACHE_MIDDLEWARE_SECONDS * 2)
+        cache.set(key, result, settings.POOTLE_TOP_STATS_CACHE_TIMEOUT)
     return result
 
 
@@ -92,7 +92,7 @@ def gentopstats_project(project):
                                    'pootleprofile__submission', ['username'])[:settings.TOPSTAT_SIZE]
 
         result = map(None, top_sugg, top_review, top_sub)
-        cache.set(key, result, settings.CACHE_MIDDLEWARE_SECONDS * 2)
+        cache.set(key, result, settings.POOTLE_TOP_STATS_CACHE_TIMEOUT)
     return result
 
 

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -52,3 +52,5 @@ CACHE_MIDDLEWARE_ANONYMOUS_ONLY = True
 
 # Keep stats cache for roughly a month
 OBJECT_CACHE_TIMEOUT = 2500000
+# Refresh top stats on the main page every day
+POOTLE_TOP_STATS_CACHE_TIMEOUT = 60*60*24


### PR DESCRIPTION
Previous behaviour had us cache for CACHE_MIDDLEWARE_SECONDS \* 2 or 3
which is 10-15 minutes by default. That is ridiculously quick for
something that is very expensive to compute and doesn't change that
much.
By default we now cache for a whole day and this can be changed in the
new setting TOP_STATS_CACHE_TIMEOUT.
