### PR TITLE
Use live() to retrieve non-obsolete Store and Directory objects

### DIFF
--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -70,23 +70,23 @@ class Command(PootleCommand):
                 self.do_translation_project(tp, self.path, **options)
 
     def handle_translation_project(self, translation_project, **options):
-        stores = translation_project.stores.all()
+        stores = translation_project.stores.live()
         prefix = "%s-%s" % (translation_project.project.code,
                             translation_project.language.code)
         self._create_zip(stores, prefix)
 
     def handle_project(self, project, **options):
-        stores = Store.objects.filter(translation_project__project=project)
+        stores = Store.objects.live().filter(translation_project__project=project)
         if not stores:
             raise CommandError("No matches for project %r" % (project))
         self._create_zip(stores, prefix=project.code)
 
     def handle_language(self, language, **options):
-        stores = Store.objects.filter(translation_project__language=language)
+        stores = Store.objects.live().filter(translation_project__language=language)
         self._create_zip(stores, prefix=language.code)
 
     def handle_path(self, path, **options):
-        stores = Store.objects.filter(pootle_path__startswith=path)
+        stores = Store.objects.live().filter(pootle_path__startswith=path)
         if not stores:
             raise CommandError("Could not find store matching %r" % (path))
 

--- a/pootle/apps/import_export/views.py
+++ b/pootle/apps/import_export/views.py
@@ -30,7 +30,7 @@ def export(request):
     if not path:
         raise Http404
 
-    stores = Store.objects.filter(pootle_path__startswith=path)
+    stores = Store.objects.live().filter(pootle_path__startswith=path)
     num_items = stores.count()
 
     if not num_items:

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -57,7 +57,7 @@ class PootleCommand(NoArgsCommand):
                                   self.name, tp)
                 return
         elif hasattr(self, "handle_store"):
-            store_query = tp.stores.all()
+            store_query = tp.stores.live()
             for store in store_query.iterator():
                 logging.info(u"Running %s over %s",
                              self.name, store.pootle_path)

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -56,7 +56,7 @@ class Command(RefreshStatsCommand):
 
         logger.info('Initializing stores...')
 
-        stores = Store.objects.all()
+        stores = Store.objects.live()
         if store_filter:
             stores = stores.filter(**store_filter)
 

--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -172,7 +172,7 @@ class Command(PootleCommand):
 
         logger.info('Initializing stores...')
 
-        stores = Store.objects.all()
+        stores = Store.objects.live()
         if store_filter:
             stores = stores.filter(**store_filter)
 
@@ -240,7 +240,8 @@ class Command(PootleCommand):
         for item in queryset.iterator():
             if item['unit__store'] != saved_store:
                 try:
-                    key = Store.objects.get(id=item['unit__store']).get_cachekey()
+                    key = Store.objects.live().get(id=item['unit__store']) \
+                                              .get_cachekey()
                 except Store.DoesNotExist:
                     continue
                 saved_store = item['unit__store']
@@ -291,7 +292,8 @@ class Command(PootleCommand):
         for item in res.iterator():
             if saved_id != item['store']:
                 try:
-                    key = Store.objects.get(id=item['store']).get_cachekey()
+                    key = Store.objects.live().get(id=item['store']) \
+                                              .get_cachekey()
                 except Store.DoesNotExist:
                     continue
 
@@ -384,7 +386,8 @@ class Command(PootleCommand):
 
         for item in queryset.iterator():
             try:
-                key = Store.objects.get(id=item['unit__store']).get_cachekey()
+                key = Store.objects.live().get(id=item['unit__store']) \
+                                          .get_cachekey()
             except Store.DoesNotExist:
                 continue
             logger.info('Set suggestion count for %s' % key)
@@ -403,7 +406,7 @@ class Command(PootleCommand):
 
         for item in queryset.iterator():
             try:
-                key = Store.objects.get(id=item['store']).get_cachekey()
+                key = Store.objects.live().get(id=item['store']).get_cachekey()
             except Store.DoesNotExist:
                 continue
             logger.info('Set mtime for %s' % key)
@@ -424,7 +427,7 @@ class Command(PootleCommand):
             max_time = item['max_creation_time']
             if max_time:
                 try:
-                    store = Store.objects.get(id=item['store'])
+                    store = Store.objects.live().get(id=item['store'])
                 except Store.DoesNotExist:
                     continue
                 unit = store.unit_set.filter(creation_time=max_time)[0]

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1309,19 +1309,14 @@ class StoreManager(models.Manager):
     def get_queryset(self):
         """Mimics `select_related(depth=1)` behavior. Pending review."""
         return super(StoreManager, self).get_queryset() \
-                                        .filter(obsolete=False) \
                                         .select_related(
                                             'parent',
                                             'translation_project',
                                         )
 
-    def with_obsolete(self):
-        """Mimics `select_related(depth=1)` behavior. Pending review."""
-        return super(StoreManager, self).get_queryset() \
-                                        .select_related(
-                                            'parent',
-                                            'translation_project',
-                                        )
+    def live(self):
+        """Filters non-obsolete stores."""
+        return self.filter(obsolete=False)
 
 
 class Store(models.Model, CachedTreeItem, base.TranslationStore):

--- a/pootle/apps/pootle_terminology/views.py
+++ b/pootle/apps/pootle_terminology/views.py
@@ -51,7 +51,7 @@ def create_termunit(term, unit, targets, locations, sourcenotes, transnotes,
 def get_terminology_filename(translation_project):
     try:
         # See if a terminology store already exists
-        return translation_project.stores.filter(
+        return translation_project.stores.live().filter(
             name__startswith='pootle-terminology.',
         ).values_list('name', flat=True)[0]
     except IndexError:
@@ -84,7 +84,7 @@ def extract(request, translation_project):
             sourcelanguage=str(translation_project.project.source_language.code)
         )
 
-        for store in translation_project.stores.iterator():
+        for store in translation_project.stores.live().iterator():
             if store.is_terminology:
                 continue
             extractor.processunits(store.units, store.pootle_path)
@@ -108,7 +108,8 @@ def extract(request, translation_project):
 
         # Calculate maximum terms
         source_words = sum(store._get_total_wordcount()
-                           for store in translation_project.stores.iterator())
+                           for store in translation_project.stores.live()
+                                                                  .iterator())
         maxunits = int(source_words * 0.02)
         maxunits = min(max(settings.MIN_AUTOTERMS, maxunits),
                        settings.MAX_AUTOTERMS)
@@ -161,7 +162,7 @@ def manage(request, translation_project):
 
     if translation_project.project.is_terminology:
         # Which file should we edit?
-        stores = list(Store.objects.filter(
+        stores = list(Store.objects.live().filter(
             translation_project=translation_project,
         ))
         if len(stores) == 1:

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -284,13 +284,13 @@ class TranslationProject(models.Model, CachedTreeItem):
 
     def update(self, overwrite=True):
         """Update all stores to reflect state on disk"""
-        stores = self.stores.exclude(file='').filter(state__gte=PARSED)
+        stores = self.stores.live().exclude(file='').filter(state__gte=PARSED)
         for store in stores.iterator():
             store.update(overwrite=overwrite)
 
     def sync(self, conservative=True, skip_missing=False, only_newer=True):
         """Sync unsaved work on all stores to disk"""
-        stores = self.stores.exclude(file='').filter(state__gte=PARSED)
+        stores = self.stores.live().exclude(file='').filter(state__gte=PARSED)
         for store in stores.iterator():
             store.sync(update_structure=not conservative,
                        conservative=conservative,
@@ -298,7 +298,7 @@ class TranslationProject(models.Model, CachedTreeItem):
 
     def require_units(self):
         """Makes sure all stores are parsed"""
-        for store in self.stores.filter(state__lt=PARSED).iterator():
+        for store in self.stores.live().filter(state__lt=PARSED).iterator():
             try:
                 store.require_units()
             except IntegrityError:
@@ -390,11 +390,11 @@ class TranslationProject(models.Model, CachedTreeItem):
                 termproject = TranslationProject.objects \
                         .get_terminology_project(self.language_id)
                 mtime = termproject.get_cached(CachedMethods.MTIME)
-                terminology_stores = termproject.stores.all()
+                terminology_stores = termproject.stores.live()
             except TranslationProject.DoesNotExist:
                 pass
 
-            local_terminology = self.stores.filter(
+            local_terminology = self.stores.live().filter(
                     name__startswith='pootle-terminology')
             for store in local_terminology.iterator():
                 if mtime is None:

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -94,7 +94,7 @@ class VirtualFolder(models.Model):
             for filename in self.filter_rules.split(","):
                 vf_file = "".join([location, filename])
 
-                qs = Store.objects.filter(pootle_path=vf_file)
+                qs = Store.objects.live().filter(pootle_path=vf_file)
 
                 if qs.exists():
                     self.units.add(*qs[0].units.all())

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -170,9 +170,9 @@ def get_children(directory):
     in the templates.
     """
     directories = [make_directory_item(child_dir)
-                   for child_dir in directory.child_dirs.iterator()]
+                   for child_dir in directory.child_dirs.live().iterator()]
 
     stores = [make_store_item(child_store)
-              for child_store in directory.child_stores.iterator()]
+              for child_store in directory.child_stores.live().iterator()]
 
     return directories + stores

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -132,7 +132,7 @@ def set_resource(request, path_obj, dir_path, filename):
         resource_path = resource_path + filename
 
         try:
-            store = Store.objects.select_related(
+            store = Store.objects.live().select_related(
                 'translation_project',
                 'parent',
             ).get(pootle_path=pootle_path)
@@ -143,7 +143,7 @@ def set_resource(request, path_obj, dir_path, filename):
     if directory is None and not is_404:
         if dir_path:
             try:
-                directory = Directory.objects.get(pootle_path=pootle_path)
+                directory = Directory.objects.live().get(pootle_path=pootle_path)
             except Directory.DoesNotExist:
                 is_404 = True
         else:
@@ -206,14 +206,14 @@ def set_project_resource(request, path_obj, dir_path, filename):
         pootle_path = pootle_path + filename
         resource_path = resource_path + filename
 
-        resources = Store.objects.extra(
+        resources = Store.objects.live().extra(
             where=[
                 'pootle_store_store.pootle_path LIKE %s',
                 'pootle_store_store.pootle_path ' + sql_not_regex + ' %s',
             ], params=[query_pootle_path, disabled_tps_regex]
         ).select_related('translation_project__language')
     else:
-        resources = Directory.objects.extra(
+        resources = Directory.objects.live().extra(
             where=[
                 'pootle_app_directory.pootle_path LIKE %s',
                 'pootle_app_directory.pootle_path ' + sql_not_regex + ' %s',

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -36,7 +36,7 @@ def test_delete_mark_obsolete(af_tutorial_subdir_po):
     tp.scan_files()
 
     # Now files that ceased to exist should be marked as obsolete
-    updated_store = Store.objects.with_obsolete().get(pootle_path=pootle_path)
+    updated_store = Store.objects.get(pootle_path=pootle_path)
     assert updated_store.obsolete
 
     # The units they contained are obsolete too


### PR DESCRIPTION
Default managers for Store and Directory objects retrieve all objects (including obsoletes).
Fix #3675

@julen, @jleclanche, @dwaynebailey , @unho please check if I have added `live()` where necessary. 