### PR TITLE
Cleanup: use `JsonResponse` for XHR requests

### DIFF
--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -28,8 +28,8 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.cache import make_method_key
+from pootle.core.utils.json import jsonify
 from pootle_language.models import Language
-from pootle_misc.util import jsonify
 from pootle_statistics.models import Submission, SubmissionTypes
 from pootle_store.models import SuggestionStates
 

--- a/pootle/apps/evernote_reports/views.py
+++ b/pootle/apps/evernote_reports/views.py
@@ -28,9 +28,10 @@ from django.views.generic.detail import SingleObjectMixin
 from accounts.models import CURRENCIES
 from pootle.core.decorators import admin_required
 from pootle.core.log import PAID_TASK_ADDED, PAID_TASK_DELETED, log
+from pootle.core.utils.json import jsonify
 from pootle.core.utils.timezone import make_aware, make_naive
 from pootle.core.views import AjaxResponseMixin
-from pootle_misc.util import (ajax_required, jsonify, get_date_interval,
+from pootle_misc.util import (ajax_required, get_date_interval,
                               get_max_month_datetime, import_func)
 from pootle_profile.views import (NoDefaultUserMixin, TestUserFieldMixin,
                                   DetailView)

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -19,9 +19,9 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from optparse import make_option
 
+from pootle.core.utils.json import PootleJSONEncoder
 from pootle_app.management.commands import PootleCommand
 from pootle_app.models import Directory
-from pootle_misc.util import PootleJSONEncoder
 from pootle_project.models import Project
 
 DUMPED = {

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -9,7 +9,6 @@
 
 
 import os
-import json
 
 import sys
 reload(sys)
@@ -19,7 +18,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from optparse import make_option
 
-from pootle.core.utils.json import PootleJSONEncoder
+from pootle.core.utils.json import jsonify
 from pootle_app.management.commands import PootleCommand
 from pootle_app.models import Directory
 from pootle_project.models import Project
@@ -72,7 +71,7 @@ class Command(PootleCommand):
             res = {}
             self._dump_stats(tp.directory, res, stop_level=stop_level)
 
-            stats_dump = json.dumps(res, indent=4, cls=PootleJSONEncoder)
+            stats_dump = jsonify(res)
             self.stdout.write(stats_dump)
         if data:
             self._dump_item(tp.directory, 0, stop_level=stop_level)

--- a/pootle/apps/pootle_app/views/admin/projects.py
+++ b/pootle/apps/pootle_app/views/admin/projects.py
@@ -11,9 +11,9 @@ __all__ = ('ProjectAdminView', 'ProjectAPIView')
 
 from django.views.generic import TemplateView
 
+from pootle.core.utils.json import jsonify
 from pootle.core.views import APIView, SuperuserRequiredMixin
 from pootle_app.forms import ProjectForm
-from pootle_misc.util import jsonify
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_store.filetypes import filetype_choices

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -15,9 +15,9 @@ from pootle.core.decorators import get_path_obj, permission_required
 from pootle.core.helpers import (get_export_view_context,
                                  get_overview_context,
                                  get_translation_context)
+from pootle.core.utils.json import jsonify
 from pootle.i18n.gettext import tr_lang
 from pootle_app.views.admin.permissions import admin_permissions
-from pootle_misc.util import jsonify
 
 
 @get_path_obj

--- a/pootle/apps/pootle_misc/util.py
+++ b/pootle/apps/pootle_misc/util.py
@@ -7,8 +7,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import json
-
 from functools import wraps
 from importlib import import_module
 
@@ -16,8 +14,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseBadRequest
 from django.utils import timezone
-from django.utils.encoding import force_unicode
-from django.utils.functional import Promise
 
 # Timezone aware minimum for datetime (if appropriate) (bug 2567)
 from datetime import datetime, timedelta
@@ -25,7 +21,6 @@ datetime_min = datetime.min
 if settings.USE_TZ:
     datetime_min = timezone.make_aware(datetime_min, timezone.utc)
 
-from pootle.core.markup import Markup
 from pootle.core.utils.timezone import make_aware
 
 
@@ -49,31 +44,6 @@ def import_func(path):
 
 def dictsum(x, y):
     return dict((n, x.get(n, 0)+y.get(n, 0)) for n in set(x) | set(y))
-
-
-class PootleJSONEncoder(json.JSONEncoder):
-    """Custom JSON encoder for Pootle.
-
-    This is mostly implemented to avoid calling `force_unicode` all the time on
-    certain types of objects.
-    https://docs.djangoproject.com/en/1.4/topics/serialization/#id2
-    """
-    def default(self, obj):
-        if (isinstance(obj, Promise) or isinstance(obj, Markup) or
-            isinstance(obj, datetime)):
-            return force_unicode(obj)
-
-        return super(PootleJSONEncoder, self).default(obj)
-
-
-def jsonify(obj):
-    """Serialize Python `obj` object into a JSON string."""
-    if settings.DEBUG:
-        indent = 4
-    else:
-        indent = None
-
-    return json.dumps(obj, indent=indent, cls=PootleJSONEncoder)
 
 
 def ajax_required(f):

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -22,9 +22,9 @@ from pootle.core.helpers import (get_export_view_context,
                                  get_overview_context,
                                  get_translation_context)
 from pootle.core.url_helpers import split_pootle_path
+from pootle.core.utils.json import jsonify
 from pootle_app.views.admin import util
 from pootle_app.views.admin.permissions import admin_permissions
-from pootle_misc.util import jsonify
 from pootle_project.forms import tp_form_factory
 from pootle_translationproject.models import TranslationProject
 

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -30,10 +30,11 @@ from pootle.core.dateparse import parse_datetime
 from pootle.core.decorators import (get_path_obj, get_resource,
                                     permission_required)
 from pootle.core.exceptions import Http400
+from pootle.core.utils.json import jsonify
 from pootle_app.models.permissions import check_user_permission
 from pootle_misc.checks import check_names
 from pootle_misc.forms import make_search_form
-from pootle_misc.util import ajax_required, jsonify, to_int, get_date_interval
+from pootle_misc.util import ajax_required, to_int, get_date_interval
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -20,8 +20,8 @@ from pootle.core.decorators import (get_path_obj, get_resource,
 from pootle.core.helpers import (get_export_view_context,
                                  get_overview_context,
                                  get_translation_context)
+from pootle.core.utils.json import jsonify
 from pootle_app.views.admin.permissions import admin_permissions as admin_perms
-from pootle_misc.util import jsonify
 from staticpages.models import StaticPage
 
 

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -16,8 +16,9 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic import (CreateView, DeleteView, TemplateView,
                                   UpdateView)
 
+from pootle.core.utils.json import jsonify
 from pootle.core.views import SuperuserRequiredMixin
-from pootle_misc.util import ajax_required, jsonify
+from pootle_misc.util import ajax_required
 
 from .forms import agreement_form_factory
 from .models import AbstractPage, LegalPage, StaticPage

--- a/pootle/core/forms.py
+++ b/pootle/core/forms.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from pootle_misc.util import jsonify
+from .utils.json import jsonify
 
 
 # MathCaptchaForm Copyright (c) 2007, Dima Dogadaylo (www.mysoftparade.com)

--- a/pootle/core/http.py
+++ b/pootle/core/http.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.http import HttpResponse
+
+from .utils.json import jsonify
+
+
+class JsonResponse(HttpResponse):
+    """An HTTP response class that consumes data to be serialized to JSON.
+
+    :param data: Data to be dumped into json.
+    """
+
+    def __init__(self, data, **kwargs):
+        kwargs.setdefault('content_type', 'application/json')
+        data = jsonify(data)
+        super(JsonResponse, self).__init__(content=data, **kwargs)
+
+
+class JsonResponseBadRequest(JsonResponse):
+    status_code = 400
+
+
+class JsonResponseForbidden(JsonResponse):
+    status_code = 403
+
+
+class JsonResponseNotFound(JsonResponse):
+    status_code = 404
+
+
+class JsonResponseServerError(JsonResponse):
+    status_code = 500

--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from __future__ import absolute_import
+
+import json
+
+from django.conf import settings
+from django.utils.encoding import force_unicode
+from django.utils.functional import Promise
+
+from ..markup import Markup
+
+
+class PootleJSONEncoder(json.JSONEncoder):
+    """Custom JSON encoder for Pootle.
+
+    This is mostly implemented to avoid calling `force_unicode` all the time on
+    certain types of objects.
+    https://docs.djangoproject.com/en/1.4/topics/serialization/#id2
+    """
+    def default(self, obj):
+        if (isinstance(obj, Promise) or isinstance(obj, Markup) or
+            isinstance(obj, datetime)):
+            return force_unicode(obj)
+
+        return super(PootleJSONEncoder, self).default(obj)
+
+
+def jsonify(obj):
+    """Serialize Python `obj` object into a JSON string."""
+    if settings.DEBUG:
+        indent = 4
+    else:
+        indent = None
+
+    return json.dumps(obj, indent=indent, cls=PootleJSONEncoder)

--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -12,13 +12,14 @@ from __future__ import absolute_import
 import json
 
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.encoding import force_unicode
 from django.utils.functional import Promise
 
 from ..markup import Markup
 
 
-class PootleJSONEncoder(json.JSONEncoder):
+class PootleJSONEncoder(DjangoJSONEncoder):
     """Custom JSON encoder for Pootle.
 
     This is mostly implemented to avoid calling `force_unicode` all the time on
@@ -26,8 +27,7 @@ class PootleJSONEncoder(json.JSONEncoder):
     https://docs.djangoproject.com/en/1.4/topics/serialization/#id2
     """
     def default(self, obj):
-        if (isinstance(obj, Promise) or isinstance(obj, Markup) or
-            isinstance(obj, datetime)):
+        if isinstance(obj, Promise) or isinstance(obj, Markup):
             return force_unicode(obj)
 
         return super(PootleJSONEncoder, self).default(obj)

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -24,7 +24,8 @@ from django.views.generic import View
 
 from pootle_misc.util import ajax_required
 
-from .utils.json import PootleJSONEncoder, jsonify
+from .http import JsonResponse, JsonResponseBadRequest
+from .utils.json import PootleJSONEncoder
 
 
 class SuperuserRequiredMixin(object):
@@ -89,18 +90,13 @@ class AjaxResponseMixin(object):
     def dispatch(self, *args, **kwargs):
         return super(AjaxResponseMixin, self).dispatch(*args, **kwargs)
 
-    def render_to_json_response(self, context, **response_kwargs):
-        data = jsonify(context)
-        response_kwargs['content_type'] = 'application/json'
-        return HttpResponse(data, **response_kwargs)
-
     def form_invalid(self, form):
         response = super(AjaxResponseMixin, self).form_invalid(form)
-        return self.render_to_json_response(form.errors, status=400)
+        return JsonResponseBadRequest(response)
 
     def form_valid(self, form):
         response = super(AjaxResponseMixin, self).form_valid(form)
-        return self.render_to_json_response({})
+        return JsonResponse({})
 
 
 class APIView(View):

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -22,7 +22,9 @@ from django.views.defaults import (permission_denied as django_403,
                                    server_error as django_500)
 from django.views.generic import View
 
-from pootle_misc.util import PootleJSONEncoder, ajax_required, jsonify
+from pootle_misc.util import ajax_required
+
+from .utils.json import PootleJSONEncoder, jsonify
 
 
 class SuperuserRequiredMixin(object):

--- a/pootle/middleware/errorpages.py
+++ b/pootle/middleware/errorpages.py
@@ -27,8 +27,8 @@ except ImportError:
     sentry_exception_handler = None
 
 from pootle.core.exceptions import Http400
+from pootle.core.utils.json import jsonify
 from pootle_misc.baseurl import get_next
-from pootle_misc.util import jsonify
 
 
 class ErrorPagesMiddleware(object):


### PR DESCRIPTION
This PR introduces `JsonResponse` (and friends), therefore reducing a lot of boilerplate when returning JSON responses. It also adjusts the existing `PootleJSONEncoder` to reuse bits from Django's own `DjangoJSONEncoder`.

Please test as much views as you can and report back if you experience any failures.

Fixes #3529.