### PR TITLE
Language list: use simplified names

### DIFF
--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -8,6 +8,7 @@
 # AUTHORS file for copyright and authorship information.
 
 from django.conf import settings
+from django.utils import translation
 
 from pootle.__version__ import sver
 from pootle_language.models import Language
@@ -43,7 +44,7 @@ def pootle_context(request):
             'DEBUG': settings.DEBUG,
         },
         'custom': settings.CUSTOM_TEMPLATE_CONTEXT,
-        'ALL_LANGUAGES': Language.live.cached_dict(),
+        'ALL_LANGUAGES': Language.live.cached_dict(translation.get_language()),
         'ALL_PROJECTS': Project.objects.cached_dict(request.user),
         'display_agreement': _agreement_context(request),
     }

--- a/tests/fixtures/cache.py
+++ b/tests/fixtures/cache.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def delete_pattern():
+    """Adds the no-op `delete_pattern()` method to `LocMemCache`."""
+    from django.core.cache.backends.locmem import LocMemCache
+    LocMemCache.delete_pattern = lambda x, y: 0


### PR DESCRIPTION
At the same time this enables localized language names where applicable.

Please test with different UI locales — I couldn't do it since iso-codes seems broken on my end.

Fixes #3700.