### PR TITLE
Redis required for caching and drop memcached

### DIFF
--- a/docs/releases/2.7.0.rst
+++ b/docs/releases/2.7.0.rst
@@ -175,6 +175,8 @@ Sysadmins
 
 - Direct upgrade is now only possible from 2.6.0.  Thus to upgrade from older
   releases first upgrade to 2.6.0
+- Redis is now required for all caching, memcached and other alternatives will
+  not work.
 - Registration and authentication is now handled by `django-allauth
   <https://readthedocs.org/projects/django-allauth/>`_.  This gives Pootle
   implicit support for OpenID, OAuth, OAuth2 and Persona sign-in protocols.
@@ -230,8 +232,6 @@ Internal changes
 - Translation projects now have a ``creation_time`` field.
 - Dropped code for several external apps from Pootle codebase. Also upgraded to
   newer versions of those apps.
-- The default caching in database has been replaced by local-memory caching.
-  Using memcached is still highly recommended.
 - Fixed and avoided any inconsistencies in the unit's submitter information.
 - URLs have been unified and all follow the same scheme. URLs ending in *.html*
   have been removed altogether. ``reverse()`` and ``{% url %}`` are used almost

--- a/docs/server/cache.rst
+++ b/docs/server/cache.rst
@@ -51,86 +51,11 @@ You can specify which backend to use by overriding the value of
 :setting:`CACHES` in your configuration file.
 
 
-.. _cache#memcached:
-
-Memcached
-^^^^^^^^^
-
-::
-
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-            'LOCATION': '127.0.0.1:11211',
-        }
-    }
-
-:ref:`Memcached <django:memcached>` is the **recommended cache backend**, it
-provides the best performance.  And works fine with multiprocessing servers
-like Apache. It requires the `python-memcached` package and a running
-memcached server. Due to extra dependencies it is not enabled by default.
-
-
-.. _cache#memcached_on_unix_sockets:
-
-Memcached on Unix sockets
-"""""""""""""""""""""""""
-
-::
-
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-            'LOCATION': 'unix:/path/to/memcached.sock',
-        }
-    }
-
-If you don't want Pootle using TCP/IP to access memcached then you can use Unix
-sockets.  This is often a situation in hardened installations using SELinux.
-
-You will need to ensure that memcached is running with the ``-s`` option. ::
-
-    memcached -u nobody -s /path/to/memcached.sock -a 0777
-
-
-.. _cache#database:
-
-Database
-^^^^^^^^
-
-::
-
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
-            'LOCATION': 'my_cache_table',
-        }
-    }
-
-|Database caching|_ relies on a table in the main Pootle database for storing
-the cached data, which makes it suitable for multiprocessing servers, with the
-added benefit that the cached data remains intact after a server reboot
-(unlike memcached) but it is considerably slower than memcached.
-
-.. versionchanged:: 2.1.1
-
-This is the default cache backend. On new installs and upgrades the required
-database will be created.
-
-Users of older versions need to create the cache tables manually if they would
-like to switch to the database cache backend using this :doc:`management command
-<commands>`::
-
-    $ pootle createcachetable pootlecache
-
 .. _Django's caching system: http://docs.djangoproject.com/en/dev/topics/cache/
 .. |Django's caching system| replace:: *Django's caching system*
 
 .. _multiple cache backends: http://docs.djangoproject.com/en/dev/topics/cache/#setting-up-the-cache
 .. |multiple cache backends| replace:: *multiple cache backends*
-
-.. _Database caching: http://docs.djangoproject.com/en/dev/topics/cache/#database-caching
-.. |Database caching| replace:: *Database caching*
 
 .. we use | | here and above for italics like :ref: in normal links
    (Django intersphinx objects do not include section titles, must use frags)

--- a/docs/server/cache.rst
+++ b/docs/server/cache.rst
@@ -3,9 +3,9 @@
 Caching System
 ==============
 
-Pootle uses a caching system to improve performance. It is an essential part
-of :doc:`optimizing <optimization>` your Pootle installation. It is based on
-|Django's caching system|_, and is used for various things:
+Pootle uses a caching system to improve performance. It is an essential part of
+your Pootle installation. It is based on |Django's caching system|_, and is
+used for various things:
 
 - To serve cached (possibly slightly outdated) versions of most pages to
   anonymous users to reduce their impact on server performance.
@@ -26,19 +26,13 @@ Without a well functioning cache system, Pootle could be slow.
 
 Named Caches
 ------------
-The cache backends are at least configured with a 'default' cache.  If this is
-the only cache that exists then all caching is placed into this cache.  The
-Pootle cache can also be configured to take advantage of certain named caches.
+Pootle is configured with a these named caches:
 
-Current named caches:
-
-- ``'default'`` -- all non specified cache data and all cache data if only one
-  cache is defined.
+- ``'default'`` -- all non specified cache data and all cache data.
 - ``'stats'`` --  all cached data related to overview stats.
 
 In large installations you may want to setup separate caches to improve cache
 performance.  You can then setup caching parameters for each cache separately.
-In most cases though you will simply use a single 'default' cache.
 
 
 .. _cache#cache_backends:
@@ -47,8 +41,10 @@ Cache Backends
 --------------
 
 Django supports |multiple cache backends|_ (methods of storing cache data).
-You can specify which backend to use by overriding the value of
-:setting:`CACHES` in your configuration file.
+However, Redis is the only cache backend supported by Pootle.  We use some
+custom features of Redis so cannot support other backends. You can customise
+the Redis cache settings by overriding the value of :setting:`CACHES` in your
+configuration file, an example exists in file:`90-local.conf.example`.
 
 
 .. _Django's caching system: http://docs.djangoproject.com/en/dev/topics/cache/

--- a/docs/server/optimization.rst
+++ b/docs/server/optimization.rst
@@ -28,16 +28,6 @@ Adjust the :setting:`DATABASES` setting accordingly.
   PostgreSQL adapter for Python.
 
 
-Caching
-^^^^^^^
-
-Fast and efficient caching avoids hitting the DB when it's not really needed.
-Adjust the :setting:`CACHES` setting accordingly.
-
-`python-memcached <http://www.tummy.com/software/python-memcached/>`_ Efficient
-caching.
-
-
 Indexing Engines
 ^^^^^^^^^^^^^^^^
 
@@ -110,8 +100,6 @@ some tips for performance tuning on your Pootle installation.
   <optimization#mysql>` instead of the default SQLite.  You can :doc:`migrate
   an existing installation <database_migration>` if you already have data you
   don't want to lose.
-
-- Install :doc:`memcached <cache>` and enable it in the settings file.
 
 - Install the latest recommended version of all dependencies. Django and the
   Translate Toolkit might affect performance.  Later versions of Pootle should

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -223,7 +223,7 @@ def optimal_depcheck():
     else:
         optimal.append({
             'dependency': 'cache',
-            'text': _("For optimal performance, use memcached as the caching "
+            'text': _("For optimal performance, use Redis as the caching "
                       "backend.")
         })
 

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -112,20 +112,9 @@ def required_depcheck():
     if status_redis_available:
         status_redis_version, version = depcheck.test_redis_server_version()
         if status_redis_version:
-            status_workers, connection_settings['num'] = \
-                depcheck.test_rq_workers_running()
-            if status_workers:
-                    text = ungettext(
-                            'Redis server accepting connections on %(host)s:%(port)s. '
-                            'With %(num)d RQ worker running.',
-                            'Redis server accepting connections on %(host)s:%(port)s. '
-                            'With %(num)d RQ workers running.',
-                            connection_settings['num'], connection_settings)
-                    state = 'tick'
-            else:
-                text = _('No RQ workers are running.  Redis server is accepting '
-                         'connections on %(host)s:%(port)s.', connection_settings)
-                state = 'error'
+            text = _('Redis server accepting connections on '
+                     '%(host)s:%(port)s.', connection_settings)
+            state = 'tick'
         else:
             trans_vars = {
                 'installed': version,
@@ -136,10 +125,26 @@ def required_depcheck():
                      "requires at least version %(required)s.", trans_vars)
             state = 'error'
     else:
-        text = _('Redis server is not running on %(host)s:%(port)s.',
+        text = _('Redis server is not available on %(host)s:%(port)s.',
                  connection_settings)
         state = 'error'
 
+    required.append({
+        'dependency': 'redis',
+        'state': state,
+        'text': text,
+    })
+
+    status_workers, connection_settings['num'] = depcheck.test_rq_workers_running()
+    if status_workers:
+            text = ungettext(
+                    '%(num)d RQ worker running.',
+                    '%(num)d RQ workers running.',
+                    connection_settings['num'], connection_settings)
+            state = 'tick'
+    else:
+        text = _('No RQ workers are running.')
+        state = 'error'
     required.append({
         'dependency': 'rq',
         'state': state,

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -198,14 +198,14 @@ def optimal_depcheck():
 
     if depcheck.test_cache():
         if depcheck.test_memcache():
-            if not depcheck.test_memcached():
-                # memcached configured but connection failing
+            if not depcheck.test_cache_server_connection():
+                # Server configured but connection failing
                 optimal.append({
                     'dependency': 'cache',
-                    'text': _("Pootle is configured to use memcached as a "
+                    'text': _("Pootle is configured to use Redis as a "
                               "caching backend, but can't connect to the "
-                              "memcached server. Caching is currently "
-                              "disabled.")
+                              "Redis server. Caching is currently "
+                              "impossible.")
                 })
             else:
                 if not depcheck.test_session():

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -146,6 +146,28 @@ def required_depcheck():
         'text': text,
     })
 
+    if depcheck.test_cache():
+        if not depcheck.test_cache_server_connection():
+            # Server configured but connection failing
+            required.append({
+                'dependency': 'cache',
+                'state': 'error',
+                'text': _("Pootle is configured to use Redis as a caching "
+                          "backend, but can't connect to the cache.")
+            })
+        else:
+            required.append({
+                'dependency': 'cache',
+                'state': 'tick',
+                'text': _("Caching configured and running.")
+            })
+    else:
+        required.append({
+            'dependency': 'cache',
+            'state': 'error',
+            'text': _("Redis is required as the caching backend.")
+        })
+
 
     return required
 
@@ -207,29 +229,11 @@ def optimal_depcheck():
                      "python-MySQLdb first.")
         optimal.append({'dependency': 'db', 'text': text})
 
-    if depcheck.test_cache():
-        if not depcheck.test_cache_server_connection():
-            # Server configured but connection failing
-            optimal.append({
-                'dependency': 'cache',
-                'text': _("Pootle is configured to use Redis as a "
-                          "caching backend, but can't connect to the "
-                          "Redis server. Caching is currently "
-                          "impossible.")
-            })
-        else:
-            if not depcheck.test_session():
-                text = _("For optimal performance, use django.contrib."
-                         "sessions.backends.cached_db as the session "
-                         "engine.")
-                optimal.append({'dependency': 'session', 'text': text})
-    else:
-        optimal.append({
-            'dependency': 'cache',
-            'text': _("For optimal performance, use Redis as the caching "
-                      "backend.")
-        })
-
+    if not depcheck.test_session():
+        text = _("For optimal performance, use django.contrib."
+                 "sessions.backends.cached_db as the session "
+                 "engine.")
+        optimal.append({'dependency': 'session', 'text': text})
     if not depcheck.test_webserver():
         optimal.append({
             'dependency': 'webserver',

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -197,29 +197,21 @@ def optimal_depcheck():
         optimal.append({'dependency': 'db', 'text': text})
 
     if depcheck.test_cache():
-        if depcheck.test_memcache():
-            if not depcheck.test_cache_server_connection():
-                # Server configured but connection failing
-                optimal.append({
-                    'dependency': 'cache',
-                    'text': _("Pootle is configured to use Redis as a "
-                              "caching backend, but can't connect to the "
-                              "Redis server. Caching is currently "
-                              "impossible.")
-                })
-            else:
-                if not depcheck.test_session():
-                    text = _("For optimal performance, use django.contrib."
-                             "sessions.backends.cached_db as the session "
-                             "engine.")
-                    optimal.append({'dependency': 'session', 'text': text})
-        else:
+        if not depcheck.test_cache_server_connection():
+            # Server configured but connection failing
             optimal.append({
                 'dependency': 'cache',
-                'text': _("Pootle is configured to use memcached as caching "
-                          "backend, but Python support for memcached is not "
-                          "installed. Caching is currently disabled.")
+                'text': _("Pootle is configured to use Redis as a "
+                          "caching backend, but can't connect to the "
+                          "Redis server. Caching is currently "
+                          "impossible.")
             })
+        else:
+            if not depcheck.test_session():
+                text = _("For optimal performance, use django.contrib."
+                         "sessions.backends.cached_db as the session "
+                         "engine.")
+                optimal.append({'dependency': 'session', 'text': text})
     else:
         optimal.append({
             'dependency': 'cache',

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -106,6 +106,18 @@ def test_rq_workers_running():
     return len(workers) >= 1 and not workers[0].stopped, len(workers)
 
 
+def test_cache():
+    """Test if cache backend is Redis."""
+    if getattr(settings, "CACHES", None):
+        return "RedisCache" in settings.CACHES['default']['BACKEND']
+
+
+def test_cache_server_connection():
+    """Test if we can connect to the cache server."""
+    from django.core.cache import cache
+    return cache._cache.servers[0].connect()
+
+
 ##############################
 # Test optional dependencies #
 ##############################
@@ -145,18 +157,6 @@ def test_db():
     """Test that we are not using sqlite3 as the django database."""
     if getattr(settings, "DATABASES", None):
         return "sqlite" not in settings.DATABASES['default']['ENGINE']
-
-
-def test_cache():
-    """Test if cache backend is Redis."""
-    if getattr(settings, "CACHES", None):
-        return "RedisCache" in settings.CACHES['default']['BACKEND']
-
-
-def test_cache_server_connection():
-    """Test if we can connect to the cache server."""
-    from django.core.cache import cache
-    return cache._cache.servers[0].connect()
 
 
 def test_session():

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -153,7 +153,7 @@ def test_cache_server_connection():
 
 
 def test_session():
-    """Test that session backend is set to memcache."""
+    """Test that session backend is set to cache or cache_db."""
     return settings.SESSION_ENGINE.split('.')[-1] in ('cache', 'cached_db')
 
 

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -129,10 +129,9 @@ def test_db():
 
 
 def test_cache():
-    """Test if cache backend is memcached."""
-    #FIXME: maybe we shouldn't complain if cache is set to db or file?
+    """Test if cache backend is Redis."""
     if getattr(settings, "CACHES", None):
-        return "memcache" in settings.CACHES['default']['BACKEND']
+        return "RedisCache" in settings.CACHES['default']['BACKEND']
 
 
 def test_memcache():

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -32,6 +32,14 @@ DJANGO_MINIMUM_REQUIRED_VERSION = (1, 7, 4)
 # Minimum lxml version required for Pootle to run.
 LXML_MINIMUM_REQUIRED_VERSION = (2, 2, 2, 0)
 
+# Minimum Redis server version required.
+# Initially set to some minimums based on:
+# 1. Ubuntu 12.04LTS's version 2.8.4 (10.04LTS was too old for RQ)
+# 2. RQ requires >= 2.6.0, and
+# 3. Wanting to insist on at least the latest stable that devs are using i.e.
+#    2.8.* versions of Redis
+REDIS_MINIMUM_REQUIRED_SERVER_VERSION = (2, 8, 4)
+
 
 ##########################
 # Test core dependencies #
@@ -77,6 +85,17 @@ def test_redis_server_available():
         return True, queue.connection.connection_pool.connection_kwargs
     except ConnectionError:
         return False, queue.connection.connection_pool.connection_kwargs
+
+
+def test_redis_server_version():
+    from django_rq.queues import get_queue
+    queue = get_queue()
+    redis_version_string = queue.connection.info()['redis_version']
+    redis_version = tuple([int(x) for x in redis_version_string.split(".")])
+    if redis_version >= REDIS_MINIMUM_REQUIRED_SERVER_VERSION:
+        return True, redis_version_string
+    else:
+        return False, redis_version_string
 
 
 def test_rq_workers_running():

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -146,8 +146,8 @@ def test_memcache():
             return False
 
 
-def test_memcached():
-    """Test if we can connect to memcache server."""
+def test_cache_server_connection():
+    """Test if we can connect to the cache server."""
     from django.core.cache import cache
     return cache._cache.servers[0].connect()
 

--- a/pootle/depcheck.py
+++ b/pootle/depcheck.py
@@ -134,18 +134,6 @@ def test_cache():
         return "RedisCache" in settings.CACHES['default']['BACKEND']
 
 
-def test_memcache():
-    try:
-        import memcache
-        return True
-    except ImportError:
-        try:
-            import pylibmc
-            return True
-        except ImportError:
-            return False
-
-
 def test_cache_server_connection():
     """Test if we can connect to the cache server."""
     from django.core.cache import cache

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -56,10 +56,9 @@ CACHES = {
 }
 
 
-# Using memcached to store sessions improves performance for anonymous
+# Using caching to store sessions improves performance for anonymous
 # users. For more info, check
 # http://docs.djangoproject.com/en/dev/topics/http/sessions/#configuring-the-session-engine
-# Uncomment this if you're using memcached as CACHE_BACKEND
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
 # To improve performance, non-logged users get cached copies of most pages.

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -20,23 +20,28 @@ DATABASES = {
 
 # Cache Backend settings
 #
-# By default we use Django's local-memory cache which is only suitable
-# for small deployments.
+# By default we use Redis as our main cache backend as we potentially rely on
+# features specific to Redis.  Other backends will likely not work.
 #
-# If you are going to deploy a real server memcached is preferred. For more
-# information, check
+# For more # information, check
 # http://docs.djangoproject.com/en/dev/topics/cache/#setting-up-the-cache
+# and https://github.com/sebleier/django-redis-cache#usage
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'pootlecache',
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': 'localhost:6379',
         'TIMEOUT': 60,
         'OPTIONS': {
-            'MAX_ENTRIES': 65536,
-            'CULL_FREQUENCY': 16,
-        }
-    }
+            'DB': 1,
+            'CONNECTION_POOL_CLASS': 'redis.BlockingConnectionPool',
+            'CONNECTION_POOL_CLASS_KWARGS': {
+                'max_connections': 50,
+                'timeout': 20,
+            },
+        },
+    },
 }
+
 
 # Using memcached to store sessions improves performance for anonymous
 # users. For more info, check

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -40,6 +40,19 @@ CACHES = {
             },
         },
     },
+    'stats': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': 'localhost:6379',
+        'TIMEOUT': None,
+        'OPTIONS': {
+            'DB': 2,
+            'CONNECTION_POOL_CLASS': 'redis.BlockingConnectionPool',
+            'CONNECTION_POOL_CLASS_KWARGS': {
+                'max_connections': 50,
+                'timeout': 20,
+            },
+        },
+    },
 }
 
 

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -63,15 +63,20 @@ DATABASES = {
 
 #
 # Cache Backend settings
-#
-# Use local memory caching for development
-# https://docs.djangoproject.com/en/dev/topics/cache/#local-memory-caching
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'pootlecache',
-    }
-}
+
+# For more information, check
+# http://docs.djangoproject.com/en/dev/topics/cache/#setting-up-the-cache
+#CACHES = {
+#    'default': {
+#        'BACKEND': 'redis_cache.RedisCache',
+#        'LOCATION': 'localhost:6379',
+#    },
+#    'stats': {
+#        'BACKEND': 'redis_cache.RedisCache',
+#        'LOCATION': 'localhost:6379',
+#        'TIMEOUT': None,
+#    },
+#}
 
 
 # Logging

--- a/pootle/settings/90-local.conf.sample
+++ b/pootle/settings/90-local.conf.sample
@@ -62,17 +62,18 @@ DATABASES = {
 
 # Cache Backend settings
 
-# By default we use Django's local-memory cache which is only suitable
-# for small deployments.
-#
-# If you are going to deploy a real server memcached is preferred. For more
-# information, check
+# For more information, check
 # http://docs.djangoproject.com/en/dev/topics/cache/#setting-up-the-cache
 #CACHES = {
 #    'default': {
-#        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-#        'LOCATION': '127.0.0.1:11211',
-#    }
+#        'BACKEND': 'redis_cache.RedisCache',
+#        'LOCATION': 'localhost:6379',
+#    },
+#    'stats': {
+#        'BACKEND': 'redis_cache.RedisCache',
+#        'LOCATION': 'localhost:6379',
+#        'TIMEOUT': None,
+#    },
 #}
 
 # The directory where the Pootle writes logs to


### PR DESCRIPTION
This needs review and I think is good to land as is.  This removes all references and suggestions of using memcached from the code.  It adds all the needed caches and forces the use of Redis caching.  All the depchecks have been adapted or de-memcached as needed.

The only reference to memcached will be in the existing PO files, old release notes and upgrade instructions.

@julen I'd like some clarity on why we're using django-redis-cache instead of django-redis.  I also added hiredis package as that seems to be suggested by the django-redis-cache default setup and comments.