### PR TITLE
Modify docs for "Committing".

### DIFF
--- a/docs/features/version_control.rst
+++ b/docs/features/version_control.rst
@@ -197,8 +197,8 @@ from Pootle will look something like this::
 
 So it is still possible to see who submitted what and when, and actually
 provides some useful statistics in the commit message.  A user must be assigned
-'commit' privileges by the project administrator.  If the user has the correct
-privileges, they will see a "submit" link next to each file.
+'commit' privileges by the project administrator, and must have his email defined.  
+If the user has the correct privileges, they will see a "submit" link next to each file.
 
 
 .. _version_control#authentication:


### PR DESCRIPTION
Hello, 

When a user has en empty email, `git commit` triggers the following error: 

```
No existing author found with '<user>'
```

I changed the docs to explain this. 
