### PR TITLE
Fix sidebar look after import_export

### DIFF
--- a/pootle/apps/import_export/templates/browser/overview.html
+++ b/pootle/apps/import_export/templates/browser/overview.html
@@ -3,12 +3,12 @@
 
 {% block sidebar_content %}
 {% if display_download or upload_form %}
-<div id="import-export-sidebar">
+<div class="sidebar-group">
   {% if display_download %}
   <p class="sidebar-action">
     <a href="{% url 'pootle-export' %}?path={{ pootle_path }}"
-      title="{% trans 'Download translation files' %}">
-      <i class="icon-download"></i> <span>{% trans 'Download' %}</span>
+      title="{% trans 'Download translation files for offline translation' %}">
+      <i class="icon-download"></i> <span>{% trans 'Download for offline translation' %}</span>
     </a>
   </p>
   {% endif %}

--- a/pootle/apps/import_export/templates/browser/overview.html
+++ b/pootle/apps/import_export/templates/browser/overview.html
@@ -5,23 +5,34 @@
 {% if display_download or upload_form %}
 <div id="import-export-sidebar">
   {% if display_download %}
-  <a href="{% url 'pootle-export' %}?path={{ pootle_path }}"
-    title="{% trans 'Download translation files' %}">
-    <i class="icon-download"></i> <span>{% trans 'Download' %}</span>
-  </a>
+  <p class="sidebar-action">
+    <a href="{% url 'pootle-export' %}?path={{ pootle_path }}"
+      title="{% trans 'Download translation files' %}">
+      <i class="icon-download"></i> <span>{% trans 'Download' %}</span>
+    </a>
+  </p>
   {% endif %}
 
   {% if upload_form %}
-  <form action="" method="post" enctype="multipart/form-data" id="upload-form">
+  <p class="sidebar-action">
+    <a href="" id="js-open-upload-dialog"
+      title="{% trans 'Upload translation files or archives in .zip format' %}">
+      <i class="icon-upload"></i> <span>{% trans 'Upload translations' %}</span>
+    </a>
+  </p>
+
+  <form action="" method="post" enctype="multipart/form-data"
+    id="js-upload-form" class="upload-form">
     {% csrf_token %}
-    <i class="icon-upload"></i>
     {% for field in upload_form %}
       {{ field }}
-      {{ field.errors }}
     {% endfor %}
-    <input type="text" id="js-fake-upload" value="{% trans 'Select' %}" />
-    <input type="submit" value="{% trans 'Upload' %}" />
+    <input type="submit" />
   </form>
+  {# Dirty hack: Upload form is hidden, so render errors out of it so they get displayed. #}
+  {% for field in upload_form %}
+    <div>{{ field.errors }}</div>
+  {% endfor %}
   {% endif %}
 </div>
 {% endif %}
@@ -36,18 +47,19 @@
 {% if upload_form %}
 <script type="text/javascript">
 $(function () {
-  document.getElementById("js-file-upload-input").onchange = function () {
-    var filename =  this.value.replace("C:\\fakepath\\", "");
-    document.getElementById("js-fake-upload").value = filename;
-  };
-
-  document.getElementById("js-fake-upload").onclick = function () {
+  document.getElementById("js-open-upload-dialog").onclick = function () {
+    // Open the file browser dialog to select a file to upload.
     document.getElementById("js-file-upload-input").click();
+    // Prevent visiting URL.
+    return false;
   };
 
-  document.getElementById("js-fake-upload").onchange = function () {
-    if (document.getElementById("js-fake-upload").value.length === 0) {
-      document.getElementById("js-file-upload-input").value = "";
+  document.getElementById("js-file-upload-input").onchange = function () {
+    var filename = this.value.replace("C:\\fakepath\\", "");
+
+    // Submit form only if there is some actual value on the file input.
+    if (filename.length !== 0) {
+      document.getElementById("js-upload-form").submit();
     }
   };
 });

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -433,6 +433,13 @@ td.stats-name a:hover > i + span,
     transition: all 0.3s ease 0s;
 }
 
+#sidebar-content
+{
+    margin: 2em auto;
+    padding: 0 2em;
+    max-width: 960px;
+}
+
 #sidebar.sidebar-open
 {
     width: 30%;
@@ -446,12 +453,12 @@ html[dir="rtl"] #sidebar
     box-shadow: 1px 0px 2px rgba(0, 0, 0, 0.2);
 }
 
-#sidebar #staticpage
+#sidebar #sidebar-content
 {
     display: none;
 }
 
-#sidebar.sidebar-open #staticpage
+#sidebar.sidebar-open #sidebar-content
 {
     display: block;
 }
@@ -492,6 +499,12 @@ html[dir="rtl"] #sidebar-toggle
 
     box-shadow: 2px 0px 2px rgba(0, 0, 0, 0.2);
     border-radius: 0 2px 2px 0;
+}
+
+div.sidebar-group
+{
+    margin: 0;
+    padding: 0;
 }
 
 
@@ -940,6 +953,12 @@ ul.errorlist
     padding: 0 2em;
     font-size: 120%;
     max-width: 960px;
+}
+
+div.sidebar-group #staticpage
+{
+    margin: 0;
+    padding: 0;
 }
 
 #staticpage h1
@@ -2122,11 +2141,6 @@ span.email .i
 /*
  * Import-export styling
  */
-
-#import-export-sidebar {
-    background-color: #e5e5e5;
-    padding: 2em 1em;
-}
 
 .upload-form
 {

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -337,12 +337,14 @@ html[dir="rtl"] ul.icons
 /* Hack to avoid ugly underlines in the space between icons and text */
 
 td.stats-name a:hover,
+.sidebar-action a:hover,
 .last-action > a:hover
 {
     text-decoration: none;
 }
 
 td.stats-name a:hover > i + span,
+.sidebar-action a:hover > i + span,
 .last-action > a:hover > img + span
 {
     text-decoration: underline;
@@ -2126,10 +2128,7 @@ span.email .i
     padding: 2em 1em;
 }
 
-#upload-form {
-    margin-top: .5em;
-}
-
-#upload-form input[type="file"] {
+.upload-form
+{
     display: none;
 }

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -505,6 +505,14 @@ div.sidebar-group
 {
     margin: 0;
     padding: 0;
+    padding-bottom: 2em;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+div.sidebar-group:last-child
+{
+    padding: 0;
+    border-bottom: none;
 }
 
 

--- a/pootle/templates/browser/overview.html
+++ b/pootle/templates/browser/overview.html
@@ -78,13 +78,17 @@
 {% if has_sidebar %}
 <div id="sidebar"
   class="js-sidebar{% if is_sidebar_open %} sidebar-open{% endif %}">
-  {% block sidebar_content %}
+  <div id="sidebar-content">
+    {% block sidebar_content %}
 
-  {% if announcement %}
-  {% include "staticpages/_body.html" with page=announcement %}
-  {% endif %}
+    {% if announcement %}
+    <div class="sidebar-group">
+      {% include "staticpages/_body.html" with page=announcement %}
+    </div>
+    {% endif %}
 
-  {% endblock %}
+    {% endblock %}
+  </div>
   <a id="sidebar-toggle" class="js-sidebar-toggle"></a>
 </div>
 {% endif %}


### PR DESCRIPTION
This fixes issue #3640

- Added a new #sidebar-content div to enclose sidebar content in order
  to correctly hide the whole sidebar except the toggle handle
- Moved padding and margin from specific content divs (#staticpage and
  #import-export-sidebar) to that new div
- Changed some texts to provide more useful hints to the users
- Use placeholder instead of input value
- Removed grey background for import-export
- Added some JavaScript to avoid user typing on the fake upload input