### PR TITLE
Redis version number

### DIFF
--- a/docs/releases/2.7.0.rst
+++ b/docs/releases/2.7.0.rst
@@ -13,7 +13,7 @@ Changes in Requirements
 - `Translate Toolkit <http://toolkit.translatehouse.org/download.html>`_ >=
   1.13.0
 - Python >= 2.7, < 3.0
-- Redis - latest stable release.
+- Redis >= 2.8.4
 - Unix-based operating system.
 
 


### PR DESCRIPTION
Latest stable release just says nothing about required version. I ran into this issue while installing new Pootle on my CentOS 6.6 server where latest redis is just 2.4. Please use a version number instead.