### PR TITLE
Fixing regular expression for locale codes

### DIFF
--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -31,7 +31,7 @@ from pootle_project.models import Project, RESERVED_PROJECT_CODES
 from pootle_store.models import Store
 
 
-LANGCODE_RE = re.compile("^[a-z]{2,}([_-][a-z]{2,})*(@[a-z0-9]+)?$",
+LANGCODE_RE = re.compile("^[a-z]{2,}([_-]([a-z]{2,}|[0-9]{3}))*(@[a-z0-9]+)?$",
                          re.IGNORECASE)
 
 


### PR DESCRIPTION
I had tried to enter es_419 (Spanish (Latin America)) as a locale code,
but pootle rejected it as non-standard even though AFAIK this is the
standard code. Pootle’s regex seemingly doesn’t know about numeric
region codes being valid in locale codes.