### PR TITLE
MarkupField: do not consider `help_text` for migrations

### DIFF
--- a/pootle/apps/virtualfolder/migrations/0001_initial.py
+++ b/pootle/apps/virtualfolder/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('filter_rules', models.TextField(help_text='Filtering rules that tell which stores this virtual folder comprises.', verbose_name='Filter')),
                 ('priority', models.FloatField(default=1, help_text='Number specifying importance. Greater priority means it is more important.', verbose_name='Priority')),
                 ('is_browsable', models.BooleanField(default=True, help_text='Whether this virtual folder is active or not.', verbose_name='Is browsable?')),
-                ('description', pootle.core.markup.fields.MarkupField(help_text='Use this to provide more information or instructions. Allowed markup: HTML', verbose_name='Description', blank=True)),
+                ('description', pootle.core.markup.fields.MarkupField(verbose_name='Description', blank=True)),
                 ('units', models.ManyToManyField(related_name='vfolders', to='pootle_store.Unit', db_index=True)),
             ],
             options={

--- a/pootle/core/markup/fields.py
+++ b/pootle/core/markup/fields.py
@@ -122,3 +122,8 @@ class MarkupField(models.TextField):
         defaults = {'widget': MarkupTextarea}
         defaults.update(kwargs)
         return super(MarkupField, self).formfield(**defaults)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(MarkupField, self).deconstruct()
+        kwargs.pop('help_text', None)
+        return name, path, args, kwargs


### PR DESCRIPTION
While this might cause issues when redefining fields, it's safe in this
case because it's a custom Pootle field used for a very specific scenario.

Refs. https://code.djangoproject.com/ticket/21498#comment:6

Fixes #3687.