### PR TITLE
Migration: fixes postgress install

### DIFF
--- a/pootle/apps/pootle_store/migrations/0001_initial.py
+++ b/pootle/apps/pootle_store/migrations/0001_initial.py
@@ -9,6 +9,9 @@ AUTH_USER_MODEL = getattr(settings, "AUTH_USER_MODEL", "auth.User")
 
 
 class Migration(SchemaMigration):
+    depends_on = (
+        ("pootle_app", "0001_initial"),
+    )
 
     def forwards(self, orm):
         # Adding model 'QualityCheck'


### PR DESCRIPTION
Store requires that pootle_app migration has already run and thus Directory is
available.  Other DBs seem to manage as they aren't as strict as Postgres. All
Postgres fans shout yay.
