### PR TITLE
Add missing import

### DIFF
--- a/pootle/apps/pootle_store/decorators.py
+++ b/pootle/apps/pootle_store/decorators.py
@@ -31,7 +31,7 @@ from pootle_app.models.permissions import (check_permission,
 from pootle_misc.util import jsonify
 from pootle_profile.models import get_profile
 
-from .models import Unit
+from .models import Unit, Store
 
 
 def _common_context(request, translation_project, permission_codes):


### PR DESCRIPTION
pootle_store/decorators.py was missing Store import and thus caused
tracback with: NameError: global name 'Store' is not defined trying to
download a file.
