### PR TITLE
docs: use parrallel builds to speedup docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docs:
 	git submodule update --init
 	# The following creates the HTML docs.
 	# NOTE: cd and make must be in the same line.
-	cd ${DOCS_DIR}; make SPHINXOPTS="-W -q" html ${TAIL}
+	cd ${DOCS_DIR}; make SPHINXOPTS="-W -q -j 15" html ${TAIL}
 
 docs-review: docs
 	python -mwebbrowser file://$(shell pwd)/${DOCS_DIR}/_build/html/index.html


### PR DESCRIPTION
Using parrallel builds to increase doc regeneration as well as speedup
Travis builds.

With hot filesystem speed are as follows depending on the -j value:

| Processes | Duration |
| --- | --- |
| 1 | 7.75s |
| 3 | 5.2s |
| 5 | 4.21s |
| 8 | 3.88s |
| 10 | 3.96s |
| 15 | 3.38s |
| 20 | 3.48s |

Cold (12 runs)

| Processes | Duration |
| --- | --- |
| 1 | 20.27 (17.82-22.71) |
| 15 | 17.91 (14.41-21.42) |

Not as big a saving as I'd hoped for a cold start but good for doc
development.
