### PR TITLE
Display again missing contact links

### DIFF
--- a/pootle/middleware/errorpages.py
+++ b/pootle/middleware/errorpages.py
@@ -29,7 +29,6 @@ except ImportError:
 from pootle.core.exceptions import Http400
 from pootle.core.http import (JsonResponseBadRequest, JsonResponseForbidden,
                               JsonResponseNotFound, JsonResponseServerError)
-from pootle.core.utils.json import jsonify
 from pootle_misc.baseurl import get_next
 
 

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -91,7 +91,11 @@
         <a href="#nav-main" id="menu-toggle" class="js-toggle">&nbsp;</a>
         <ul id="nav-main">
           {% block nav_items %}
-          {% block nav_items_pre %}{% endblock %}
+          {% block nav_items_pre %}
+          {% if settings.CAN_CONTACT %}
+            <li><a class="js-popup-ajax" href="{% url 'pootle-contact' %}">{% trans "Contact Us" %}</a></li>
+          {% endif %}
+          {% endblock %}
           {% if user.is_authenticated %}
           <li id="user" class="js-navbar-dropdown">
             <a href="{{ user.get_absolute_url }}" data-action="toggle">


### PR DESCRIPTION
They are conditionally displayed based on `CAN_CONTACT` setting and are
included in blocks that can be easily overwritten in custom installs.