### PR TITLE
Styleguide: Always use single quotes for template tags and template filt...

### DIFF
--- a/docs/developers/styleguide.rst
+++ b/docs/developers/styleguide.rst
@@ -403,8 +403,10 @@ Template naming
     going to be used directly, start its name with an underscore, e.g.
     *_included_template.html*.
 
-Miscellany
-  - Always use double quotes for HTML attribute values:
+Quoting
+  - Always use double quotes for HTML attribute values.
+  - Always use single quotes for Django template tags and template filters
+    located inside HTML attribute values.
 
     .. code-block:: html
 
@@ -414,7 +416,9 @@ Miscellany
 
 
         <!-- Bad -->
+        <a href="{% url "whatever" %}" class="highlight">
         <a href='{% url 'whatever' %}' class='highlight'>
+        <a href='{% url "whatever" %}' class='highlight'>
 
 
 CSS


### PR DESCRIPTION
...ers inside HTML attribute values

So we avoid clashing with the HTML double quotes as much as possible.
