### PR TITLE
Fix wrong permission name

### DIFF
--- a/pootle/core/initdb.py
+++ b/pootle/core/initdb.py
@@ -124,7 +124,7 @@ def create_pootle_permissions():
             'codename': "translate",
         },
         {
-            'name': _("Can review translations"),
+            'name': _("Can review suggestions"),
             'codename': "review",
         },
         {


### PR DESCRIPTION
Fixes #3670.

Users using master will have to run the following SQL query to rename the permission:

```sql
UPDATE `auth_permission`
SET `name` = 'Can review suggestions'
WHERE `codename` = 'review' AND `name` = 'Can review translations';
```