### PR TITLE
Restrict wordcount stats to project files

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -2162,9 +2162,14 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             'translated': 0,
             'fuzzy': 0
         }
+
+        # only count files with an ext matching the project ext
+        proj_ext = "." + self.translation_project.project.localfiletype
+
         # XXX: `order_by()` here is important as it removes the default
         # ordering for units. See #3897 for reference.
-        res = self.units.order_by().values('state') \
+        res = self.units.filter(store__name__endswith=proj_ext) \
+                        .order_by().values('state') \
                         .annotate(wordcount=models.Sum('source_wordcount'))
         for item in res:
             ret['total'] += item['wordcount']


### PR DESCRIPTION
when calculating wordcount stats only use files with extentions matching project.localfiletype

this removes .pot or other template files from the wordcount

fixes #3245