### PR TITLE
Security release: Update Django requirement to 1.5.6

### DIFF
--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -28,7 +28,7 @@ from django.conf import settings
 TTK_MINIMUM_REQUIRED_VERSION = (1, 11, 0)
 
 # Minimum Django version required for Pootle to run.
-DJANGO_MINIMUM_REQUIRED_VERSION = (1, 5, 5)
+DJANGO_MINIMUM_REQUIRED_VERSION = (1, 5, 6)
 
 # Minimum lxml version required for Pootle to run.
 LXML_MINIMUM_REQUIRED_VERSION = (2, 1, 4, 0)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Make sure you update docs/server/installation.rst and, if needed, the release
 # notes in docs/releases/$next when bumping Django versions and dependencies
-Django>=1.5.5,<1.6
+Django>=1.5.6,<1.6
 
 # Django apps
 django-allauth==0.15.0


### PR DESCRIPTION
https://www.djangoproject.com/weblog/2014/apr/21/security/
