### PR TITLE
Travis: install lxml without compile optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ cache:
 before_install:
   - travis_retry sudo apt-get install -qq bc
 install:
-  - travis_retry pip install -r requirements/travis.txt --timeout=240
+  - CFLAGS="-O0" travis_retry pip install -r requirements/travis.txt --timeout=240
   - travis_retry pip install "Django>=$DJANGO_VERSION,<"$(echo $(echo $DJANGO_VERSION | cut -d"." -f1,2) + 0.1 | bc) --timeout=240
   - pip freeze  # Print all installed versions for reference.
 before_script:


### PR DESCRIPTION
Use CFLAGS="-O0" as recommended by
http://lxml.de/installation.html#installation to speedup installation
times in Travis builds.

This is applied to all installations here, should maybe be limited to
lxml.

The next step wpuld be to create precompiled wheel packages to speedup
setup.

Currently we're taking about 3min to setup the packages for testing.
