### PR TITLE
templatetags: Drop support for non-diffmatchpatch highlight_diffs()

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ argparse
 
 # Libraries
 cssmin>=0.1.4
+diff-match-patch>=20121119
 lxml>=2.1.4
 
 # For providing API


### PR DESCRIPTION
Also drop reliance on ttk diff-match-patch, use pypi instead.
