### PR TITLE
Unrelated vfolders changes

### DIFF
--- a/docs/features/virtual_folders.json
+++ b/docs/features/virtual_folders.json
@@ -35,6 +35,27 @@
         }
     },
     {
+        "name": "directories-for-lang",
+        "location": "/{LANG}/",
+        "filters": {
+            "files": [
+                "firefox/browser/profile/",
+                "firefox/browser/chrome/browser/"
+            ]
+        }
+    },
+    {
+        "name": "directories-and-files-for-tp",
+        "location": "/{LANG}/firefox/",
+        "filters": {
+            "files": [
+                "browser/updater/",
+                "browser/chrome/browser/devtools/appcacheutils.properties.po",
+                "browser/chrome/browser/migration/"
+            ]
+        }
+    },
+    {
         "name": "default",
         "location": "/"
     },

--- a/docs/features/virtual_folders.rst
+++ b/docs/features/virtual_folders.rst
@@ -45,8 +45,8 @@ might be handy when using the virtual folders as goals.
 
 The filtering rules specify which translation units are included within a
 virtual folder. Currently the only supported filtering rule consists of a list
-of file paths relative to the virtual folder location. It is possible to not
-specify any filtering rule.
+of file or directory paths relative to the virtual folder location. It is
+possible to not specify any filtering rule.
 
 
 .. _virtual_folders#apply:

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -727,10 +727,14 @@ def get_edit_unit(request, unit):
     alt_src_langs = get_alt_src_langs(request, user, translation_project)
     project = translation_project.project
 
+    # Retrieve the unit top priority, if any.
+    priority = unit.vfolders.aggregate(priority=Max('priority'))['priority']
+
     template_vars = {
         'unit': unit,
         'form': form,
         'comment_form': comment_form,
+        'priority': priority,
         'store': store,
         'directory': directory,
         'profile': user,

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -12,6 +12,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.markup import get_markup_filter_name, MarkupField
+from pootle_app.models import Directory
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_store.models import Store, Unit
@@ -95,6 +96,15 @@ class VirtualFolder(models.Model):
 
                 if qs.exists():
                     self.units.add(*qs[0].units.all())
+                else:
+                    if not vf_file.endswith("/"):
+                        vf_file += "/"
+
+                    if Directory.objects.filter(pootle_path=vf_file).exists():
+                        qs = Unit.objects.filter(
+                            store__pootle_path__startswith=vf_file
+                        )
+                        self.units.add(*qs)
 
     def clean_fields(self):
         """Validate virtual folder fields."""

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -9,6 +9,8 @@
 
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.markup import get_markup_filter_name, MarkupField
@@ -156,3 +158,28 @@ class VirtualFolder(models.Model):
                     for proj in projects]
 
         return [self.location]
+
+
+@receiver(post_save, sender=Unit)
+def relate_unit(sender, instance, created=False, **kwargs):
+    """Add newly created units to the virtual folders they belong, if any.
+
+    When a new store or translation project, or even a full project is added,
+    some of their units might be matched by the filters of any of the
+    previously existing virtual folders, so this signal handler relates those
+    new units to the virtual folders they belong to, if any.
+    """
+    if not created:
+        return
+
+    pootle_path = instance.store.pootle_path
+
+    for vf in VirtualFolder.objects.iterator():
+        for location in vf.get_all_pootle_paths():
+            if not pootle_path.startswith(location):
+                continue
+
+            for filename in vf.filter_rules.split(","):
+                if pootle_path == "".join([location, filename]):
+                    vf.units.add(instance)
+                    break

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -568,6 +568,7 @@ table td.translate-translation
     box-shadow: 0 0 10px rgba(0, 0, 0, 1);
 }
 
+.translate-priority,
 .translate-locations,
 .translate-context-value
 {

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -13,6 +13,13 @@
       </ul>
     </div>
     <div class="translate-{% locale_align %}">
+      <!-- Priority -->
+      {% if priority %}
+      <div class="sidebar" dir="{% locale_dir %}">
+        <span class="sidetitle" lang="{{ LANGUAGE_CODE }}">{% trans "Priority:" %}</span>
+        <div class="translate-priority">{{ priority }}</div>
+      </div>
+      {% endif %}
       {% if unit.getcontext and unit.locations != unit.context %}
       <!-- Context information and comments -->
       <div class="translate-context sidebar">


### PR DESCRIPTION
This is a set of vfolders implementation changes (and new features) that can be landed independently of  PR #3642

Setup instructions:

- Get https://drive.google.com/file/d/0B-8KVyCPnkZRS0JSWE9HN08zaU0/view?usp=sharing and uncompress it on your `PODIRECTORY`
- Add a new `test_vfolders` project.
- Run `./manage.py update_stores --project=test_vfolders`
- Get http://dpaste.com/0NHWD4W and save it as `vfolders_test_directory.json`
- Run `./manage.py add_vfolders vfolders_test_directory.json`

Instructions to test accept filter by path on JSON:

- Run `./manage.py shell_plus`
- Ensure the number returned by `VirtualFolder.objects.get(name="test-directory").units.count()` and `Unit.objects.filter(store__pootle_path__startswith="/af/test_vfolders/browser/chrome/overrides/").count()` is the same (should be 89)

Instructions to test relate newly added units:

- Go to `PODIRECTORY/test_vfolders/af/`
- Add there a new `newfile.po`. It can be any PO file.
- Run `./manage.py update_stores --project=test_vfolders`
- Run `./manage.py shell_plus`
- Ensure that `set([u.store.pootle_path for u in VirtualFolder.objects.get(name='test-newfile').units.all()])` returns `{u'/af/test_vfolders/newfile.po'}`

Instructions to test display priority for current unit:

- Run `./manage.py runserver`
- Open your browser and go to `http://127.0.0.1:8000/af/test_vfolders/translate/chat/accounts.properties.po`
- Ensure that no priority is displayed in current unit above Locations.
- Now go to `http://127.0.0.1:8000/af/test_vfolders/translate/browser/chrome/overrides/`
- Ensure priority 7.0 is being displayed for the current unit above the Locations.