### PR TITLE
Redis is a default option (dashboard reporting)

### DIFF
--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -107,6 +107,21 @@ def required_depcheck():
         'text': text,
     })
 
+    status, connection_settings = depcheck.test_redis_server_available()
+    if status:
+        text = _('Redis server accepting connections on %(host)s:%(port)s.', connection_settings)
+        state = 'tick'
+    else:
+        text = _('Redis server is not running on %(host)s:%(port)s.', connection_settings)
+        state = 'error'
+
+    required.append({
+        'dependency': 'rq',
+        'state': state,
+        'text': text,
+    })
+
+
     return required
 
 

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -31,6 +31,7 @@ from django.utils.translation import ugettext as _
 
 from django_rq.queues import get_queue, get_failed_queue
 from django_rq.workers import Worker
+from redis.exceptions import ConnectionError
 
 from pootle import depcheck
 from pootle.core.decorators import admin_required
@@ -307,7 +308,10 @@ def server_stats_more(request):
 def rq_stats():
     queue = get_queue()
     failed_queue = get_failed_queue()
-    workers = Worker.all(queue.connection)
+    try:
+        workers = Worker.all(queue.connection)
+    except ConnectionError:
+        return None
     is_running = False
     if len(workers) == 1:
         is_running = not workers[0].stopped

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -79,6 +79,14 @@ def test_redis_server_available():
         return False, queue.connection.connection_pool.connection_kwargs
 
 
+def test_rq_workers_running():
+    from django_rq.queues import get_queue
+    from django_rq.workers import Worker
+    queue = get_queue()
+    workers = Worker.all(queue.connection)
+    return len(workers) >= 1 and not workers[0].stopped, len(workers)
+
+
 ##############################
 # Test optional dependencies #
 ##############################

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -67,6 +67,18 @@ def test_lxml():
         return None, None
 
 
+def test_redis_server_available():
+    from django_rq.queues import get_queue
+    from django_rq.workers import Worker
+    from redis.exceptions import ConnectionError
+    queue = get_queue()
+    try:
+        workers = Worker.all(queue.connection)
+        return True, queue.connection.connection_pool.connection_kwargs
+    except ConnectionError:
+        return False, queue.connection.connection_pool.connection_kwargs
+
+
 ##############################
 # Test optional dependencies #
 ##############################


### PR DESCRIPTION
This is the dashboard component of ensuring that Redis is part of the default Pootle setup.

This adds Redis to the critical checks and adds the needed depcheck functions.  We check that we can:

1. Access Redis
2. Have at least 1 worker running

The documentation that is required for #3351 will come via its own PR. 

Partial fix of #3351 