### PR TITLE
rq: fix queue running indicator for > 1 workers

### DIFF
--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -293,9 +293,7 @@ def rq_stats():
     queue = get_queue()
     failed_queue = get_failed_queue()
     workers = Worker.all(queue.connection)
-    is_running = False
-    if len(workers) == 1:
-        is_running = not workers[0].stopped
+    is_running = len(workers) >= 1 and not workers[0].stopped
 
     result = {
         'job_count': queue.count,


### PR DESCRIPTION
This indicator is on the admin dashboard and was showing as not running if there was more than one worker.  Took the opportunity to simplify the logic a bit.

Fixes #3552 