### PR TITLE
Display edit link for sidebar announcements

### DIFF
--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -477,6 +477,11 @@ td.stats-name a:hover > i + span,
     list-style: inherit;
 }
 
+.staticpage .edit-link
+{
+    font-size: small;
+}
+
 
 /*
  * CHECKS DESCRIPTIONS

--- a/pootle/templates/staticpages/_body.html
+++ b/pootle/templates/staticpages/_body.html
@@ -9,7 +9,14 @@
   {% endblocktrans %}
   </div>
   {% endif %}
-  <h1 class="title">{{ page.title }}</h1>
+  <h1 class="title">
+    {{ page.title }}
+    {% if user.is_superuser %}
+    <span class="edit-link">
+      [<a href="{% url 'pootle-staticpages-edit' pk=page.id page_type='announcements' %}">edit</a>]
+    </span>
+    {% endif %}
+  </h1>
   {% with language_code=language.code %}
   {{ page.body|rewrite_language_links:language_code }}
   {% endwith %}


### PR DESCRIPTION
Fixes #3861

Not sure it's right to get the `page_type` this way but couldn't figure out a better way, suggestions welcome.