### PR TITLE
Stats: update WORDCOUNT_STATS after suggestion accepted

### DIFF
--- a/tests/data/po/tutorial/it/tutorial.po
+++ b/tests/data/po/tutorial/it/tutorial.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Pootle Tests\n"
+
+#: fish.c
+msgid "fish"
+msgstr ""
+
+#: test.c
+msgid "test"
+msgstr "rest"
+
+#: fish.c
+msgid "%d fish"
+msgid_plural "%d fishies"
+msgstr[0] ""
+msgstr[1] ""

--- a/tests/fixtures/mock.py
+++ b/tests/fixtures/mock.py
@@ -18,3 +18,10 @@ from _pytest.monkeypatch import monkeypatch
 # functions, therefore the patching has no effect
 mp = monkeypatch()
 mp.setattr('django.utils.functional.cached_property', property)
+
+
+class FakeJob(object):
+    id = 'FAKE_JOB_ID'
+
+
+mp.setattr('rq.get_current_job', lambda: FakeJob())

--- a/tests/fixtures/models/language.py
+++ b/tests/fixtures/models/language.py
@@ -69,6 +69,12 @@ def spanish(english):
 
 
 @pytest.fixture
+def italian(english):
+    """Require the Spanish language."""
+    return _require_language('it', 'Italian')
+
+
+@pytest.fixture
 def fish(english):
     """Require the Fish language ><(((º>"""
     return _require_language(code='fish', fullname='Fish')

--- a/tests/fixtures/models/store.py
+++ b/tests/fixtures/models/store.py
@@ -71,6 +71,13 @@ def af_tutorial_po(settings, afrikaans_tutorial, system):
 
 
 @pytest.fixture
+def it_tutorial_po(settings, italian_tutorial, system):
+    """Require the /it/tutorial/tutorial.po store."""
+    po_directory = settings.POOTLE_TRANSLATION_DIRECTORY
+    return _require_store(italian_tutorial, po_directory, 'tutorial.po')
+
+
+@pytest.fixture
 def af_tutorial_subdir_po(settings, afrikaans_tutorial, system):
     """Require the /af/tutorial/subdir/tutorial.po store."""
     po_directory = settings.POOTLE_TRANSLATION_DIRECTORY

--- a/tests/fixtures/models/translation_project.py
+++ b/tests/fixtures/models/translation_project.py
@@ -47,5 +47,11 @@ def french_tutorial(french, tutorial):
 
 @pytest.fixture
 def spanish_tutorial(spanish, tutorial):
-    """Require French Tutorial."""
+    """Require Spanish Tutorial."""
     return _require_tp(spanish, tutorial)
+
+
+@pytest.fixture
+def italian_tutorial(italian, tutorial):
+    """Require Italian Tutorial."""
+    return _require_tp(italian, tutorial)

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -248,6 +248,9 @@ def test_accept_suggestion_update_wordcount(it_tutorial_po, system):
     change the wordcount stats of the unit's store.
     """
 
+    # Parse store
+    it_tutorial_po.update(overwrite=False, only_newer=False)
+
     untranslated_unit = it_tutorial_po.getitem(0)
     suggestion_text = 'foo bar baz'
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -38,6 +38,14 @@ CACHES = {
     },
 }
 
+# Using synchronous mode for testing
+RQ_QUEUES = {
+    'default': {
+        'USE_REDIS_CACHE': 'redis',
+        'DEFAULT_TIMEOUT': 360,
+        'ASYNC': False,
+    },
+}
 
 # Mail server settings
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
Fix was landed here d278170  because of a release need. So if a suggestion is accepted for untranslated or fuzzy unit we mark WORDCOUNT_STATS field as dirty. It will refresh stats properly.

Initial implementation of tests was confusing.
There is `queue._async = False` in testing conf.
We don't create a real job object. We just run a function directly.
`get_current_job()` function is monkeypatched.

Fixes #3857