### PR TITLE
Removing pot files from stats

### DIFF
--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -275,6 +275,9 @@ class Command(PootleCommand):
         if unit_filter:
             units = units.filter(**unit_filter)
 
+        # exclude template files from wordcount
+        units = units.exclude(store__file__endswith="pot")
+
         res = units.values('store', 'state') \
                    .annotate(wordcount=Sum('source_wordcount')) \
                    .order_by('store', 'state')

--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -275,9 +275,9 @@ class Command(PootleCommand):
         if unit_filter:
             units = units.filter(**unit_filter)
 
-
+        local_filetype = 'store__translation_project__project__localfiletype'
         res = units.values('store', 'state',
-                           'store__translation_project__project__localfiletype',
+                           local_filetype,
                            'store__file') \
                    .annotate(wordcount=Sum('source_wordcount')) \
                    .order_by('store', 'state')
@@ -288,11 +288,11 @@ class Command(PootleCommand):
         key = None
 
         for item in res.iterator():
-            # exclude template files from wordcount
-            fileext = os.path.splitext(item['store__file'])[1][1:]
-            project_fileext = item[
+            # only include files with ext matching project ext
+            file_ext = os.path.splitext(item['store__file'])[1][1:]
+            proj_ext = item[
                 'store__translation_project__project__localfiletype']
-            if not fileext == project_fileext:
+            if not file_ext == proj_ext:
                 continue
 
             if saved_id != item['store']:

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -2138,9 +2138,14 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             'translated': 0,
             'fuzzy': 0
         }
+
+        # only count files with an ext matching the project ext
+        proj_ext = self.translation_project.project.localfiletype
+
         # XXX: `order_by()` here is important as it removes the default
         # ordering for units. See #3897 for reference.
-        res = self.units.order_by().values('state') \
+        res = self.units.filter(store__file__endswith=proj_ext) \
+                        .order_by().values('state') \
                         .annotate(wordcount=models.Sum('source_wordcount'))
         for item in res:
             ret['total'] += item['wordcount']


### PR DESCRIPTION
When calculating wordcount stats don't include .pot template files

fixes #3245

as requested by @jleclanche - the process i followed was:

- looked at main project models to get better understanding of db architecture
- used grep to find out where stats where coming from in ui (which was mostly pointless)
- on realising that they are cached by refresh_stats used pdb to step through until i found what looked like a good place to add a filter
- checked that stats are correctly updated when further translations are completed