### PR TITLE
Cache virtual folder stats using CachedTreeItem

### DIFF
--- a/docs/features/virtual_folders.json
+++ b/docs/features/virtual_folders.json
@@ -3,7 +3,7 @@
         "name": "user1",
         "location": "/{LANG}/firefox/browser/",
         "priority": 999.99,
-        "is_browsable": true,
+        "is_public": true,
         "description": "Most visible strings for the user.",
         "filters": {
             "files": [
@@ -16,7 +16,7 @@
         "name": "user2",
         "location": "/gl/firefox/",
         "priority": 7.5,
-        "is_browsable": false,
+        "is_public": false,
         "filters": {
             "files": [
                 "browser/chrome/browser/aboutSessionRestore.dtd.po",
@@ -68,7 +68,7 @@
     {
         "name": "other",
         "location": "/af/firefox/",
-        "is_browsable": true,
+        "is_public": true,
         "filters": {
             "files": [
                 "browser/chrome/browser/aboutCertError.dtd.po"
@@ -91,7 +91,7 @@
         "name": "install",
         "location": "/ru/{PROJ}/",
         "priority": 5,
-        "is_browsable": true,
+        "is_public": true,
         "description": "Installation related strings.",
         "filters": {
             "files": [

--- a/docs/features/virtual_folders.rst
+++ b/docs/features/virtual_folders.rst
@@ -21,7 +21,7 @@ Virtual folders have several attributes:
 - A mandatory lowercase name,
 - A mandatory location,
 - An optional priority,
-- An optional browsability flag,
+- An optional publicness flag,
 - An optional description,
 - A field accepting several optional filtering rules.
 
@@ -41,8 +41,8 @@ The priority defaults to ``1`` and accepts any value greater than ``0``,
 including numbers with decimals, like ``0.75``. Higher numbers means higher
 priority.
 
-By default virtual folders can be browsed. If they are not browsable then they
-won't be displayed, but they are still used for sorting.
+By default virtual folders are public. If they are not public then they won't
+be displayed, but they are still used for sorting.
 
 Also the virtual folders can have a description which might be useful to
 explain the contents of the folder or provide additional instructions. This
@@ -95,7 +95,7 @@ If a virtual folder applies in the current location, then clicking on the links
 on the overview page will provide the units in priority order when translating
 in the editor. The priority sorting on the translation editor is calculated
 taking into account all the applicable virtual folders in the current location,
-including the not browsable ones.
+including the not public ones.
 
 
 .. _virtual_folders#json-format:

--- a/docs/features/virtual_folders.rst
+++ b/docs/features/virtual_folders.rst
@@ -68,6 +68,24 @@ the specs for the :ref:`JSON format <virtual_folders#json-format>` in order to
 know how to craft a JSON file that fits your needs.
 
 
+.. _virtual_folders#stats:
+
+Calculating virtual folders stats
+---------------------------------
+
+To calculate the translation stats of virtual folders use the
+:djadmin:`refresh_stats_rq` management command. Virtual folder stats will be
+calculated along regular directories and files stats.
+
+.. warning:: Note that the :djadmin:`refresh_stats` management command will not
+    trigger virtual folder stats calculation.
+
+After the initial calculation no extra runs will be required unless virtual
+folders are changed by a run of the :djadmin:`add_vfolders` management command.
+Changes introduced due to translation through the editor will automatically
+update the stats without intervention.
+
+
 .. _virtual_folders#translate:
 
 Translating virtual folders

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -66,6 +66,13 @@ class Directory(models.Model, CachedTreeItem):
                             .filter(pootle_path__startswith=self.pootle_path)
 
     @property
+    def vfolder_treeitems(self):
+        if 'virtualfolder' in settings.INSTALLED_APPS:
+            return self.vf_treeitems.all()
+
+        return []
+
+    @property
     def has_vfolders(self):
         return ('virtualfolder' in settings.INSTALLED_APPS and
                 self.vf_treeitems.count() > 0)
@@ -281,3 +288,7 @@ class Directory(models.Model, CachedTreeItem):
         self.obsolete = True
         self.save()
         self.clear_all_cache(parents=False, children=False)
+
+        # Clear stats cache for sibling VirtualFolderTreeItems as well.
+        for vfolder_treeitem in self.vfolder_treeitems:
+            vfolder_treeitem.clear_all_cache(parents=False, children=False)

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -162,20 +162,20 @@ class Directory(models.Model, CachedTreeItem):
 
         return result
 
-    def get_parent(self):
+    def get_parents(self):
         if self.parent:
             if self.is_translationproject():
-                return self.translationproject.get_parent()
+                return self.translationproject.get_parents()
             elif self.is_project():
-                return self.project.get_parent()
+                return self.project.get_parents()
             elif self.is_language():
-                return self.language.get_parent()
+                return self.language.get_parents()
             elif self.parent.is_translationproject():
-                return self.parent.translationproject
+                return [self.parent.translationproject]
             else:
-                return self.parent
+                return [self.parent]
         else:
-            return None
+            return []
 
     def get_cachekey(self):
         return self.pootle_path

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -7,6 +7,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.functional import cached_property
@@ -63,6 +64,11 @@ class Directory(models.Model, CachedTreeItem):
         from pootle_store.models import Store
         return Store.objects.live() \
                             .filter(pootle_path__startswith=self.pootle_path)
+
+    @property
+    def has_vfolders(self):
+        return ('virtualfolder' in settings.INSTALLED_APPS and
+                self.vf_treeitems.count() > 0)
 
     @property
     def is_template_project(self):

--- a/pootle/apps/pootle_app/project_tree.py
+++ b/pootle/apps/pootle_app/project_tree.py
@@ -158,6 +158,8 @@ def add_items(fs_items_set, db_items, create_or_resurrect_db_item, parent):
         db_items[name].makeobsolete()
     if len(items_to_delete) > 0:
         parent.update_all_cache()
+        for vfolder_treeitem in parent.vfolder_treeitems:
+            vfolder_treeitem.update_all_cache()
 
     for name in db_items_set - items_to_delete:
         items.append(db_items[name])

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -36,7 +36,6 @@ from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import PermissionSet
 from pootle_store.filetypes import filetype_choices, factory_classes
 from pootle_store.util import absolute_real_path
-from virtualfolder.signals import vfolder_post_save
 
 
 RESERVED_PROJECT_CODES = ('admin', 'translate', 'settings')
@@ -287,14 +286,17 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
     @property
     def vfolders(self):
         """Return the public virtual folders for this project."""
-        # This import must be here to avoid circular import issues.
-        from virtualfolder.models import VirtualFolder
+        if 'virtualfolder' in settings.INSTALLED_APPS:
+            # This import must be here to avoid circular import issues.
+            from virtualfolder.models import VirtualFolder
 
-        return [vf.tp_relative_path
-                for vf in VirtualFolder.objects.filter(
-                    units__store__translation_project__project__code=self.code,
-                    is_public=True
-                ).distinct()]
+            return [vf.tp_relative_path
+                    for vf in VirtualFolder.objects.filter(
+                        units__store__translation_project__project__code=self.code,
+                        is_public=True
+                    ).distinct()]
+
+        return []
 
     @cached_property
     def languages(self):
@@ -524,22 +526,25 @@ class ProjectSet(VirtualResource, ProjectURLMixin):
     ### /TreeItem
 
 
-@receiver([vfolder_post_save, pre_delete])
-def invalidate_resources_cache_for_vfolders(sender, instance, **kwargs):
-    if instance.__class__.__name__ == 'VirtualFolder':
-        try:
-            # In case this is vfolder_post_save.
-            affected_projects = kwargs['projects']
-        except KeyError:
-            # In case this is pre_delete.
-            affected_projects = Project.objects.filter(
-                translationproject__stores__unit__vfolders=instance
-            ).distinct().values_list('code', flat=True)
+if 'virtualfolder' in settings.INSTALLED_APPS:
+    from virtualfolder.signals import vfolder_post_save
 
-        cache.delete_many([
-            make_method_key('Project', 'resources', proj)
-            for proj in affected_projects
-        ])
+    @receiver([vfolder_post_save, pre_delete])
+    def invalidate_resources_cache_for_vfolders(sender, instance, **kwargs):
+        if instance.__class__.__name__ == 'VirtualFolder':
+            try:
+                # In case this is vfolder_post_save.
+                affected_projects = kwargs['projects']
+            except KeyError:
+                # In case this is pre_delete.
+                affected_projects = Project.objects.filter(
+                    translationproject__stores__unit__vfolders=instance
+                ).distinct().values_list('code', flat=True)
+
+            cache.delete_many([
+                make_method_key('Project', 'resources', proj)
+                for proj in affected_projects
+            ])
 
 
 @receiver([post_delete, post_save])

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -286,14 +286,14 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
 
     @property
     def vfolders(self):
-        """Return the browsable virtual folders for this project."""
+        """Return the public virtual folders for this project."""
         # This import must be here to avoid circular import issues.
         from virtualfolder.models import VirtualFolder
 
         return [vf.tp_relative_path
                 for vf in VirtualFolder.objects.filter(
                     units__store__translation_project__project__code=self.code,
-                    is_browsable=True
+                    is_public=True
                 ).distinct()]
 
     @cached_property

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1432,7 +1432,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             self.update_dirty_cache()
 
     def delete(self, *args, **kwargs):
-        parent = self.get_parent()
+        parents = self.get_parents()
         vfolder_treeitems = self.parent_vfolder_treeitems
 
         store_log(user='system', action=STORE_DELETED,
@@ -1446,8 +1446,8 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         super(Store, self).delete(*args, **kwargs)
 
         self.clear_all_cache(parents=False, children=False)
-        if parent is not None:
-            parent.update_all_cache()
+        for p in parents:
+            p.update_all_cache()
 
         for vfolder_treeitem in vfolder_treeitems:
             vfolder_treeitem.update_all_cache()
@@ -2045,11 +2045,11 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
     def can_be_updated(self):
         return not self.obsolete
 
-    def get_parent(self):
+    def get_parents(self):
         if self.parent.is_translationproject():
-            return self.translation_project
+            return [self.translation_project]
         else:
-            return self.parent
+            return [self.parent]
 
     def get_cachekey(self):
         return self.pootle_path

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1433,7 +1433,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
     def delete(self, *args, **kwargs):
         parents = self.get_parents()
-        vfolder_treeitems = self.parent_vfolder_treeitems
 
         store_log(user='system', action=STORE_DELETED,
                   path=self.pootle_path, store=self.id)
@@ -1448,9 +1447,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         self.clear_all_cache(parents=False, children=False)
         for p in parents:
             p.update_all_cache()
-
-        for vfolder_treeitem in vfolder_treeitems:
-            vfolder_treeitem.update_all_cache()
 
     def makeobsolete(self):
         """Make this store and all its units obsolete."""
@@ -2047,9 +2043,13 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
     def get_parents(self):
         if self.parent.is_translationproject():
-            return [self.translation_project]
+            parents = [self.translation_project]
         else:
-            return [self.parent]
+            parents = [self.parent]
+
+        parents.extend(self.parent_vfolder_treeitems)
+
+        return parents
 
     def get_cachekey(self):
         return self.pootle_path

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -324,8 +324,8 @@ class TranslationProject(models.Model, CachedTreeItem):
     def get_cachekey(self):
         return self.directory.pootle_path
 
-    def get_parent(self):
-        return self.project
+    def get_parents(self):
+        return [self.project]
 
     ### /TreeItem
 

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -327,6 +327,21 @@ class TranslationProject(models.Model, CachedTreeItem):
     def get_parents(self):
         return [self.project]
 
+    def clear_all_cache(self, children=True, parents=True):
+        super(TranslationProject, self).clear_all_cache(children=children,
+                                                        parents=parents)
+
+        if 'virtualfolder' in settings.INSTALLED_APPS:
+            # VirtualFolderTreeItem can only have VirtualFolderTreeItem parents
+            # so it is necessary to flush their cache by calling them one by
+            # one.
+            from virtualfolder.models import VirtualFolderTreeItem
+            tp_vfolder_treeitems = VirtualFolderTreeItem.objects.filter(
+                pootle_path__startswith=self.pootle_path
+            )
+            for vfolder_treeitem in tp_vfolder_treeitems.iterator():
+                vfolder_treeitem.clear_all_cache(children=False, parents=False)
+
     ### /TreeItem
 
     def directory_exists(self):

--- a/pootle/apps/virtualfolder/helpers.py
+++ b/pootle/apps/virtualfolder/helpers.py
@@ -26,7 +26,7 @@ def extract_vfolder_from_path(pootle_path):
     The path /gl/firefox/browser/vfolder/chrome/file.po with the vfolder
     virtual folder on it will be converted to
     /gl/firefox/browser/chrome/file.po if the virtual folder exists and is
-    browsable.
+    public.
 
     Have in mind that several virtual folders with the same name might apply in
     the same path (as long as they have different locations this is possible)
@@ -55,7 +55,7 @@ def extract_vfolder_from_path(pootle_path):
 
         vfolders = VirtualFolder.objects.filter(
             name=vfolder_name,
-            is_browsable=True
+            is_public=True
         ).order_by('-priority')
 
         vfolder = None
@@ -73,7 +73,7 @@ def extract_vfolder_from_path(pootle_path):
             break
 
         if vfolder is None:
-            # The virtual folder does not exist or is not browsable or doesn't
+            # The virtual folder does not exist or is not public or doesn't
             # apply in this location, so this is an invalid path.
             break
 
@@ -82,6 +82,6 @@ def extract_vfolder_from_path(pootle_path):
 
         return vfolder, adjusted_path
 
-    # There is no virtual folder (or is not browsable) and the provided path
+    # There is no virtual folder (or is not public) and the provided path
     # doesn't exist, so let the calling code to deal with this.
     return None, pootle_path

--- a/pootle/apps/virtualfolder/management/commands/add_vfolders.py
+++ b/pootle/apps/virtualfolder/management/commands/add_vfolders.py
@@ -104,12 +104,12 @@ class Command(BaseCommand):
                                   "changed to %f.", vfolder.name,
                                   vfolder.priority)
 
-                if ('is_browsable' in vfolder_item and
-                    vfolder.is_browsable != vfolder_item['is_browsable']):
+                if ('is_public' in vfolder_item and
+                    vfolder.is_public != vfolder_item['is_public']):
 
-                    vfolder.is_browsable = vfolder_item['is_browsable']
+                    vfolder.is_public = vfolder_item['is_public']
                     changed = True
-                    logging.debug("is_browsable status for virtual folder "
+                    logging.debug("is_public status for virtual folder "
                                   "'%s' will be changed.", vfolder.name)
 
                 if ('description' in vfolder_item and

--- a/pootle/apps/virtualfolder/migrations/0002_add_virtualfoldertreeitem.py
+++ b/pootle/apps/virtualfolder/migrations/0002_add_virtualfoldertreeitem.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import pootle.core.mixins.treeitem
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0001_initial'),
+        ('pootle_app', '0001_initial'),
+        ('virtualfolder', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='VirtualFolderTreeItem',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('pootle_path', models.CharField(unique=True, max_length=255, editable=False, db_index=True)),
+                ('directory', models.ForeignKey(related_name='vf_treeitems', to='pootle_app.Directory')),
+                ('parent', models.ForeignKey(related_name='child_vf_treeitems', to='virtualfolder.VirtualFolderTreeItem', null=True)),
+                ('stores', models.ManyToManyField(related_name='parent_vf_treeitems', to='pootle_store.Store', db_index=True)),
+                ('vfolder', models.ForeignKey(related_name='vf_treeitems', to='virtualfolder.VirtualFolder')),
+            ],
+            options={
+            },
+            bases=(models.Model, pootle.core.mixins.treeitem.CachedTreeItem),
+        ),
+        migrations.AlterUniqueTogether(
+            name='virtualfoldertreeitem',
+            unique_together=set([('directory', 'vfolder')]),
+        ),
+    ]

--- a/pootle/apps/virtualfolder/migrations/0003_drop_virtualfolder_ordering.py
+++ b/pootle/apps/virtualfolder/migrations/0003_drop_virtualfolder_ordering.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('virtualfolder', '0002_add_virtualfoldertreeitem'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='virtualfolder',
+            options={},
+        ),
+    ]

--- a/pootle/apps/virtualfolder/migrations/0004_rename_is_browsable_to_is_public.py
+++ b/pootle/apps/virtualfolder/migrations/0004_rename_is_browsable_to_is_public.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('virtualfolder', '0003_drop_virtualfolder_ordering'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='virtualfolder',
+            name='is_browsable',
+        ),
+        migrations.AddField(
+            model_name='virtualfolder',
+            name='is_public',
+            field=models.BooleanField(default=True, help_text='Whether this virtual folder is public or not.', verbose_name='Is public?'),
+            preserve_default=True,
+        ),
+    ]

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -283,6 +283,10 @@ class VirtualFolderTreeItemManager(models.Manager):
         return super(VirtualFolderTreeItemManager, self) \
             .get_queryset().select_related('vfolder')
 
+    def live(self):
+        """Filter VirtualFolderTreeItems with non-obsolete directories."""
+        return self.filter(directory__obsolete=False)
+
 
 class VirtualFolderTreeItem(models.Model, CachedTreeItem):
 
@@ -393,6 +397,9 @@ class VirtualFolderTreeItem(models.Model, CachedTreeItem):
 
     ### TreeItem
 
+    def can_be_updated(self):
+        return not self.directory.obsolete
+
     def get_cachekey(self):
         return self.pootle_path
 
@@ -403,9 +410,9 @@ class VirtualFolderTreeItem(models.Model, CachedTreeItem):
         return []
 
     def get_children(self):
-        result = [store for store in self.stores.iterator()]
+        result = [store for store in self.stores.live().iterator()]
         result.extend([vfolder_treeitem for vfolder_treeitem
-                       in self.child_vf_treeitems.iterator()])
+                       in self.child_vf_treeitems.live().iterator()])
         return result
 
     def get_stats(self, include_children=True):

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -396,8 +396,11 @@ class VirtualFolderTreeItem(models.Model, CachedTreeItem):
     def get_cachekey(self):
         return self.pootle_path
 
-    def get_parent(self):
-        return self.parent
+    def get_parents(self):
+        if self.parent:
+            return [self.parent]
+
+        return []
 
     def get_children(self):
         result = [store for store in self.stores.iterator()]

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -126,18 +126,6 @@ class VirtualFolder(models.Model):
 
         return [self.location]
 
-    @classmethod
-    def get_matching_for(cls, pootle_path):
-        """Return the matching virtual folders in the given pootle path.
-
-        Not all the applicable virtual folders have matching filtering rules.
-        This method further restricts the list of applicable virtual folders to
-        retrieve only those with filtering rules that actually match.
-        """
-        return VirtualFolder.objects.filter(
-            units__store__pootle_path__startswith=pootle_path
-        ).distinct()
-
     def __unicode__(self):
         return ": ".join([self.name, self.location])
 

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -56,10 +56,10 @@ class VirtualFolder(models.Model):
         help_text=_('Number specifying importance. Greater priority means it '
                     'is more important.'),
     )
-    is_browsable = models.BooleanField(
-        _('Is browsable?'),
+    is_public = models.BooleanField(
+        _('Is public?'),
         default=True,
-        help_text=_('Whether this virtual folder is active or not.'),
+        help_text=_('Whether this virtual folder is public or not.'),
     )
     description = MarkupField(
         _('Description'),
@@ -324,7 +324,7 @@ class VirtualFolderTreeItem(models.Model, CachedTreeItem):
 
     @property
     def is_visible(self):
-        return (self.vfolder.is_browsable and
+        return (self.vfolder.is_public and
                 (self.has_critical_errors or
                  (self.vfolder.priority >= 1 and not self.is_fully_translated)))
 

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -9,8 +9,6 @@
 
 from django.utils.translation import ugettext_lazy as _
 
-from virtualfolder.models import VirtualFolder
-
 
 HEADING_CHOICES = [
     {
@@ -97,7 +95,7 @@ def make_generic_item(path_obj, **kwargs):
 def make_directory_item(directory):
     filters = {}
 
-    if VirtualFolder.get_matching_for(directory.pootle_path).count():
+    if directory.has_vfolders:
         # The directory has virtual folders, so append priority sorting to URL.
         filters['sort'] = 'priority'
 

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -191,19 +191,16 @@ def get_children(directory):
     return directories + stores
 
 
-def make_vfolder_item(virtual_folder, pootle_path):
+def make_vfolder_treeitem(vfolder_treeitem):
     return {
-        'href_all': virtual_folder.get_translate_url(pootle_path),
-        'href_todo': virtual_folder.get_translate_url(pootle_path,
-                                                      state='incomplete'),
-        'href_sugg': virtual_folder.get_translate_url(pootle_path,
-                                                      state='suggestions'),
-        'href_critical': virtual_folder.get_critical_url(pootle_path),
-        'title': virtual_folder.name,
-        'code': virtual_folder.code,
-        'priority': virtual_folder.priority,
-        'is_grayed': (not virtual_folder.is_browsable or
-                      virtual_folder.priority < 1),
+        'href_all': vfolder_treeitem.get_translate_url(),
+        'href_todo': vfolder_treeitem.get_translate_url(state='incomplete'),
+        'href_sugg': vfolder_treeitem.get_translate_url(state='suggestions'),
+        'href_critical': vfolder_treeitem.get_critical_url(),
+        'title': vfolder_treeitem.vfolder.name,
+        'code': vfolder_treeitem.code,
+        'priority': vfolder_treeitem.vfolder.priority,
+        'is_grayed': not vfolder_treeitem.is_visible,
         'icon': 'folder',
     }
 
@@ -217,9 +214,7 @@ def get_vfolders(directory, all_vfolders=False):
     If ``all_vfolders`` is True then all the virtual folders matching the
     provided directory are returned. If not only the visible ones are returned.
     """
-    if all_vfolders:
-        return [make_vfolder_item(vf, directory.pootle_path)
-            for vf in VirtualFolder.get_matching_for(directory.pootle_path)]
-
-    return [make_vfolder_item(vf, directory.pootle_path)
-            for vf in VirtualFolder.get_visible_for(directory.pootle_path)]
+    return [make_vfolder_treeitem(vfolder_treeitem)
+            for vfolder_treeitem
+            in directory.vf_treeitems.order_by('-vfolder__priority').iterator()
+            if all_vfolders or vfolder_treeitem.is_visible]

--- a/pootle/core/helpers.py
+++ b/pootle/core/helpers.py
@@ -12,12 +12,14 @@ from itertools import groupby
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
+from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import check_permission
 from pootle_misc.checks import check_names, get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_misc.stats import get_translation_states
-from pootle_store.models import Store, Unit
+from pootle_store.models import Unit
 from pootle_store.views import get_step_query
+from pootle_translationproject.models import TranslationProject
 from virtualfolder.models import VirtualFolder
 
 from .url_helpers import get_path_parts, get_previous_url
@@ -155,8 +157,10 @@ def get_browser_context(request):
 
     filters = {}
 
-    if (not isinstance(resource_obj, Store) and
-        VirtualFolder.get_matching_for(request.pootle_path).count()):
+    if ((isinstance(resource_obj, Directory) and
+         resource_obj.has_vfolders) or
+        (isinstance(resource_obj, TranslationProject) and
+         resource_obj.directory.has_vfolders)):
         filters['sort'] = 'priority'
 
     url_action_continue = resource_obj.get_translate_url(state='incomplete',

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -87,9 +87,9 @@ class TreeItem(object):
     def set_children(self, children):
         self._children = children
 
-    def get_parent(self):
+    def get_parents(self):
         """This method will be overridden in descendants"""
-        return None
+        return []
 
     def get_cachekey(self):
         """This method will be overridden in descendants"""
@@ -413,8 +413,8 @@ class CachedTreeItem(TreeItem):
             log("%s deleted from %s cache" % (keys, itemkey))
 
         if parents:
-            p = self.get_parent()
-            if p is not None:
+            item_parents = self.get_parents()
+            for p in item_parents:
                 p._clear_cache(keys, parents=parents, children=False)
 
         if children:
@@ -521,8 +521,7 @@ class CachedTreeItem(TreeItem):
                     keys_for_parent.remove(key)
 
             if keys_for_parent:
-                p = self.get_parent()
-                if p is not None:
+                for p in self.get_parents():
                     create_update_cache_job(p, keys_for_parent, decrement)
                 self.unregister_dirty(decrement)
             else:
@@ -537,8 +536,7 @@ class CachedTreeItem(TreeItem):
         to the default queue
         """
         all_cache_methods = set(CachedMethods.get_all())
-        p = self.get_parent()
-        if p is not None:
+        for p in self.get_parents():
             p.register_all_dirty()
             create_update_cache_job(p, all_cache_methods)
 

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -216,7 +216,7 @@ var stats = {
           $td = $vfoldersTable.find('#total-words-' + code);
 
           // Display only the virtual folders that must be displayed.
-          if (this.isAdmin || item.translated < item.total) {
+          if (this.isAdmin || item.isVisible) {
             this.processTableItem(item, code, $vfoldersTable, $td, now);
           } else {
             //FIXME vfolders might be added or removed since they can become

--- a/pootle/tools/phaselist2vfolder.py
+++ b/pootle/tools/phaselist2vfolder.py
@@ -33,8 +33,8 @@ priorities = {
     'notnb': 0.3,
     'never': 0.1,
 }
-# If a goal should be marked as unbrowsable
-unbrowsables = [
+# If a goal should be marked as not public
+not_public = [
     'notnb',
     'never',
 ]
@@ -55,14 +55,14 @@ with open(phaselistfile) as phaselist:
             priority = 1.0
             if goal in priorities:
                 priority = priorities[goal]
-            browsable = True
-            if goal in unbrowsables:
-                browsable = False
+            public = True
+            if goal in not_public:
+                public = False
             vfolders.append({
                 'name': goal,
                 'location': '/{LANG}/%s/' % project,
                 'priority': priority,
-                'is_browsable': browsable,
+                'is_public': public,
                 'filters': {
                     'files': [
                         pofile,

--- a/tests/core/mixins/treeitem.py
+++ b/tests/core/mixins/treeitem.py
@@ -35,23 +35,27 @@ def test_get_children(tutorial, afrikaans):
 
 
 @pytest.mark.django_db
-def test_get_parent(af_tutorial_subdir_po, af_tutorial_po,
+def test_get_parents(af_tutorial_subdir_po, af_tutorial_po,
                      afrikaans_tutorial, afrikaans, tutorial):
     """Ensure that retrieved parent objects have a correct type."""
-    parent = af_tutorial_subdir_po.get_parent()
-    assert isinstance(parent, Directory)
+    parents = af_tutorial_subdir_po.get_parents()
+    assert len(parents) == 1
+    assert isinstance(parents[0], Directory)
 
-    parent = af_tutorial_po.get_parent()
-    assert isinstance(parent, TranslationProject)
+    parents = af_tutorial_po.get_parents()
+    assert len(parents) == 1
+    assert isinstance(parents[0], TranslationProject)
 
-    parent = afrikaans_tutorial.get_parent()
-    assert isinstance(parent, Project)
+    parents = afrikaans_tutorial.get_parents()
+    assert len(parents) == 1
+    assert isinstance(parents[0], Project)
 
-    parent = afrikaans_tutorial.directory.get_parent()
-    assert isinstance(parent, Project)
+    parents = afrikaans_tutorial.directory.get_parents()
+    assert len(parents) == 1
+    assert isinstance(parents[0], Project)
 
-    parent = tutorial.directory.get_parent()
-    assert parent is None
+    parents = tutorial.directory.get_parents()
+    assert len(parents) == 0
 
-    parent = afrikaans.directory.get_parent()
-    assert parent is None
+    parents = afrikaans.directory.get_parents()
+    assert len(parents) == 0


### PR DESCRIPTION
@translate/core  Ready to review.

The purpose of these changes is to use CachedTreeItem in order to keep stats in cache, resulting in a faster retrieval. In order to do so VFolderCachedTreeItem trees are created besides regular tree, see an example in https://imgrush.com/leOJqX9pAlUj. Unfortunately creating those tree structures results in worsening the vfolder and regular directory name clash (#3534) which was reported as #3809. Stats can only be calculated using `refresh_stats_rq`.

Instructions for setup:

- Check out the branch locally
- You might need to make the assets to ensure you use the latest JS.
- Run `./manage.py shell_plus`
- Run `VirtualFolder.objects.all().delete()` and exit the shell
- If you have a `test_vfolders` project remove it from Pootle and from `POOTLE_TRANSLATION_DIRECTORY`
- Get https://docs.google.com/file/d/0B-8KVyCPnkZRSHAzbUFRYmV3LWM and uncompress it on your `POOTLE_TRANSLATION_DIRECTORY`
- Add a new `test_vfolders` project.
- Run `./manage.py update_stores --project=test_vfolders`
- Get http://dpaste.com/15NCKRS and save it as `vfolders_test_directory.json`
- Run `./manage.py add_vfolders vfolders_test_directory.json`
- Run `./manage.py refresh_stats_rq --project=test_vfolders`


Instructions for testing:

- Run `./manage.py runserver`
- Log in as a regular user (not admin)
- Go to `http://127.0.0.1:8000/af/test_vfolders/browser/chrome/`
- Check that:
  - the vfolders stats table is displayed
  - the listed vfolders are all the vfolders that should be displayed. The following must not be displayed:
    - not browsable vfolders,
    - completely translated vfolders,
    - priority below 1 vfolders,
    - vfolders that don't match any file in that path.
  - you can see completely translated vfolders that have failing checks.
  - the counts match. Note that each vfolder counts must only include the files they match in the current location or below it.
  -  the translate links are correct. Just are like regular translate links for this location, but with the vfolder name included just after its location, for example a vfolder with location `/af/test_vfolders/browser/` and name `test-overlapping-vfolder` will have a needs work translate link pointing to `http://127.0.0.1:8000/af/test_vfolders/translate/browser/test-overlapping-vfolder/chrome/#filter=incomplete`
- Log in as an admin user
- Check that in `http://127.0.0.1:8000/af/test_vfolders/browser/chrome/` now you can also see styled as disabled (grayed out):
  - not browsable vfolders ,
  - completely translated vfolders,
  - vfolders with priority below 1.
- Click on the `need translation` translate link for vfolder `test-overrides` on the vfolders stats table and ensure that:
  - you see `browser/test-overrides/chrome` in the navbar dropdown,
  - the URL in the browser location bar is `http://127.0.0.1:8000/af/test_vfolders/translate/browser/test-overrides/chrome/#filter=incomplete`,
  - the units displayed only belong to files matched by the vfolder filter in `/af/test_vfolders/browser/chrome/`
  - it is not possible to sort by priority.
- Select the same path to be translated in the editor, but not restricted to a vfolder: `http://127.0.0.1:8000/af/test_vfolders/translate/browser/chrome/#filter=incomplete`. Check that:
  - the unit count is bigger
  - you can sort by priority.
- Open the navbar dropdown and ensure that all the vfolders that match within current project are displayed:
  - Should be included (even if they have low priority or are completely translated):
    - test-overlapping-vfolder
    - test-overrides
    - test-low-priority
    - test-vfolder1
    - test-vfolder2
    - test-vfolder3
    - test-completely-translated-with-failing-checks
  - Are not browsable and thus should not be included:
    - test-not-browsable
    - test-completely-translated
  - Don't apply to any file, so they should not be included:
    - test-directory
    - test-newfile
- Open `http://127.0.0.1:8000/af/test_vfolders/translate/chat/#filter=incomplete` and ensure that:
  - no priority is being displayed for any of the units listed,
  - it is not possible to select priority sorting.
- Open `http://127.0.0.1:8000/af/test_vfolders/translate/dom/chrome/#filter=incomplete` and ensure that:
  - the top priority is being displayed for all the units shown (the units in this location belong to the vfolders whose name starts with `test-vfolder`, which eases looking in the JSON). Remember to ensure that the top priority is shown for a unit that is included in several vfolders.
  - you can sort by priority. Remember top priorities are above and lower at the bottom. 