### PR TITLE
Travis: disable unsupported DB backends and Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ python:
   - 2.7
 env:
   matrix:
-    - DJANGO_VERSION=1.6.5 DATABASE_BACKEND=sqlite
-    - DJANGO_VERSION=1.6.5 DATABASE_BACKEND=postgres
+    # FIXME reenable backends when these are made to work once again
+    #- DJANGO_VERSION=1.6.5 DATABASE_BACKEND=sqlite
+    #- DJANGO_VERSION=1.6.5 DATABASE_BACKEND=postgres
     - DJANGO_VERSION=1.6.5 DATABASE_BACKEND=mysql_myisam
-    - DJANGO_VERSION=1.6.5 DATABASE_BACKEND=mysql_innodb
-    - DJANGO_VERSION=1.7.1 DATABASE_BACKEND=sqlite
-    - DJANGO_VERSION=1.7.1 DATABASE_BACKEND=postgres
-    - DJANGO_VERSION=1.7.1 DATABASE_BACKEND=mysql_myisam
-    - DJANGO_VERSION=1.7.1 DATABASE_BACKEND=mysql_innodb
+    #- DJANGO_VERSION=1.6.5 DATABASE_BACKEND=mysql_innodb
+    #- DJANGO_VERSION=1.7.1 DATABASE_BACKEND=sqlite
+    #- DJANGO_VERSION=1.7.1 DATABASE_BACKEND=postgres
+    #- DJANGO_VERSION=1.7.1 DATABASE_BACKEND=mysql_myisam
+    #- DJANGO_VERSION=1.7.1 DATABASE_BACKEND=mysql_innodb
 matrix:
   exclude:
     - python: 2.6


### PR DESCRIPTION
They're known to fail and we can reenable them when support is brought
back into core.  For now they're simply making Travis take longer to
report issues.
