### PR TITLE
Bring quality checks documentation within Pootle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 # /pootle/settings/
 /pootle/settings/*-local.conf
 
+# TTK checks descriptions template
+/pootle/templates/help/_ttk_quality_checks.html
+
 # Possible customizations
 /pootle/templates/custom
 /pootle/static/*/custom

--- a/docs/developers/releasing.rst
+++ b/docs/developers/releasing.rst
@@ -139,6 +139,18 @@ that needs fixing.
     $ git grep 2013  # Should pick up anything that should be examined
 
 
+Update checks descriptions
+--------------------------
+
+The quality checks descriptions are kept as a static HTML page that has to be
+regenerated in order to ensure the descriptions match the currently available
+quality checks.
+
+.. code-block:: bash
+
+    $ pootle regenerate_checks_descriptions
+
+
 Update translations
 -------------------
 

--- a/docs/releases/2.7.0.rst
+++ b/docs/releases/2.7.0.rst
@@ -211,6 +211,8 @@ Command changes
   commands.
 - Added command and store action logging.
 - Added ``test_checks`` management command.
+- Added ``regenerate_checks_descriptions`` command to recreate the checks
+  descriptions.
 - Removed ``--directory`` and ``--path-prefix`` parameters from management
   commands. ``--project`` and ``--language`` should be used instead to
   reduce the scope of commands.

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -345,6 +345,19 @@ By default, :ref:`commands#test_checks` tests all existing checks. When
 against.
 
 
+.. _commands#regenerate-checks-descriptions:
+
+regenerate_checks_descriptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7
+
+This command regenerates the static page holding the quality checks
+descriptions. If new checks are added, or existing checks are updated or
+removed it is advisable to run this command in order to keep the descriptions
+updated.
+
+
 .. _commands#translation-memory:
 
 Translation Memory

--- a/docs/server/upgrading.rst
+++ b/docs/server/upgrading.rst
@@ -144,6 +144,20 @@ To perform the upgrade follow the next steps:
     (env)$ pootle setup
 
 
+* If you are upgrading from Pootle 2.7.0 or later you also have to regenerate
+  the quality checks descriptions.
+
+  .. code-block:: bash
+
+    (env)$ pootle regenerate_checks_descriptions
+
+
+  .. note::
+
+    It is necessary to install the ``docutils`` package to be able to run this
+    command.
+
+
 * Reapply your custom changes to Pootle code, templates or styling. Check about
   the :doc:`customization of style sheets and templates
   </developers/customization>` to move your customizations to the right

--- a/pootle/apps/pootle_app/management/commands/regenerate_checks_descriptions.py
+++ b/pootle/apps/pootle_app/management/commands/regenerate_checks_descriptions.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import codecs
+import os
+
+from translate.filters.checks import TeeChecker
+
+# This must be run before importing Django.
+os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
+
+from django.conf import settings
+from django.core.management.base import CommandError, NoArgsCommand
+
+from pootle_misc.checks import check_names, excluded_filters
+
+
+class Command(NoArgsCommand):
+    help = 'Regenerate the Translate Toolkit quality checks descriptions.'
+
+    def handle_noargs(self, **options):
+        """Regenerate all the Translate Toolkit quality checks descriptions.
+
+        The resulting HTML is save on the 'checks/_ttk_descriptions.html'
+        template so it can be rendered when Pootle displays the quality checks
+        descriptions page.
+        """
+        try:
+            from docutils.core import publish_parts
+        except ImportError:
+            raise CommandError("Please install missing 'docutils' dependency.")
+
+        def get_check_description(name, filterfunc):
+            """Get a HTML snippet for a specific quality check description.
+
+            The quality check description is extracted from the check function
+            docstring (which uses reStructuredText) and rendered using docutils
+            to get the HTML snippet.
+            """
+            # Provide a header with an anchor to refer to.
+            description = ('\n<h3 id="%s">%s</h3>\n\n' %
+                           (name, unicode(check_names[name])))
+
+            # Clean the leading whitespace on each docstring line so it gets
+            # properly rendered.
+            docstring = '\n'.join([line.strip()
+                                   for line in filterfunc.__doc__.split('\n')])
+
+            # Render the reStructuredText in the docstring into HTML.
+            description += publish_parts(docstring, writer_name='html')['body']
+            return description
+
+        self.stdout.write('Regenerating Translate Toolkit quality checks '
+                          'descriptions.')
+
+        # Get a checker with the Translate Toolkit checks. Note that filters
+        # that are not used in Pootle are excluded.
+        filterdict = TeeChecker().getfilters(excludefilters=excluded_filters)
+
+        filterdocs = [get_check_description(name, filterfunc)
+                      for (name, filterfunc) in filterdict.iteritems()]
+
+        filterdocs.sort()
+
+        body = u'\n'.join(filterdocs)
+
+        # Output the quality checks descriptions to the HTML file.
+        filename = os.path.join(settings.WORKING_DIR,
+                                'templates/help/_ttk_quality_checks.html')
+
+        with codecs.open(filename, 'w', 'utf-8') as f:
+            f.write(body)
+
+        self.stdout.write('Done.')

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -169,8 +169,7 @@ class Submission(models.Model):
                 unit.update({
                     'check_name': check_name,
                     'check_display_name': check_names[check_name],
-                    'checks_url': reverse('pootle-staticpages-display',
-                                          args=['help/quality-checks']),
+                    'checks_url': reverse('pootle-checks-descriptions'),
                 })
                 source.update({
                     'check_name': '<a href="%(checks_url)s#%(check_name)s">'

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -604,8 +604,7 @@ def timeline(request, unit):
                 entry.update({
                     'check_name': check_name,
                     'check_display_name': check_names[check_name],
-                    'checks_url': reverse('pootle-staticpages-display',
-                                          args=['help/quality-checks']),
+                    'checks_url': reverse('pootle-checks-descriptions'),
                     'action': {
                                 SubmissionTypes.MUTE_CHECK: 'Muted',
                                 SubmissionTypes.UNMUTE_CHECK: 'Unmuted'

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -996,6 +996,24 @@ div.sidebar-group #staticpage
 
 
 /*
+ * CHECKS DESCRIPTIONS
+ */
+
+#staticpage.checks-descriptions code,
+#staticpage.checks-descriptions tt
+{
+    color: red;
+}
+
+#staticpage.checks-descriptions h3:target
+{
+    background-color: #ff9;
+    outline: 5px solid #ff9;
+    color: #880;
+}
+
+
+/*
  * SETTINGS PAGE
  */
 

--- a/pootle/templates/editor/units/xhr_checks.html
+++ b/pootle/templates/editor/units/xhr_checks.html
@@ -4,7 +4,7 @@
 <ul class="checks">
   {% for check in unit.get_qualitychecks.iterator %}
   <li class="check{% if check.false_positive %} false-positive{% endif %}">
-    <a href="{% staticpage_url 'help/quality-checks' %}#{{ check.name }}" target="_blank">{{ check.display_name }}</a>
+    <a href="{% url 'pootle-checks-descriptions' %}#{{ check.name }}" target="_blank">{{ check.display_name }}</a>
     {% if canreview %}
     <a class="js-toggle-check toggle-check" data-check-id="{{ check.id }}">
       <i title="{% trans 'Mute quality check' %}" class="mute-check icon-block"></i>

--- a/pootle/templates/help/_pootle_quality_checks.html
+++ b/pootle/templates/help/_pootle_quality_checks.html
@@ -1,0 +1,371 @@
+<h3 id="broken_entities">Broken HTML Entities</h3>
+
+<p>The HTML entities must be written as <code>&amp;name;</code>, <code>&amp;#DDDD;</code> or <code>&amp;#xHHHH;</code> (where 'name' is a valid entity name, and 'DDDD' and 'HHHH' are the Unicode symbol numbers in decimal or hexadecimal formats respectively).</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>&amp;nbsp</code> &mdash; this one is missing the trailing semicolon. The correct one will be <code>&amp;nbsp<strong>;</strong></code>.
+  </li>
+  <li>
+    <code>&amp;gt ;</code> &mdash; this one has an extra space between the name and the semicolon. The correct one will be <code>&amp;gt;</code>.
+  </li>
+</ul>
+
+
+<h3 id="java_format">Java format</h3>
+
+<p>Java format placeholder strings usually look like: <code>{0}</code>, <code>{1,number}</code>, <code>{2,number,#.##}</code>. When you see such placeholders in source strings, please make sure to keep them unmodified in he target ones. You are allowed to change the ordering of multiple placeholders to better suit your translation. For the curious, please see the detailed documentation on <a href="http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html">Java MessageFormat syntax</a>.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>{0 number}</code> &mdash; this one is missing the comma. The correct one will be <code>{0,number}</code>.
+  </li>
+  <li>
+    <code>{0,numero}</code> &mdash; here the special word <em>number</em> is translated though it shouldn't be. The correct one is <code>{0,number}</code>.
+  </li>
+</ul>
+
+
+<h3 id="template_format">Template format</h3>
+
+<p>These are placeholders of the following format: <code>${fullName}</code>, <code>${pendingUserEmail}</code>, <code>${if:accountManagerExists}</code>. When you see such placeholders in source strings, please make sure to keep them unmodified in he target ones. You are allowed to change the ordering of multiple placeholders to better suit your translation.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>${Nombre completo}</code> &mdash; the text inside the braces is translated, you must leave the original one (<code>${fullName}</code>).
+  </li>
+  <li>
+    <code>${BUSINESSNAME}</code> &mdash; here the case was changed from the original (<code>${businessName}</code>), though it shouldn't. The easiest way is just to copy the English text to the target string.
+  </li>
+</ul>
+
+
+<h3 id="mustache_placeholders">Mustache placeholders</h3>
+
+<p>These are the tags with curly braces like: <code>{% verbatim %}{{{pointsUrl}}}{% endverbatim %}</code>, <code>{% verbatim %}{{originalRecipients}}{% endverbatim %}</code>. Please do not modify the text inside such braces and make sure the number of braces in the target string matches the original one.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>{% verbatim %}{{/supportLink}{% endverbatim %}</code> &mdash; this tag is missing the trailing brace. Here is the correct one: <code>{% verbatim %}{{/supportLink}}{% endverbatim %}</code>. You can simply copy these tags to your translation.
+  </li>
+  <li>
+    <code>{% verbatim %}{{# getDarkerFontTag}}{{originalRecipients}}{{/ getDarkerFontTag}}{% endverbatim %}</code> &mdash; here the spaces inside both opening and closing tags are unwanted. The correct string should look like this: <code>{% verbatim %}{{#getDarkerFontTag}}{{originalRecipients}}{{/getDarkerFontTag}}{% endverbatim %}</code>.
+  </li>
+</ul>
+
+
+<h3 id="mustache_placeholder_pairs">Mustache placeholder pairs</h3>
+
+<p>These are the tags with curly braces like: <code>{% verbatim %}{{#getStrongTag}}{{{appName}}}{{/getStrongTag}}{% endverbatim %}</code>. Please do not modify the text inside such braces, make sure the number of braces in the target string matches the original one and keep in mind that opening tags like <code>{% verbatim %}{{#tagname}}{% endverbatim %}</code> must precede their closing counterparts, <code>{% verbatim %}{{/tagname}}{% endverbatim %}</code>.</p>
+
+<p>The easiest way to avoid mistakes is to copy the English text to the target string.</p>
+
+
+<h3 id="mustache_like_placeholder_pairs">Mustache like placeholder pairs</h3>
+
+<p>These are the tags with curly braces like: <code>{% verbatim %}{{getStrongTag}}{{{appName}}}{{/getStrongTag}}{% endverbatim %}</code>. Please do not modify the text inside such braces, make sure the number of braces in the target string matches the original one and keep in mind that opening tags like <code>{% verbatim %}{{tagname}}{% endverbatim %}</code> must precede their closing counterparts, <code>{% verbatim %}{{/tagname}}{% endverbatim %}</code>.</p>
+
+<p>The easiest way to avoid mistakes is to copy the English text to the target string.</p>
+
+
+<h3 id="c_format">C format placeholders</h3>
+
+<p>These are placeholders like <code>%s</code>, <code>%d</code>, <code>%.2f</code>, <code>%x</code>.</p>
+
+<p>Such placeholders must not be modified and must be present in translation.</p>
+
+
+<h3 id="non_printable">Non printable</h3>
+
+<p>This check serves to detect internal symbols in the translations. Please make sure you didn't copy anything from the application that can generate the code with such symbols.</p>
+
+
+<h3 id="unbalanced_tag_braces">Unbalanced tag braces</h3>
+
+<p>Please keep in mind that the number of opening and closing braces in source and target strings should always match. Here are a few common tags: <code>&lt;strong&gt;(&lt;/strong&gt;)</code>, <code>&lt;em&gt;(&lt;/em&gt;)</code>, <code>&lt;span&gt;(&lt;/span&gt;)</code>, etc.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>&lt;strong</code> &mdash; this tag is missing the trailing brace. Here is the correct one: <code>&lt;/strong&gt;</code>. You can simply copy these tags to your translation.
+  </li>
+  <li>
+    <code>&lt;/strong&gt;&lt;/strong&gt;</code> &mdash; an extra tag is added to the target string.
+  </li>
+</ul>
+
+
+<h3 id="changed_attributes">Changed attributes</h3>
+
+<p>Please keep in mind that the attributes of the following tags in source and target strings should always match: <code>&lt;span&gt;</code>, <code>&lt;a href&gt;</code>.</p>
+
+
+<h3 id="unescaped_ampersands">Unescaped ampersands</h3>
+
+<p>All standalone &amp; symbols need to be escaped as <code>&amp;amp;</code> Here are examples of valid use of ampersands in named HTML entities: <code>&amp;quot;</code>, <code>&amp;gt;</code>, <code>&amp;mdash;</code>, etc.</p>
+
+<p>Please avoid either replacing the code that stands for quotation marks (<code>&amp;quot;</code>) or dashes (<code>&amp;mdash;</code>) with the marks themselves (&quot;, &mdash;) or omitting them in your translation.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>&</code> &mdash; should be <code>&amp;amp;</code>.
+  </li>
+  <li>
+    <code>Edit &gt; Find &gt; Save Search</code> &mdash; should be <code>Edit &amp;gt; Find &amp;gt; Save Search</code>.
+  </li>
+</ul>
+
+
+<h3 id="whitespace">Whitespaces</h3>
+
+<p>This check compares the number of leading and trailing whitespaces and newlines in source and target strings. Make sure the translation has the same number of leading or trailing spaces and/or newlines as the original, otherwise this may result in rendering problems in the UI of our software clients.</p>
+
+
+<h3 id="date_format">Date format</h3>
+
+<p>Checks whether date formats are consistent between the two strings. Here are the examples: <code>MM/yyyy</code>, <code>hh:mm a</code>, <code>EEEE, MMMM d yyyy</code>, etc. Please see <a href="http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">SimpleFormat documentation</a> for more information.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>MM/aaaa</code> &mdash; the 'year' part is localized here though it should be left in English (<code>MM/yyyy</code>).
+  </li>
+  <li>
+    <code>h mm</code> &mdash; this string is missing the colon, the correct is <code>h:mm</code>.
+  </li>
+</ul>
+
+<p>You are allowed to change the ordering of multiple parameters to meet your region's standards (e.g. <code>EEEE, dd MMMM yyyy, hh:mm</code>, <code>dd MMMM yyyy, EEEE, hh:mm</code>, <code><code>yyyy MMMM dd, EEEE, hh:mm</code></code>).</p>
+
+
+<h3 id="uppercase_placeholders">Uppercase placeholders</h3>
+
+<p>Checks whether uppercase placeholders are consistent between the two strings. Examples: <code>SYMBOLS_NUMBER</code>, <code>HKEY_CURRENT_USER</code>.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>SIMBOLOS_NUMEROS</code> &mdash; the placeholder is translated though it shouldn't be. The correct one is <code>SYMBOLS_NUMBER</code>.
+  </li>
+  <li>
+    <code>symbols_number</code> &mdash; make sure to use upper case.
+  </li>
+</ul>
+
+
+<h3 id="percent_sign_placeholders">Percent sign placeholders</h3>
+
+<p>Example: <code>%some_text</code></p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>%какой-то_текст</code> &mdash; The placeholder is translated or modified though it shouldn't be.
+  </li>
+  <li>
+    <code>some_text%</code> &mdash; Percent sign is missing or added in the end.
+  </li>
+  <li>
+    <code>% some_text</code> &mdash; A space added between the percent sign and the placeholder.
+  </li>
+</ul>
+
+
+<h3 id="percent_sign_closure_placeholders">Percent sign closure placeholders</h3>
+
+<p>Here are some examples of such placeholders: <code>%%Edit%%</code>, <code>%%Notebook%%</code>, <code>%%Taglist%%</code>.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>%%Modificat%%</code> &mdash; the placeholder is translated though it shouldn't be. The correct one is <code>%%Edit%%</code>
+  </li>
+  <li>
+    <code>%%Edit</code> &mdash; this one is missing trailing percent signs. Here is the correct one: <code>%%Edit%%</code>
+  </li>
+</ul>
+
+<p>Also please make sure the number of percent signs in your translation matches the one in the source string.</p>
+
+
+<h3 id="dollar_sign_placeholders">$ placeholders</h3>
+
+<p>These are the placeholders like <code>$tag</code>, <code>$bar2</code>, <code>$3</code>.</p>
+
+<p>All of these must not be translated and must be present in translation.</p>
+
+
+<h3 id="dollar_sign_closure_placeholders">$ closure placeholders</h3>
+
+<p>Example: <code>$num$</code></p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>%num%</code> &mdash; Dollar sign is replaced with percent sign.
+  </li>
+  <li>
+    <code>$num; num$</code> &mdash; The opening or the closing percent sign is missing.
+  </li>
+  <li>
+    <code>$ num$</code> &mdash; A space added between the dollar sign and the placeholder.
+  </li>
+  <li>
+    <code>$some_other_text$</code> &mdash; The placeholder is modified.
+  </li>
+</ul>
+
+
+<h3 id="javaencoded_unicode">Java-encoded unicode</h3>
+
+<p>Here are a couple of examples: <code>\u2011</code>, <code>\u00AE</code>.</p>
+
+<p>Please make sure to keep such elements unmodified. The easiest way is to copy them from the source string.</p>
+
+
+<h3 id="objective_c_format">Objective-C format</h3>
+
+<p>These are variables of the following format: <code>%@</code>, <code>%1$@</code>, <code>'%1$i'</code>,<code>'%1$i'</code> etc.</p>
+
+<p>Please make sure not to modify such variables in your translations. They should be exactly the same as in the source. Do not replace any characters inside a variable, do not change the quotes format.</p>
+
+
+<h3 id="android_format">Android format</h3>
+
+<p>These are the placeholders like <code>%1$s</code>, <code>%2$ld</code>.</p>
+
+<p>Here all symbols after $ are special ones and must not be changed.</p>
+
+
+<h3 id="accelerators">Accelerators</h3>
+
+<p>These are words containing ampersands (<code>&amp;</code>) or underscores (<code>&#95;</code>). Ampersands and underscores stand before letter that are used as hot keys on your keyboard that you can press to quickly access a menu or function.</p>
+
+<p>Please do not omit them in your translation. Try to keep it similar to the English, look at the examples below:</p>
+
+<ul>
+  <li>
+    <code>Note H&istory</code> is <code>Stor&ico della Nota</code> in Italian.
+  </li>
+  <li>
+    <code>View _Tags</code> is <code>Ver E_tiquetas</code> in Portuguese.
+  </li>
+</ul>
+
+
+<h3 id="unbalanced_curly_braces">Curly braces</h3>
+
+<p>The number of opening and closing braces (<code>{</code> and <code>}</code>) must match.</p>
+
+
+<h3 id="double_quotes_in_tags">Double quotes in tags</h3>
+
+<p>This check counts the number of double quotation marks (") inside XML/HTML tags (<...>) in source and translated phrases. If the number doesn't match, you'll see the respective error. Check up for missing or unnecessary double quotation marks inside XML/HTML tags in the translated string.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    Missing double quote mark: <code>&lt;a href=http://evernote.com/contact/support/"&gt;</code> - there's a missing double quote mark before <b>http</b>.
+  </li>
+  <li>
+    Incorrect quote marks format: <code>&lt;a href="http://evernote.com/contact/support/»&gt;</code> - ending double quote mark is not in proper format.
+  </li>
+</ul>
+
+
+<h3 id="doublequoting">Doublequoting</h3>
+
+<p>This check compares total amount of double quote marks in the original and translated string. If the number of double quotation marks in source and translation is the same in any part of the string (not just in tags), you'll see the notification. This is a non-critical check.</p>
+
+
+<h3 id="potential_unwanted_placeholders">Potential unwanted placeholders</h3>
+
+<p>This error is displayed if the translated string contains more symbols &quot;@&quot;, &quot;_&quot;, &quot;$&quot;, or &quot;%&quot; than the source string.</p>
+
+<p>Example:</p>
+
+<ul>
+  <li>
+    Source text: <code>Quarterly Sales Meeting v5</code>
+  </li>
+  <li>
+    Translated text: <code>Réunion_rapports_trimestriels_ventes v5</code>
+  </li>
+</ul>
+
+
+<h3 id="percent_brace_placeholders">Percent brace placeholders</h3>
+
+<p>Example: <code>%{placeholder}</code></p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>%placeholder</code> &mdash; Braces are missing
+  </li>
+  <li>
+    <code>{placeholder}</code> &mdash; Percent sign is missing
+  </li>
+  <li>
+    <code>% {placeholder}</code> &mdash; Unnecessary space added between the percent sign and the brace
+  </li>
+  <li>
+    <code>%{плейсхолдер}</code> &mdash; Placeholder is translated
+  </li>
+</ul>
+
+
+<h3 id="tags_differ">Tags differ</h3>
+
+<p>This check compares number of tags in the source string and the translated string, plus the text contained in tags.</p>
+
+<p>Example: <code> &lt;font face=&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font&gt;</code>.</p>
+
+<p>Common mistakes:</p>
+
+<ul>
+  <li>
+    <code>Sponsored Group Service Signup</code> &mdash; Tags are missing
+  </li>
+  <li>
+    <code>&lt;font =&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font&gt;</code> &mdash;  Text inside tags is modified
+  </li>
+  <li>
+    <code>font face=&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font</code> &mdash; Angle brackets are missing
+  </li>
+</ul>
+
+<p>Generally, it's a good idea to copy the source string to translation field and translate it leaving tags not modified.</p>
+
+
+<h3 id="incorrectly_escaped_ampersands">Incorrectly escaped ampersands</h3>
+
+<p>You'll see this error if ampersand sign from the source string is replaced with corresponding HTML entity in the translation.</p>
+
+<p>Example: <code> Articles &amp; Guides</code></p>
+
+<p>Common mistake:</p>
+
+<ul>
+  <li>
+    <code>Articles &amp;amp; Guides</code> &mdash;  &amp; sign is replaced with &quot;&amp;amp;&quot; in the translated string.
+  </li>
+</ul>

--- a/pootle/templates/help/quality_checks.html
+++ b/pootle/templates/help/quality_checks.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+{% block title %}Quality Checks | {{ block.super }}{% endblock title %}
+
+{% block header_block %}{% endblock %}
+
+{% block content %}
+<div id="staticpage" class="checks-descriptions" dir="ltr">
+  <h1 class="title">Quality Checks</h1>
+
+  <p>Pootle has an ability to check for common translation mistakes. Once you submit a translation, it will compare its certain features with the original string and identify potential problems. Сhecks are displayed in the upper right corner, just above the submit button. Once there are checks in red, you will stay on the same unit, until you have each check resolved or muted. Note that you should only mute checks if you know what you're doing. Muted checks will be reviewed periodically by the managers.</p>
+
+  {% if settings.CAN_CONTACT %}
+  <p>If you are not sure what a particular error means and how to fix it properly, use <i>"Report a problem with this string"</i> link at the top of the unit. The managers will try to assist you as soon as possible.</p>
+  {% endif %}
+
+  <p>Below is the description of each quality check.</p>
+
+  {% include "help/_pootle_quality_checks.html" %}
+
+  {% include "help/_ttk_quality_checks.html" %}
+
+</div>
+{% endblock content %}

--- a/pootle/urls.py
+++ b/pootle/urls.py
@@ -9,6 +9,7 @@
 
 from django.conf import settings
 from django.conf.urls import include, patterns, url
+from django.views.generic import TemplateView
 
 
 urlpatterns = patterns('',
@@ -36,6 +37,9 @@ urlpatterns += patterns('',
 
     # Pootle URLs
     url(r'^pages/', include('staticpages.urls')),
+    url(r'^help/quality-checks/',
+        TemplateView.as_view(template_name="help/quality_checks.html"),
+        name='pootle-checks-descriptions'),
     url(r'', include('pootle_app.urls')),
     url(r'^projects/', include('pootle_project.urls')),
     url(r'', include('pootle_terminology.urls')),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,6 @@ pyDes
 rq>=0.5.0
 
 # Translate Toolkit
-translate-toolkit>=1.10.0
+#translate-toolkit>=1.10.0
 # If you want to use Translate Toolkit 'master'
-#-e git://github.com/translate/translate.git#egg=translate-toolkit
+-e git://github.com/translate/translate.git#egg=translate-toolkit


### PR DESCRIPTION
This staticpage also have to be created on the upgrade to 2.6. Working on that.

@translate/evernote @translate/house Please review.

Ideally Evernote checks would use the same approach it is used for TTK checks: retrieve description from each check docstring.

Also note that this doesn't handle the scenario where TTK is upgraded and new checks are added, or removed or changed.