### PR TITLE
Travis: no need to set cache backend settings

### DIFF
--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -25,13 +25,6 @@ if os.environ.get("TRAVIS"):
         }
     }
 
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        }
-    }
-
-
     if DATABASE_BACKEND == "postgres":
         DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
         DATABASES['default']['NAME'] = 'pootle'


### PR DESCRIPTION
These are already set in `tests/settings.py` which will be used when tests
are actually run.
