### PR TITLE
sorttable.js: Fix dumb cookie parsing

### DIFF
--- a/pootle/static/js/vendor/sorttable.js
+++ b/pootle/static/js/vendor/sorttable.js
@@ -440,7 +440,11 @@ sorttable = {
    * Retrieves the sorting order for `theadId` column in `cookieId`
    */
   getSortCookie: function (cookieId) {
-    return JSON.parse($.cookie(cookieId));
+    try {
+      return JSON.parse($.cookie(cookieId));
+    } catch(e) {
+      return {};
+    }
   },
 
 }


### PR DESCRIPTION
Sorry for the whitespace again, comes with it. (use ?w=0 to review without it)
