### PR TITLE
Dropped MySQL dependence on MyISAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,11 @@ python:
   - 2.7
 env:
   matrix:
-    # FIXME reenable backends when these are made to work once again
-    #- DJANGO_VERSION=1.7.8 DATABASE_BACKEND=sqlite
-    #- DJANGO_VERSION=1.7.8 DATABASE_BACKEND=postgres
-    - DJANGO_VERSION=1.7.8 DATABASE_BACKEND=mysql_myisam
-    #- DJANGO_VERSION=1.7.8 DATABASE_BACKEND=mysql_innodb
+    - DJANGO_VERSION=1.7.8 DATABASE_BACKEND=sqlite
+    - DJANGO_VERSION=1.7.8 DATABASE_BACKEND=postgres
+    - DJANGO_VERSION=1.7.8 DATABASE_BACKEND=mysql_innodb
   global:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
-matrix:
-  exclude:
-    - python: 2.7
-      env: DJANGO_VERSION=1.7.8 DATABASE_BACKEND=sqlite
-    - python: 2.7
-      env: DJANGO_VERSION=1.7.8 DATABASE_BACKEND=mysql_innodb
-    - python: 2.7
-      env: DJANGO_VERSION=1.7.8 DATABASE_BACKEND=postgres
-  allow_failures:
-    # Disable alternate databases until we break away from being stuck on
-    # MyISAM
-    - env: DJANGO_VERSION=1.7.8 DATABASE_BACKEND=sqlite
-    - env: DJANGO_VERSION=1.7.8 DATABASE_BACKEND=postgres
-    - env: DJANGO_VERSION=1.7.8 DATABASE_BACKEND=mysql_innodb
 cache:
   apt: true
   directories:
@@ -39,7 +23,7 @@ install:
   - pip freeze  # Print all installed versions for reference.
 before_script:
   - if [[ $DATABASE_BACKEND == 'postgres' ]]; then psql -c 'create database pootle;' -U postgres; fi
-  - if [ $DATABASE_BACKEND == 'mysql_myisam' -o  $DATABASE_BACKEND == 'mysql_innodb' ]; then mysql -e 'create database pootle CHARACTER SET utf8 COLLATE utf8_general_ci;'; fi
+  - if [[ $DATABASE_BACKEND == 'mysql_innodb' ]]; then mysql -e 'create database pootle CHARACTER SET utf8 COLLATE utf8_general_ci;'; fi
 script:
   - python -m compileall -q -f .
   - make docs

--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -35,12 +35,3 @@ if os.environ.get("TRAVIS"):
         DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
         DATABASES['default']['NAME'] = 'pootle'
         DATABASES['default']['USER'] = 'travis'
-        # Remove this once we've closed #3363 and #3364
-        if DATABASE_BACKEND == "mysql_myisam":
-            DATABASES['default']['OPTIONS'] = {
-                'init_command': 'SET storage_engine=MyISAM',
-            }
-        elif DATABASE_BACKEND == "mysql_innodb":
-            DATABASES['default']['OPTIONS'] = {
-                'init_command': 'SET storage_engine=InnoDB',
-            }

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -81,7 +81,7 @@ def test_apiview_invalid_method(rf):
     assert response.status_code == 405
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_apiview_get_single(rf):
     """Tests retrieving a single object using the API."""
     view = UserAPIView.as_view()
@@ -104,7 +104,7 @@ def test_apiview_get_single(rf):
         view(request, id='7')
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_apiview_get_multiple(rf):
     """Tests retrieving multiple objects using the API."""
     view = UserAPIView.as_view()
@@ -159,7 +159,7 @@ def test_apiview_get_multiple(rf):
     assert len(response_data['models']) == 1
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_apiview_post(rf):
     """Tests creating a new object using the API."""
     view = WriteableUserAPIView.as_view()
@@ -207,7 +207,7 @@ def test_apiview_post(rf):
     assert 'errors' in response_data
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_apiview_put(rf):
     """Tests updating an object using the API."""
     view = WriteableUserAPIView.as_view()
@@ -267,7 +267,7 @@ def test_apiview_put(rf):
     assert 'password' not in response_data
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_apiview_delete(rf):
     """Tests deleting an object using the API."""
     view = UserAPIView.as_view()
@@ -292,7 +292,7 @@ def test_apiview_delete(rf):
         view(request, id=user.id)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_apiview_search(rf):
     """Tests filtering through a search query."""
     # Note that `UserAPIView` is configured to search in all defined

--- a/tests/fixtures/models/directory.py
+++ b/tests/fixtures/models/directory.py
@@ -11,7 +11,7 @@ import pytest
 
 
 @pytest.fixture
-def root(db):
+def root(transactional_db):
     """Require the root directory."""
     from pootle_app.models import Directory
     root, created = Directory.objects.get_or_create(name='')

--- a/tests/fixtures/models/user.py
+++ b/tests/fixtures/models/user.py
@@ -39,7 +39,7 @@ def nobody(db):
 
 
 @pytest.fixture
-def default(db):
+def default(transactional_db):
     """Require the default authenticated user."""
     return _require_user('default', 'any authenticated user',
                          password='')
@@ -52,7 +52,7 @@ def system(db):
 
 
 @pytest.fixture
-def admin(db):
+def admin(transactional_db):
     """Require the admin user."""
     return _require_user('admin', 'Administrator', password='admin',
                          is_superuser=True)

--- a/tests/models/legalpage.py
+++ b/tests/models/legalpage.py
@@ -15,7 +15,7 @@ from staticpages.models import LegalPage
 from ..factories import AgreementFactory, LegalPageFactory, UserFactory
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db(transaction=True)
 def test_pending_agreements():
     """Tests proper user pending agreements are returned."""
     foo_user = UserFactory.create(username='foo')

--- a/tests/views/admin.py
+++ b/tests/views/admin.py
@@ -15,7 +15,7 @@ from django.core.urlresolvers import reverse_lazy
 ADMIN_URL = reverse_lazy('pootle-admin')
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_admin_not_logged_in(client):
     """Checks logged-out users cannot access the admin site."""
     response = client.get(ADMIN_URL)


### PR DESCRIPTION
* Makes test work on transactional DBs, and drops MyISAM
* Re-enables SQLite, PostgreSQL and InnoDB on Travis

Fixes #3363.