### PR TITLE
Port database migrations testing to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
 	url = https://github.com/translate/sphinx-themes.git
+[submodule "tests/version-migration/data"]
+	path = tests/version-migration/data
+	url = git://github.com/translate/pootle-test-data.git

--- a/tests/version-migration/README.rst
+++ b/tests/version-migration/README.rst
@@ -1,0 +1,50 @@
+Version Migration Testing
+=========================
+
+Purpose
+-------
+To catch migration errors across versions and databases as we make changes.
+Thus preventing us releasing versions of Pootle that cannot migrate wasting
+time assisting Pootle users one by one.  Rather catch the issue early.
+
+We do this by automatically testing migrations from various old versions of
+Pootle to the version being tested.
+
+How it works
+------------
+Mostly this will be tested on Travis but you can test locally.
+
+1. migrate.sh when run will read ``$DATABASE_ENGINE`` or read the first option
+   and run against that database.  Thus ``./migrate sqlite`` will run the tests
+   for sqlite.
+2. All database dumps in ``data/`` for the database under test are found.
+3. For each dump we:
+
+   1. Load the dump into the database.  We now have a Pootle database at the
+      older install state.
+   2. Migrate to the latest version.
+
+
+Coding the migrations
+---------------------
+The migrations follow the instructions we give users in the Pootle docs as we
+need to test following the instructions that we give.  Instructions are given
+for each version from which we migrate.
+
+Creating new database dumps
+---------------------------
+To create a database dump for an older Pootle version you will need to:
+
+1. Install Pootle for that older version, preferably in a virtualenv
+2. Create a Pootle database if needed (MySQL, Postgress)
+3. Setup the Pootle configuration:
+
+   1. Setup the correct database config
+   2. Enable memcached (to prevent any issues related to database cache tables)
+
+4. Run the correct Pootle setup commands
+5. Run Pootle such that it can import and configure things in older versions.
+   Running refresh_stats and such can be helpful to make sure Pootle is in
+   running order, not just post install state.
+6. Dump the database to ``data/dump-$engine-$pootle_versions.sql``
+7. Commit to Git and make sure any needed migration instructions are in place.

--- a/tests/version-migration/README.rst
+++ b/tests/version-migration/README.rst
@@ -46,5 +46,5 @@ To create a database dump for an older Pootle version you will need to:
 5. Run Pootle such that it can import and configure things in older versions.
    Running refresh_stats and such can be helpful to make sure Pootle is in
    running order, not just post install state.
-6. Dump the database to ``data/dump-$engine-$pootle_versions.sql``
+6. Dump the database to ``data/[description]-$engine-$pootle_versions.sql``
 7. Commit to Git and make sure any needed migration instructions are in place.

--- a/tests/version-migration/migrate.sh
+++ b/tests/version-migration/migrate.sh
@@ -71,9 +71,9 @@ function migrate_database {
 	esac
 }
 
-for database_dump in $(find $datadir -name "dump-$DATABASE_BACKEND-*.sql")
+for database_dump in $(find $datadir -name "*-$DATABASE_BACKEND-*.sql")
 do
-	pootle_version=$(basename $database_dump .sql | cut -d"-" -f3)
+	pootle_version=$(echo $database_dump | sed "s/.*-\([^-]*\)\.sql/\1/")
 	load_database $database_dump
 	migrate_database $pootle_version
 	# TODO actually run the server

--- a/tests/version-migration/migrate.sh
+++ b/tests/version-migration/migrate.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+user_supplied_db=$1
+export TRAVIS
+export DATABASE_BACKEND=${DATABASE_BACKEND:=$user_supplied_db}
+basedir=$(dirname "$0")
+datadir=$basedir/data
+dbname=pootle
+dbuser_postgres=postgres
+dbuser_mysql=travis
+
+cd "$basedir/../.."
+
+if [[ ! $DATABASE_BACKEND ]]; then
+	echo "Error: set DATABASE_BACKEND or supply database backend as first parameter"
+	exit 1
+fi
+
+function load_database {
+	local database_dump=$1
+	echo "Loading $database_dump into $DATABASE_BACKEND"
+	case $DATABASE_BACKEND in
+		mysql)
+			mysql -u $dbuser_mysql <<-EOMy
+			drop database $dbname;
+			create database $dbname CHARACTER SET utf8 COLLATE utf8_general_ci;
+			EOMy
+			mysql -u $dbuser_mysql $dbname < $database_dump
+			;;
+		postgres)
+			psql -U $dbuser_postgres -d $dbname -f $database_dump
+			;;
+		sqlite)
+			if [[ "$user_supplied_db" ]]; then
+				read -p "Deleting 'pootle/dbs/${dbname}_travis.db' Do you wish to proceed?" -n1 answer
+			        echo
+				if [ "$answer" != "y" ]; then
+					exit
+				fi
+			fi
+			rm pootle/dbs/${dbname}_travis.db
+			sqlite3 pootle/dbs/${dbname}_travis.db < $database_dump
+			;;
+		*)
+			echo "Error: $DATABASE_BACKEND is unkonwn"
+			exit 1
+			;;
+	esac
+}
+
+function migrate_database {
+	pootle_versions=$1
+	echo "Migrating $pootle_version to latest on $DATABASE_BACKEND"
+	case $pootle_version in
+		2.1.6)
+			echo "Not implemented"
+			exit 1
+			;;
+		2.5.0)
+			echo "Not implemented"
+			exit 1
+			;;
+		2.5.1)
+			echo "Migrating using $pootle_version rules"
+			./manage.py setup --traceback -v0
+			;;
+		*)
+			echo "Error: missing rules for migrating from $pootle_version"
+			exit 1
+			;;
+	esac
+}
+
+for database_dump in $(find $datadir -name "dump-$DATABASE_BACKEND-*.sql")
+do
+	pootle_version=$(basename $database_dump .sql | cut -d"-" -f3)
+	load_database $database_dump
+	migrate_database $pootle_version
+	# TODO actually run the server
+done

--- a/tests/version-migration/migrate.sh
+++ b/tests/version-migration/migrate.sh
@@ -4,7 +4,7 @@ user_supplied_db=$1
 export TRAVIS
 export DATABASE_BACKEND=${DATABASE_BACKEND:=$user_supplied_db}
 basedir=$(dirname "$0")
-datadir=$basedir/data
+datadir=$(readlink -f $basedir/data)
 dbname=pootle
 dbuser_postgres=postgres
 dbuser_mysql=travis


### PR DESCRIPTION
Fixes #3478 by porting the database migration testing scripts from ``stable/2.6.0`` to ``master``.  This has been running well on ``old-master`` and ``stable/2.6.0`` for some time and was used to get Postgres support running correctly.  It is currently disabled in Travis until their is a migration path from ``<=2.5.1.1`` to ``master``