### PR TITLE
Initialize from templates newly added TPs

### DIFF
--- a/pootle/apps/pootle_app/project_tree.py
+++ b/pootle/apps/pootle_app/project_tree.py
@@ -313,6 +313,26 @@ def translation_project_should_exist(language, project):
     return False
 
 
+def init_store_from_template(translation_project, template_store):
+    """Initialize a new file for `translation_project` using `template_store`.
+    """
+    if translation_project.file_style == 'gnu':
+        target_pootle_path, target_path = get_translated_name_gnu(translation_project,
+                                                                  template_store)
+    else:
+        target_pootle_path, target_path = get_translated_name(translation_project,
+                                                              template_store)
+
+    # Create the missing directories for the new TP.
+    target_dir = os.path.dirname(target_path)
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    output_file = template_store.file.store
+    output_file.settargetlanguage(translation_project.language.code)
+    output_file.savefile(target_path)
+
+
 def get_translated_name_gnu(translation_project, store):
     """Given a template :param:`store` and a :param:`translation_project` return
     target filename.


### PR DESCRIPTION
Fixes #3877.

I am still unable to get stats automatically calculated after TP creation from UI, but @ta2-1 said that it worked for him. It would be great if someone else can quickly test this. Instructions follow:

- Get test project files from https://drive.google.com/open?id=0B-8KVyCPnkZRbW1qMzVObk0xWW8
- Uncompress it on `translations` directory
- Open the browser and go to Admin -> Projects
- Create a new `test` project
- Run `update_stores --project=test` to get the files into the DB
- Go to http://127.0.0.1:8000/projects/test/admin/languages/ and add a new language (for example `gl`)
- Go to http://127.0.0.1:8000/gl/test/ and check that the TP is there and stats are calculated
- Check on `translations` directory that the files for the new TP are present there