### PR TITLE
Change unit revision during store.update()

### DIFF
--- a/tests/data/po/tutorial/ru/update_set_last_sync_revision.po
+++ b/tests/data/po/tutorial/ru/update_set_last_sync_revision.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Pootle Tests\n"
+
+#: test.c
+msgid "1"
+msgstr ""
+
+#: fish.c
+msgid "2"
+msgstr "second"
+
+#: fish.c
+msgid "3"
+msgstr "third"

--- a/tests/data/po/tutorial/ru/update_set_last_sync_revision_updated.po
+++ b/tests/data/po/tutorial/ru/update_set_last_sync_revision_updated.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Pootle Tests\n"
+
+#: test.c
+msgid "1"
+msgstr ""
+
+#: fish.c
+msgid "3"
+msgstr "3"
+
+#: fish.c
+msgid "2"
+msgstr "2"
+
+#: fish.c
+msgid "4"
+msgstr "4"
+
+#: fish.c
+msgid "5"
+msgstr ""

--- a/tests/fixtures/models/store.py
+++ b/tests/fixtures/models/store.py
@@ -125,3 +125,11 @@ def ru_update_save_changed_units_po(settings, russian_tutorial, system):
     po_directory = settings.POOTLE_TRANSLATION_DIRECTORY
     return _require_store(russian_tutorial, po_directory,
                           'update_save_changed_units.po')
+
+
+@pytest.fixture
+def ru_update_set_last_sync_revision_po(settings, russian_tutorial, system):
+    """Require the /ru/tutorial/tutorial.po store."""
+    po_directory = settings.POOTLE_TRANSLATION_DIRECTORY
+    return _require_store(russian_tutorial, po_directory,
+                          'update_set_last_sync_revision.po')

--- a/tests/models/revision.py
+++ b/tests/models/revision.py
@@ -18,10 +18,14 @@ from .unit import _update_translation
 @pytest.mark.django_db
 def test_max_revision(af_tutorial_po):
     """Tests `max_revision()` gets the latest revision."""
+
+    # update a store first, initial_revision = 1 after this update
+    af_tutorial_po.update(overwrite=False, only_newer=False)
+
     initial_max_revision = Unit.max_revision()
     initial_revision = Revision.get()
     assert initial_max_revision == initial_revision
-    assert initial_max_revision == 0
+    assert initial_max_revision == 1
 
     # Let's make 10 translation updates, this must also update their
     # revision numbers
@@ -35,7 +39,7 @@ def test_max_revision(af_tutorial_po):
     assert end_max_revision != initial_max_revision
 
     assert end_revision != initial_revision
-    assert end_revision == 10
+    assert end_revision == 10 + initial_revision
 
 
 @pytest.mark.django_db

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -32,6 +32,7 @@ def _update_translation(store, item, new_values, sync=True):
 
     if 'translator_comment' in new_values:
         unit.translator_comment = new_values['translator_comment']
+        unit._comment_updated = True
 
     unit.submitted_on = timezone.now()
     unit.submitted_by = User.objects.get_system_user()


### PR DESCRIPTION
Before any store.update() or store.parse() we get a new incremented value of a global revision. Then we set revision of all changed units and store.last_sync_revision to this value.
All other changes come from Web UI will increment unit revision. It allows us to keep all changes for next sync.

Fixes #3881