### PR TITLE
pootle_store: Drop mysql-style quoting

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -219,8 +219,8 @@ class UnitManager(RelatedManager):
 
         units_qs = units_qs.extra(
             where=[
-                '`pootle_store_store`.`pootle_path` LIKE %s',
-                '`pootle_store_store`.`pootle_path` NOT LIKE %s',
+                'pootle_store_store.pootle_path LIKE %s',
+                'pootle_store_store.pootle_path NOT LIKE %s',
             ], params=[units_path, '/templates/%']
         )
 


### PR DESCRIPTION
Dropping quoting entirely is OK because we don't build the table/column
names dynamically, and this style should work on all backends.
