### PR TITLE
include_raw: don't limit to `FileSystemLoader`

### DIFF
--- a/pootle/apps/pootle_store/templatetags/store_tags.py
+++ b/pootle/apps/pootle_store/templatetags/store_tags.py
@@ -27,9 +27,10 @@ from translate.storage.placeables import general
 from django import template
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.defaultfilters import stringfilter
-from django.template.loaders.filesystem import Loader
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+
+from pootle.core.utils.templates import get_template_source
 
 from pootle_store.fields import list_empty
 
@@ -215,7 +216,6 @@ def do_include_raw(parser, token):
     if template_name[0] in ('"', "'") and template_name[-1] == template_name[0]:
         template_name = template_name[1:-1]
 
-    template_loader = Loader()
-    source, path = template_loader.load_template_source(template_name)
+    source, path = get_template_source(template_name)
 
     return template.TextNode(source)

--- a/pootle/core/utils/templates.py
+++ b/pootle/core/utils/templates.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Evernote Corporation
+#
+# This file is part of Pootle.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from django.conf import settings
+from django.template.base import TemplateDoesNotExist
+from django.template.loader import find_template_loader
+
+
+def get_template_source(name, dirs=None):
+    """Retrieves the template's source contents.
+
+    :param name: Template's filename, as passed to the template loader.
+    :param dirs: list of directories to optionally override the defaults.
+    :return: tuple including file contents and file path.
+    """
+    for loader_name in settings.TEMPLATE_LOADERS:
+        loader = find_template_loader(loader_name)
+        if loader is not None:
+            try:
+                return loader.load_template_source(name, template_dirs=dirs)
+            except TemplateDoesNotExist:
+                pass
+
+    raise TemplateDoesNotExist(name)


### PR DESCRIPTION
This ensures any available template loader will be considered, therefore not blindly relying on the `FileSystemLoader`.

@unho please test and report back.