### PR TITLE
Redis: DRY settings for persistent storage

### DIFF
--- a/pootle/core/models.py
+++ b/pootle/core/models.py
@@ -24,7 +24,7 @@ from .cache import get_cache
 from .mixins import TreeItem
 
 
-cache = get_cache()
+cache = get_cache('redis')
 
 
 class Revision(object):

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -32,9 +32,14 @@ CACHES = {
         'LOCATION': 'redis://127.0.0.1:6379/1',
         'TIMEOUT': 60,
     },
-    'stats': {
+    'redis': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://127.0.0.1:6379/2',
+        'TIMEOUT': None,
+    },
+    'stats': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/3',
         'TIMEOUT': None,
     },
 }
@@ -66,10 +71,7 @@ POOTLE_LOG_DIRECTORY = '/var/log/pootle'
 
 RQ_QUEUES = {
     'default': {
-        'HOST': 'localhost',
-        'PORT': 6379,
-        'DB': 0,
-        'PASSWORD': '',
+        'USE_REDIS_CACHE': 'redis',
         'DEFAULT_TIMEOUT': 360,
     },
 }

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -73,9 +73,14 @@ DATABASES = {
 #        'LOCATION': 'redis://127.0.0.1:6379/1',
 #        'TIMEOUT': 60,
 #    },
-#    'stats': {
+#    'redis': {
 #        'BACKEND': 'django_redis.cache.RedisCache',
 #        'LOCATION': 'redis://127.0.0.1:6379/2',
+#        'TIMEOUT': None,
+#    },
+#    'stats': {
+#        'BACKEND': 'django_redis.cache.RedisCache',
+#        'LOCATION': 'redis://127.0.0.1:6379/3',
 #        'TIMEOUT': None,
 #    },
 #}

--- a/pootle/settings/90-local.conf.sample
+++ b/pootle/settings/90-local.conf.sample
@@ -71,9 +71,14 @@ DATABASES = {
 #        'LOCATION': 'redis://127.0.0.1:6379/1',
 #        'TIMEOUT': 60,
 #    },
-#    'stats': {
+#    'redis': {
 #        'BACKEND': 'django_redis.cache.RedisCache',
 #        'LOCATION': 'redis://127.0.0.1:6379/2',
+#        'TIMEOUT': None,
+#    },
+#    'stats': {
+#        'BACKEND': 'django_redis.cache.RedisCache',
+#        'LOCATION': 'redis://127.0.0.1:6379/3',
 #        'TIMEOUT': None,
 #    },
 #}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,7 +17,19 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         'LOCATION': 'pootle-tests'
-    }
+    },
+    # Must set up entries for persistent stores here because we have a
+    # check in place that will abort everything otherwise
+    'redis': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/1',
+        'TIMEOUT': None,
+    },
+    'stats': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/1',
+        'TIMEOUT': None,
+    },
 }
 
 


### PR DESCRIPTION
Also ensures the revision counter will use the `redis` named cache, which
in turn will also be used for RQ and any other future uses of Redis as a
persistent data store.

Fixes #3592.