### PR TITLE
Scorelog: add unique constraint on (submission, action_code)

### DIFF
--- a/pootle/apps/pootle_statistics/migrations/0002_auto_20150428_0601.py
+++ b/pootle/apps/pootle_statistics/migrations/0002_auto_20150428_0601.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_statistics', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='scorelog',
+            unique_together=set([('submission', 'action_code')]),
+        ),
+    ]

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -342,6 +342,9 @@ class ScoreLog(models.Model):
     action_code = models.IntegerField(null=False)
     submission = models.ForeignKey(Submission, null=False)
 
+    class Meta:
+        unique_together = ('submission', 'action_code')
+
     @classmethod
     def record_submission(cls, submission):
         """Records a new log entry for ``submission``."""


### PR DESCRIPTION
After any `Submission` object is saved few `ScoreLog` objects can be
created too. They should have different `action_code` attribute.
New constraint prevent from having duplicate entries.