### PR TITLE
Second stage on vfolders

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -38,6 +38,7 @@ from pootle_misc.forms import make_search_form
 from pootle_misc.util import ajax_required, to_int, get_date_interval
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
+from virtualfolder.helpers import extract_vfolder_from_path
 from virtualfolder.models import VirtualFolder
 
 from .decorators import get_unit_context
@@ -459,7 +460,13 @@ def get_units(request):
     request.profile = User.get(request.user)
     limit = request.profile.get_unit_rows()
 
+    vfolder, pootle_path = extract_vfolder_from_path(pootle_path)
+
     units_qs = Unit.objects.get_for_path(pootle_path, request.profile)
+
+    if vfolder is not None:
+        units_qs = units_qs.filter(vfolders=vfolder)
+
     units_qs = units_qs.select_related(
         'store__translation_project__project',
         'store__translation_project__language',

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -811,7 +811,10 @@ def get_overview_stats(request, *args, **kwargs):
     stats = request.resource_obj.get_stats()
 
     if isinstance(request.resource_obj, Directory):
-        stats['vfolders'] = VirtualFolder.get_stats_for(request.resource_obj.pootle_path)
+        stats['vfolders'] = VirtualFolder.get_stats_for(
+            request.resource_obj.pootle_path,
+            request.user.is_superuser
+        )
 
     return JsonResponse(stats)
 

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -747,8 +747,21 @@ def get_edit_unit(request, unit):
     alt_src_langs = get_alt_src_langs(request, user, translation_project)
     project = translation_project.project
 
-    # Retrieve the unit top priority, if any.
-    priority = unit.vfolders.aggregate(priority=Max('priority'))['priority']
+    priority = None
+    vfolder_pk = request.GET.get('vfolder', '')
+
+    if vfolder_pk:
+        try:
+            # If we are translating a virtual folder, then display its priority.
+            # Note that the passed virtual folder pk might be invalid.
+            priority = VirtualFolder.objects.get(pk=vfolder_pk).priority
+        except VirtualFolder.DoesNotExist:
+            pass
+
+    if priority is None:
+        # Retrieve the unit top priority, if any. This can happen if we are not
+        # in a virtual folder or if the passed virtual folder pk is invalid.
+        priority = unit.vfolders.aggregate(priority=Max('priority'))['priority']
 
     template_vars = {
         'unit': unit,

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -31,12 +31,14 @@ from pootle.core.decorators import (get_path_obj, get_resource,
                                     permission_required)
 from pootle.core.exceptions import Http400
 from pootle.core.http import JsonResponse, JsonResponseBadRequest
+from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import check_user_permission
 from pootle_misc.checks import check_names
 from pootle_misc.forms import make_search_form
 from pootle_misc.util import ajax_required, to_int, get_date_interval
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
+from virtualfolder.models import VirtualFolder
 
 from .decorators import get_unit_context
 from .fields import to_python
@@ -807,6 +809,10 @@ def get_qualitycheck_stats(request, *args, **kwargs):
 @get_resource
 def get_overview_stats(request, *args, **kwargs):
     stats = request.resource_obj.get_stats()
+
+    if isinstance(request.resource_obj, Directory):
+        stats['vfolders'] = VirtualFolder.get_stats_for(request.resource_obj.pootle_path)
+
     return JsonResponse(stats)
 
 

--- a/pootle/apps/virtualfolder/helpers.py
+++ b/pootle/apps/virtualfolder/helpers.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.url_helpers import get_all_pootle_paths, split_pootle_path
+from pootle_app.models import Directory
+from pootle_store.models import Store
+
+from .models import VirtualFolder
+
+
+def extract_vfolder_from_path(pootle_path):
+    """Return a valid virtual folder and an adjusted pootle path.
+
+    This accepts a pootle path and extracts the virtual folder from it (if
+    present) returning the virtual folder and the clean path.
+
+    If it can't be determined the virtual folder, then the provided path is
+    returned unchanged along as a None value.
+
+    The path /gl/firefox/browser/vfolder/chrome/file.po with the vfolder
+    virtual folder on it will be converted to
+    /gl/firefox/browser/chrome/file.po if the virtual folder exists and is
+    browsable.
+
+    Have in mind that several virtual folders with the same name might apply in
+    the same path (as long as they have different locations this is possible)
+    and in such cases the one with higher priority is returned.
+    """
+    lang, proj, dir_path, filename = split_pootle_path(pootle_path)
+
+    if ((filename and Store.objects.filter(pootle_path=pootle_path).exists()) or
+        Directory.objects.filter(pootle_path=pootle_path).exists()):
+        # If there is no vfolder then return the provided path.
+        return None, pootle_path
+
+    # Get the pootle paths for all the parents except the one for the file and
+    # those for the translation project and above.
+    all_dir_paths = [dir_path for dir_path in get_all_pootle_paths(pootle_path)
+                     if dir_path.count('/') > 3 and dir_path.endswith('/')]
+    all_dir_paths = sorted(all_dir_paths)
+
+    for dir_path in all_dir_paths:
+        if Directory.objects.filter(pootle_path=dir_path).exists():
+            continue
+
+        # There is no directory with such path, and that might mean that it
+        # includes a virtual folder.
+        valid_starting_path, vfolder_name = dir_path.rstrip('/').rsplit('/', 1)
+
+        vfolders = VirtualFolder.objects.filter(
+            name=vfolder_name,
+            is_browsable=True
+        ).order_by('-priority')
+
+        vfolder = None
+
+        for vf in vfolders:
+            # There might be several virtual folders with the same name, so get
+            # the first higher priority one that applies to the adjusted path.
+            try:
+                # Ensure that the virtual folder applies in the path.
+                vf.get_adjusted_location(valid_starting_path + '/')
+            except Exception:
+                continue
+
+            vfolder = vf
+            break
+
+        if vfolder is None:
+            # The virtual folder does not exist or is not browsable or doesn't
+            # apply in this location, so this is an invalid path.
+            break
+
+        valid_ending_path = pootle_path.replace(dir_path, '')
+        adjusted_path = '/'.join([valid_starting_path, valid_ending_path])
+
+        return vfolder, adjusted_path
+
+    # There is no virtual folder (or is not browsable) and the provided path
+    # doesn't exist, so let the calling code to deal with this.
+    return None, pootle_path

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -103,11 +103,20 @@ class VirtualFolder(models.Model):
                                                         priority__gte=1)
 
     @classmethod
-    def get_stats_for(cls, pootle_path):
-        """Get stats for all the virtual folders in the given path."""
-        stats = {}
+    def get_stats_for(cls, pootle_path, all_vfolders=False):
+        """Get stats for all the virtual folders in the given path.
 
-        for vf in cls.get_visible_for(pootle_path):
+        If ``all_vfolders`` is True then all virtual folders in the passed
+        pootle_path are returned, independently of their priority of
+        browsability.
+        """
+        stats = {}
+        if all_vfolders:
+            vfolders = cls.get_matching_for(pootle_path)
+        else:
+            vfolders = cls.get_visible_for(pootle_path)
+
+        for vf in vfolders:
             units = vf.units.filter(store__pootle_path__startswith=pootle_path)
             stores = Store.objects.filter(
                 pootle_path__startswith=pootle_path,

--- a/pootle/apps/virtualfolder/signals.py
+++ b/pootle/apps/virtualfolder/signals.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.dispatch import Signal
+
+
+vfolder_post_save = Signal(providing_args=["instance", "projects"])

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -19,6 +19,11 @@ HEADING_CHOICES = [
         'display_name': _("Name"),
     },
     {
+        'id': 'priority',
+        'class': 'stats-number sorttable_numeric',
+        'display_name': _("Priority"),
+    },
+    {
         'id': 'project',
         'class': 'stats',
         'display_name': _("Project"),
@@ -176,3 +181,28 @@ def get_children(directory):
               for child_store in directory.child_stores.live().iterator()]
 
     return directories + stores
+
+
+def make_vfolder_item(virtual_folder, pootle_path):
+    return {
+        'href_all': virtual_folder.get_translate_url(pootle_path),
+        'href_todo': virtual_folder.get_translate_url(pootle_path,
+                                                      state='incomplete'),
+        'href_sugg': virtual_folder.get_translate_url(pootle_path,
+                                                      state='suggestions'),
+        'href_critical': virtual_folder.get_critical_url(pootle_path),
+        'title': virtual_folder.name,
+        'code': virtual_folder.code,
+        'priority': virtual_folder.priority,
+        'icon': 'folder',
+    }
+
+
+def get_vfolders(directory):
+    """Return a list of virtual folders for this ``directory``.
+
+    The elements of the list are dictionaries which keys are populated after
+    in the templates.
+    """
+    return [make_vfolder_item(vf, directory.pootle_path)
+            for vf in VirtualFolder.get_visible_for(directory.pootle_path)]

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -194,6 +194,8 @@ def make_vfolder_item(virtual_folder, pootle_path):
         'title': virtual_folder.name,
         'code': virtual_folder.code,
         'priority': virtual_folder.priority,
+        'is_grayed': (not virtual_folder.is_browsable or
+                      virtual_folder.priority < 1),
         'icon': 'folder',
     }
 

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -198,11 +198,18 @@ def make_vfolder_item(virtual_folder, pootle_path):
     }
 
 
-def get_vfolders(directory):
+def get_vfolders(directory, all_vfolders=False):
     """Return a list of virtual folders for this ``directory``.
 
     The elements of the list are dictionaries which keys are populated after
     in the templates.
+
+    If ``all_vfolders`` is True then all the virtual folders matching the
+    provided directory are returned. If not only the visible ones are returned.
     """
+    if all_vfolders:
+        return [make_vfolder_item(vf, directory.pootle_path)
+            for vf in VirtualFolder.get_matching_for(directory.pootle_path)]
+
     return [make_vfolder_item(vf, directory.pootle_path)
             for vf in VirtualFolder.get_visible_for(directory.pootle_path)]

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -171,6 +171,7 @@ def set_resource(request, path_obj, dir_path, filename):
     request.store = store
     request.directory = directory
     request.pootle_path = pootle_path
+    request.current_vfolder = getattr(vfolder, 'pk', '')
 
     request.resource_obj = store or (directory if dir_path else path_obj)
     request.resource_path = resource_path

--- a/pootle/core/helpers.py
+++ b/pootle/core/helpers.py
@@ -77,6 +77,12 @@ def get_translation_context(request, is_terminology=False):
     """
     resource_path = getattr(request, 'resource_path', '')
     vfolder_pk = getattr(request, 'current_vfolder', '')
+    display_priority = False
+
+    if not vfolder_pk:
+        display_priority = VirtualFolder.objects.filter(
+            units__store__pootle_path__startswith=request.pootle_path
+        ).exists()
 
     return {
         'page': 'translate',
@@ -90,6 +96,7 @@ def get_translation_context(request, is_terminology=False):
         'pootle_path': request.pootle_path,
         'ctx_path': request.ctx_path,
         'current_vfolder_pk': vfolder_pk,
+        'display_priority': display_priority,
         'resource_path': resource_path,
         'resource_path_parts': get_path_parts(resource_path),
 

--- a/pootle/core/helpers.py
+++ b/pootle/core/helpers.py
@@ -76,6 +76,7 @@ def get_translation_context(request, is_terminology=False):
         is relevant to a terminology project.
     """
     resource_path = getattr(request, 'resource_path', '')
+    vfolder_pk = getattr(request, 'current_vfolder', '')
 
     return {
         'page': 'translate',
@@ -88,6 +89,7 @@ def get_translation_context(request, is_terminology=False):
 
         'pootle_path': request.pootle_path,
         'ctx_path': request.ctx_path,
+        'current_vfolder_pk': vfolder_pk,
         'resource_path': resource_path,
         'resource_path_parts': get_path_parts(resource_path),
 

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1994,6 +1994,7 @@ table.stats .item.dirty .last-updated
     opacity: 0.35;
 }
 
+.item.is-grayed,
 .item.is-disabled
 {
     font-style: italic;

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -2123,6 +2123,11 @@ table.stats .item.dirty .last-updated
     color: #606047;
 }
 
+.vfolders
+{
+     margin-bottom: 3em;
+}
+
 /* FIX FOR HEADING SIZES */
 
 h2:lang(bn),

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1308,11 +1308,15 @@ PTL.editor = {
         uid = currentUnit.id,
         editUrl = l(['/xhr/units/', uid, '/edit/'].join('')),
         widget = '',
-        ctx = {before: [], after: []};
+        ctx = {before: [], after: []},
+        reqData = {
+          vfolder: this.settings.vFolder
+        };
 
     $.ajax({
       url: editUrl,
       async: false,
+      data: reqData,
       dataType: 'json',
       success: function (data) {
         PTL.editor.tmData = data.tm_suggestions || null;

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -40,6 +40,7 @@ var stats = {
   init: function (options) {
     this.retries = 0;
     this.pootlePath = options.pootlePath;
+    this.isAdmin = options.isAdmin;
     this.processLoadedData(options.data, undefined, true);
 
     $('td.stats-name').filter(':not([dir])').bidi();
@@ -210,7 +211,7 @@ var stats = {
           $td = $vfoldersTable.find('#total-words-' + code);
 
           // Hide virtual folders that are completely translated.
-          if (item.translated === item.total) {
+          if (!this.isAdmin && item.translated === item.total) {
             //FIXME vfolders might be added or removed since they can become
             // completely translated or stop being completely translated, so
             // they might be displayable after the initial load of the overview.

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -161,6 +161,7 @@ var stats = {
 
   processLoadedData: function (data, callback, firstPageLoad) {
     var $table = $('#content table.stats'),
+        $vfoldersTable = $('#content .vfolders table.stats'),
         dirtySelector = '#top-stats, #translate-actions, #autorefresh-notice',
         now = parseInt(Date.now() / 1000, 10);
 
@@ -192,12 +193,32 @@ var stats = {
 
     if ($table.length) {
       // this is a directory that contains subitems
-      for (var name in data.children) {
-        var item = data.children[name],
-            code = name.replace(/[\.@]/g, '-'),
-            $td = $table.find('#total-words-' + code);
+      var name, item, code, $td;
+
+      for (name in data.children) {
+        item = data.children[name];
+        code = name.replace(/[\.@]/g, '-');
+        $td = $table.find('#total-words-' + code);
 
         this.processTableItem(item, code, $table, $td, now);
+      }
+
+      if ($vfoldersTable.length) {
+        for (name in data.vfolders) {
+          item = data.vfolders[name];
+          code = name.replace(/[\.@]/g, '-');
+          $td = $vfoldersTable.find('#total-words-' + code);
+
+          // Hide virtual folders that are completely translated.
+          if (item.translated === item.total) {
+            //FIXME vfolders might be added or removed since they can become
+            // completely translated or stop being completely translated, so
+            // they might be displayable after the initial load of the overview.
+            $td.parent().hide();
+          } else {
+            this.processTableItem(item, code, $vfoldersTable, $td, now);
+          }
+        }
       }
 
       // Sort columns based on previously-made selections

--- a/pootle/templates/browser/_table.html
+++ b/pootle/templates/browser/_table.html
@@ -23,7 +23,7 @@
   <tbody class="stats">
     {% for item in table.items %}
 
-    <tr class="item{% if item.is_disabled %} is-disabled{% endif %}">
+    <tr class="item{% if item.is_disabled %} is-disabled{% endif %}{% if item.is_grayed %} is-grayed{% endif %}">
 
       {% if 'name' in table.fields %}
       <td class="stats-name {{ item.icon }}"{% if item.description %} title="{{ item.description|striptags }}"{% endif %}>

--- a/pootle/templates/browser/_table.html
+++ b/pootle/templates/browser/_table.html
@@ -27,7 +27,15 @@
 
       {% if 'name' in table.fields %}
       <td class="stats-name {{ item.icon }}"{% if item.description %} title="{{ item.description|striptags }}"{% endif %}>
-        <a href="{{ item.href }}"><i class="icon-{{ item.icon }}"></i> <span>{{ item.title }}</span></a>
+        {% if item.href %}<a href="{{ item.href }}">{% endif %}
+          <i class="icon-{{ item.icon }}"></i> <span>{{ item.title }}</span>
+        {% if item.href %}</a>{% endif %}
+      </td>
+      {% endif %}
+
+      {% if 'priority' in table.fields %}
+      <td id="priority-{{ item.code }}" class="stats-number total">
+        <span class="zero">{{ item.priority }}</span>
       </td>
       {% endif %}
 

--- a/pootle/templates/browser/overview.html
+++ b/pootle/templates/browser/overview.html
@@ -109,6 +109,12 @@
   <a href="#" class="js-stats-refresh">{% trans "Refresh now" %}</a>
 </div>
 
+{% if vfolders %}
+<div class="bd vfolders" lang="{{ LANGUAGE_CODE }}">
+  {% display_table vfolders %}
+</div>
+{% endif %}
+
 {% if table %}
 <div class="bd" lang="{{ LANGUAGE_CODE }}">
   {% display_table table %}

--- a/pootle/templates/browser/overview.html
+++ b/pootle/templates/browser/overview.html
@@ -130,6 +130,7 @@ $(function () {
   PTL.search.init();
   PTL.stats.init({
     pootlePath: "{{ pootle_path }}",
+    isAdmin: {{ is_admin|yesno:"true,false" }},
     data: {{ stats|safe }}
   });
 

--- a/pootle/templates/editor/_scripts.html
+++ b/pootle/templates/editor/_scripts.html
@@ -19,6 +19,7 @@ $(function() {
   var options = {
     tmUrl: '{{ AMAGAMA_URL }}',
     pootlePath: '{{ pootle_path }}',
+    vFolder: '{{ current_vfolder_pk }}',
     ctxPath: '{{ ctx_path }}',
     resourcePath: '{{ resource_path }}',
     chunkSize: {{ request.profile.get_unit_rows }},

--- a/pootle/templates/editor/_toolbar.html
+++ b/pootle/templates/editor/_toolbar.html
@@ -4,7 +4,9 @@
   <div class="unit-sort">
     <select id="js-filter-sort">
       <option selected value="default">{% trans "Default order" %}</option>
+      {% if display_priority %}
       <option value="priority">{% trans "Important first" %}</option>
+      {% endif %}
       <option value="newest">{% trans "Newest first" %}</option>
       <option value="oldest">{% trans "Oldest first" %}</option>
     </select>


### PR DESCRIPTION
@translate/house @translate/evernote 

Instructions for setup:

- Check out the branch locally
- You might need to make the assets
- Run `./manage.py shell_plus`
- Run `VirtualFolder.objects.all().delete()` and exit the shell
- Get https://drive.google.com/file/d/0B-8KVyCPnkZRck1IUkZKWklCeHM and uncompress it on your `PODIRECTORY`
- Add a new `test_vfolders` project.
- Run `./manage.py update_stores --project=test_vfolders`
- Get http://dpaste.com/0NHWD4W and save it as `vfolders_test_directory.json`
- Run `./manage.py add_vfolders vfolders_test_directory.json`


Instructions for testing:

- Run `./manage.py runserver`
- Log in as a regular user (not admin)
- Go to `http://127.0.0.1:8000/af/test_vfolders/browser/chrome/`
- Check that:
  - the vfolders stats table is displayed
  - the listed vfolders are all the vfolders that should be displayed. The following must not be displayed:
    - not browsable vfolders,
    - completely translated vfolders,
    - priority below 1 vfolders.
  - the counts match. Note that each vfolder counts must only include the files they match in the current location or below it.
  -  the translate links are correct. Just are like regular translate links for this location, but with the vfolder name included just after its location, for example a vfolder with location `/af/test_vfolders/browser/` and name `test-overlapping-vfolder` will have a needs work translate link pointing to `http://127.0.0.1:8000/af/test_vfolders/translate/browser/test-overlapping-vfolder/chrome/#filter=incomplete`
- Log in as an admin user
- Check that in `http://127.0.0.1:8000/af/test_vfolders/browser/chrome/` now you can also see:
  - not browsable vfolders styled as disabled (grayed out),
  - completely translated vfolders,
  - vfolders with priority below 1 styled as disabled (grayed out).
- Click on the `need translation` translate link for vfolder `test-overrides` on the vfolders stats table and ensure that:
  - you see `browser/test-overrides/chrome` in the navbar dropdown,
  - the URL in the browser location bar is `http://127.0.0.1:8000/af/test_vfolders/translate/browser/test-overrides/chrome/#filter=incomplete`,
  - the units displayed only belong to files matched by the vfolder filter in `/af/test_vfolders/browser/chrome/`
  - it is not possible to sort by priority.
- Select the same path to be translated in the editor, but not restricted to a vfolder: `http://127.0.0.1:8000/af/test_vfolders/translate/browser/chrome/#filter=incomplete`. Check that:
  - the unit count is bigger
  - you can sort by priority.
- Open the navbar dropdown and ensure that all the vfolders that match within current project are displayed:
  - Should be included (even if they have low priority or are completely translated): "test-overlapping-vfolder", "test-overrides", "test-low-priority", "test-vfolder1", "test-vfolder2", "test-vfolder3"
  - Are not browsable and thus should not be included: "test-not-browsable", "test-completely-translated"
  - Don't apply to any file, so they should not be included: "test-directory", "test-newfile"
- Open `http://127.0.0.1:8000/af/test_vfolders/translate/chat/#filter=incomplete` and ensure that:
  - no priority is being displayed for any of the units listed,
  - it is not possible to select priority sorting.
- Open `http://127.0.0.1:8000/af/test_vfolders/translate/dom/chrome/#filter=incomplete` and ensure that:
  - the top priority is being displayed for all the units shown (the units in this location belong to the vfolders whose name starts with `test-vfolder`, which eases looking in the JSON). Remember to ensure that the top priority is shown for a unit that is included in several vfolders.
  - you can sort by priority. Remember top priorities are above and lower at the bottom. 