### PR TITLE
Add installation instruction to Tastypie.

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -21,7 +21,13 @@ Enabling the Pootle API
 =======================
 
 Pootle API is disabled by default. To enable it just install
-``django-tastypie`` and put the following line on your custom settings:
+``django-tastypie`` 
+
+.. code-block::
+
+  pip install django-tastypie==0.9.16
+
+and put the following line on your custom settings:
 
 .. code-block:: python
 


### PR DESCRIPTION
Add installation instruction to Tastypie, because we need a specific version to make it work with Django 1.4.11
