### PR TITLE
admin/admin cleanup

### DIFF
--- a/docs/server/upgrading.rst
+++ b/docs/server/upgrading.rst
@@ -179,6 +179,15 @@ To perform the upgrade follow the next steps:
 Post-upgrade adjustments
 ------------------------
 
+* Check that you can login as an admin user.  If your existing adin user has no
+  email address then you will not be able to login.  In order the fix this use
+  :djadmin:`createsuperuser` to create a new superuser, or to create a
+  temporary superuser to fix your existing one.
+
+  .. code-block:: bash
+
+     (env) $ pootle createsuperuser
+
 After a succesful upgrade you can now consider:
 
 * Implementing some :doc:`optimizations <optimization>` to your setup.

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -22,6 +22,6 @@ class Command(NoArgsCommand):
     help = 'Populates the database with initial values: users, projects, ...'
 
     def handle_noargs(self, **options):
-        logging.info('Populating the database.')
+        self.stdout.write('Populating the database.')
         initdb()
-        logging.info('Successfully populated the database.')
+        self.stdout.write('Successfully populated the database.')

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -25,3 +25,5 @@ class Command(NoArgsCommand):
         self.stdout.write('Populating the database.')
         initdb()
         self.stdout.write('Successfully populated the database.')
+        self.stdout.write("To create an admin user, use the `pootle "
+                          "createsuperuser` command.")

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -235,3 +235,28 @@ def check_settings(app_configs=None, **kwargs):
                 ))
 
     return errors
+
+
+@checks.register()
+def check_users(app_configs=None, **kwargs):
+    from django.contrib.auth import get_user_model
+    from django.db import ProgrammingError
+    from django.db.utils import OperationalError
+
+    errors = []
+
+    User = get_user_model()
+    try:
+        admin_user = User.objects.get(username='admin')
+    except (User.DoesNotExist, OperationalError, ProgrammingError):
+        pass
+    else:
+        if admin_user.check_password('admin'):
+            errors.append(checks.Warning(
+                _("The default 'admin' user still has a password set to "
+                  "'admin'."),
+                hint=_("Remove the 'admin' user or change its password."),
+                id="pootle.W016",
+            ))
+
+    return errors

--- a/pootle/core/initdb.py
+++ b/pootle/core/initdb.py
@@ -34,7 +34,6 @@ def initdb():
     create_pootle_permission_sets()
     create_default_projects()
     create_default_languages()
-    create_default_admin()
 
 
 def create_revision():
@@ -293,23 +292,3 @@ def create_default_languages():
             lang, created = Language.objects.get_or_create(**criteria)
         except:
             pass
-
-
-def create_default_admin():
-    """Create the default admin user for Pootle.
-
-    You definitely want to change the admin account so that your default
-    install is not accessible with the default credentials. The users 'noboby'
-    and 'default' should be left as is.
-    """
-    User = get_user_model()
-
-    criteria = {
-        'username': u"admin",
-        'full_name': u"Administrator",
-        'is_active': True,
-        'is_superuser': True,
-    }
-    admin = User(**criteria)
-    admin.set_password("admin")
-    admin.save()


### PR DESCRIPTION
This PR:

1. Adds a check for admin/admin and warns if the default password is still set (this should catch bad setup on old installs)
2. Removes the creation of admin from initdb

I did look at docs cleanup but it moved so quickly from a simple lets check if we need ``createadminuser`` instructions to a cleanup of the upgrade page.  So lets leave that out of this PR please.

I don't want to automate the default admin user creation but rather make that part of the setup of the server.  Installation should be fines, its documented.  Upgrade should also be fine as you'll have an admin user, you might however not have one with an email address but we can deal with that in the upgrade docs.