### PR TITLE
Cleanup: get_cache replacement

### DIFF
--- a/docs/server/cache.rst
+++ b/docs/server/cache.rst
@@ -22,6 +22,24 @@ of :doc:`optimizing <optimization>` your Pootle installation. It is based on
 
 Without a well functioning cache system, Pootle could be slow.
 
+.. _cache#named_caches:
+
+Named Caches
+------------
+The cache backends are at least configured with a 'default' cache.  If this is
+the only cache that exists then all caching is placed into this cache.  The
+Pootle cache can also be configured to take advantage of certain named caches.
+
+Current named caches:
+
+- ``'default'`` -- all non specified cache data and all cache data if only one
+  cache is defined.
+- ``'stats'`` --  all cached data related to overview stats.
+
+In large installations you may want to setup separate caches to improve cache
+performance.  You can then setup caching parameters for each cache separately.
+In most cases though you will simply use a single 'default' cache.
+
 
 .. _cache#cache_backends:
 

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -27,13 +27,12 @@ from optparse import make_option
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from django.conf import settings
-from django.core.cache import caches, cache as default_cache
-from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.urlresolvers import set_script_prefix
 from django.utils.encoding import force_unicode
 
 from django_rq import job
 
+from pootle.core.cache import get_cache
 from pootle.core.mixins.treeitem import CachedMethods
 from pootle_store.models import Store
 
@@ -41,11 +40,7 @@ from .refresh_stats import Command as RefreshStatsCommand
 
 
 logger = logging.getLogger('stats')
-
-try:
-    cache = caches['stats']
-except InvalidCacheBackendError:
-    cache = default_cache
+cache = get_cache('stats')
 
 
 class Command(RefreshStatsCommand):

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -27,8 +27,8 @@ from optparse import make_option
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from django.conf import settings
-from django.core.cache import get_cache, cache as default_cache
-from django.core.exceptions import ImproperlyConfigured
+from django.core.cache import caches, cache as default_cache
+from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.urlresolvers import set_script_prefix
 from django.utils.encoding import force_unicode
 
@@ -43,8 +43,8 @@ from .refresh_stats import Command as RefreshStatsCommand
 logger = logging.getLogger('stats')
 
 try:
-    cache = get_cache('stats')
-except ImproperlyConfigured:
+    cache = caches['stats']
+except InvalidCacheBackendError:
     cache = default_cache
 
 

--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -29,8 +29,6 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from translate.filters.decorators import Category
 
 from django.conf import settings
-from django.core.cache import caches, cache as default_cache
-from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.urlresolvers import set_script_prefix
 from django.db.models import Count, Max, Sum
 from django.utils import dateformat, timezone
@@ -38,6 +36,7 @@ from django.utils.encoding import force_unicode, iri_to_uri
 
 from django_rq import get_connection, job
 
+from pootle.core.cache import get_cache
 from pootle.core.mixins.treeitem import POOTLE_REFRESH_STATS
 from pootle_misc.util import datetime_min
 from pootle_project.models import Project
@@ -50,11 +49,7 @@ from . import PootleCommand
 
 
 logger = logging.getLogger('stats')
-
-try:
-    cache = caches['stats']
-except InvalidCacheBackendError:
-    cache = default_cache
+cache = get_cache('stats')
 
 
 class Command(PootleCommand):

--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -29,8 +29,8 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from translate.filters.decorators import Category
 
 from django.conf import settings
-from django.core.cache import get_cache, cache as default_cache
-from django.core.exceptions import ImproperlyConfigured
+from django.core.cache import caches, cache as default_cache
+from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.urlresolvers import set_script_prefix
 from django.db.models import Count, Max, Sum
 from django.utils import dateformat, timezone
@@ -52,8 +52,8 @@ from . import PootleCommand
 logger = logging.getLogger('stats')
 
 try:
-    cache = get_cache('stats')
-except ImproperlyConfigured:
+    cache = caches['stats']
+except InvalidCacheBackendError:
     cache = default_cache
 
 

--- a/pootle/core/cache.py
+++ b/pootle/core/cache.py
@@ -19,6 +19,10 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 
+from django.core.cache import caches, cache as default_cache
+from django.core.cache.backends.base import InvalidCacheBackendError
+
+
 def make_method_key(model, method, key):
     """Creates a cache key for model's `method` method.
 
@@ -43,3 +47,15 @@ def make_key(*args, **kwargs):
     return ':'.join([
         '%s=%s' % (k, v) for k, v in sorted(kwargs.iteritems())
     ])
+
+
+def get_cache(cache=None):
+    """Return ``cache`` or the 'default' cache if ``cache`` is not specified or
+    ``cache`` is not configured.
+
+    :param cache: The name of the requested cache.
+    """
+    try:
+        return caches[cache]
+    except InvalidCacheBackendError:
+        return default_cache

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -30,8 +30,8 @@ from functools import wraps
 from translate.filters.decorators import Category
 
 from django.conf import settings
-from django.core.cache import get_cache, cache as default_cache
-from django.core.exceptions import ImproperlyConfigured
+from django.core.cache import caches, cache as default_cache
+from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.urlresolvers import set_script_prefix
 from django.utils.encoding import force_unicode, iri_to_uri
 
@@ -51,8 +51,8 @@ POOTLE_REFRESH_STATS = 'pootle:refresh:stats'
 logger = logging.getLogger('stats')
 
 try:
-    cache = get_cache('stats')
-except ImproperlyConfigured:
+    cache = caches['stats']
+except InvalidCacheBackendError:
     cache = default_cache
 
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -30,14 +30,13 @@ from functools import wraps
 from translate.filters.decorators import Category
 
 from django.conf import settings
-from django.core.cache import caches, cache as default_cache
-from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.urlresolvers import set_script_prefix
 from django.utils.encoding import force_unicode, iri_to_uri
 
 from django_rq import job
 from django_rq.queues import get_connection
 
+from pootle.core.cache import get_cache
 from pootle.core.log import log
 from pootle.core.url_helpers import get_all_pootle_paths, split_pootle_path
 from pootle_misc.checks import get_qualitychecks_by_category
@@ -49,11 +48,7 @@ POOTLE_REFRESH_STATS = 'pootle:refresh:stats'
 
 
 logger = logging.getLogger('stats')
-
-try:
-    cache = caches['stats']
-except InvalidCacheBackendError:
-    cache = default_cache
+cache = get_cache('stats')
 
 
 def statslog(function):


### PR DESCRIPTION
This removes all uses of get_cache and replaces it with django.core.cache.caches.

This fixes #3527 but requires the landing of #3526 