### PR TITLE
build_checks_templates uses StandardUnitsChecker and StandardChecker

### DIFF
--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -109,7 +109,7 @@ check_names = {
     'percent_brace_placeholders': _(u"Percent brace placeholders"),
 }
 
-excluded_filters = ['hassuggestion', 'spellcheck', 'isfuzzy', 'untranslated']
+excluded_filters = ['hassuggestion', 'spellcheck', 'isfuzzy', 'isreview', 'untranslated']
 
 # pre-compile all regexps
 

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,8 @@ class BuildChecksTemplatesCommand(Command):
         import django
         import codecs
         from pootle.apps.pootle_misc.checks import check_names, excluded_filters
-        from translate.filters.checks import TeeChecker
+        from translate.filters.checks import (TeeChecker,
+                                              StandardChecker, StandardUnitChecker)
         try:
             from docutils.core import publish_parts
         except ImportError:
@@ -185,7 +186,9 @@ class BuildChecksTemplatesCommand(Command):
 
         # Get a checker with the Translate Toolkit checks. Note that filters
         # that are not used in Pootle are excluded.
-        fd = TeeChecker().getfilters(excludefilters=excluded_filters)
+        fd = TeeChecker(
+            checkerclasses=[StandardChecker, StandardUnitChecker]
+        ).getfilters(excludefilters=excluded_filters)
 
         docs = sorted(
             get_check_description(name, f) for name, f in fd.items()


### PR DESCRIPTION
as the template was only being built from StandardChecker it was not generating descriptions for nplurals

fixes #3756