### PR TITLE
Drop some EN specific customisations

### DIFF
--- a/pootle/templates/contact_form/xhr_contact_form.html
+++ b/pootle/templates/contact_form/xhr_contact_form.html
@@ -6,7 +6,7 @@
     {% block contact_preamble %}
     <p>
       {% blocktrans trimmed %}
-      You have to fill all the fields, and please <b>write in English</b>.
+      Please fill in all the fields.
       {% endblocktrans %}
     </p>
     {% endblock %}


### PR DESCRIPTION
Some things I picked up in LO deployment.  PR'ing so that @translate/evernote are aware of changes needed to templates on your deployment.

- First drops the 'English' contact requirements - deployment specific
- Second - I know this should go with allauth - while allauth hasn't landed this functionality should be gone and this allows us to extend this as needed in future.