### PR TITLE
Placeables: Make sure text is always escaped

### DIFF
--- a/pootle/apps/pootle_store/templatetags/store_tags.py
+++ b/pootle/apps/pootle_store/templatetags/store_tags.py
@@ -29,6 +29,7 @@ from django import template
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.defaultfilters import stringfilter
 from django.template.loaders.filesystem import Loader
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
@@ -95,7 +96,7 @@ def highlight_placeables(text):
                                                    content)
         else:
             # It is not a placeable, so just concatenate to output string.
-            output += unicode(item)
+            output += escape(item)
 
     return mark_safe(output)
 


### PR DESCRIPTION
highlight_placeables() was assuming that parse_placeables() will always
detect placeables correctly and was outputting text not part of a
placeable unescaped, but this is not a safe assumption as
parse_placeables() can fail to detect some placeables and we might end
up with unesacaped HTML material.
