### PR TITLE
Directory: make pootle_path unique

### DIFF
--- a/pootle/apps/pootle_app/migrations/0002_unique_pootle_path.py
+++ b/pootle/apps/pootle_app/migrations/0002_unique_pootle_path.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_app', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='directory',
+            name='pootle_path',
+            field=models.CharField(unique=True, max_length=255, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -43,7 +43,8 @@ class Directory(models.Model, CachedTreeItem):
     name = models.CharField(max_length=255, null=False)
     parent = models.ForeignKey('Directory', related_name='child_dirs',
             null=True, db_index=True)
-    pootle_path = models.CharField(max_length=255, null=False, db_index=True)
+    pootle_path = models.CharField(max_length=255, null=False,
+            db_index=True, unique=True)
     obsolete = models.BooleanField(default=False)
 
     is_dir = True


### PR DESCRIPTION
It doesn't make sense to have directories with duplicated `pootle_path`s; in fact, [it causes trouble to people](http://markmail.org/thread/54p23sjq3d22v675).