### PR TITLE
Permission

### DIFF
--- a/pootle/apps/pootle_app/views/admin/permissions.py
+++ b/pootle/apps/pootle_app/views/admin/permissions.py
@@ -63,7 +63,7 @@ def admin_permissions(request, current_directory, template, context):
 
     base_queryset = PootleProfile.objects.filter(user__is_active=1).exclude(
             id__in=current_directory.permission_sets \
-                                    .values_list('profile_id', flat=True),
+                                    .values_list('user', flat=True),
     )
     querysets = [(None, base_queryset.filter(
         user__username__in=('nobody', 'default')


### PR DESCRIPTION
Fix:
"FieldError: Cannot resolve keyword 'profile_id' into field. Choices are: directory, id, negative_permissions, positive_permissions, user"

when accessing permissions
