### PR TITLE
Bugfix: Views can test permission against unicode usernames

### DIFF
--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -60,7 +60,7 @@ class TestUserFieldMixin(LoginRequiredMixin):
         user = self.request.user
         url_field_value = kwargs[self.test_user_field]
         field_value = getattr(user, self.test_user_field, '')
-        can_access = user.is_superuser or str(field_value) == url_field_value
+        can_access = user.is_superuser or unicode(field_value) == url_field_value
 
         if not can_access:
             raise PermissionDenied(_('You cannot access this page.'))


### PR DESCRIPTION
Class Based Views inheriting from pootle.core.views.TestUserFieldMixin were producing
an UnicodeEncodeError when testing against unicode usernames.

Fixes #3855