### PR TITLE
Set #body height if it is less than the height of sidebar or content

### DIFF
--- a/pootle/static/js/helpers.js
+++ b/pootle/static/js/helpers.js
@@ -41,7 +41,7 @@ var helpers = {
                         $('#footer').height() + bodyPadding,
         newHeight = Math.max(contentAreaHeight, sidebarHeight);
 
-    if (bodyHeight < contentAreaHeight) {
+    if (bodyHeight < newHeight) {
       $body.css('height', newHeight);
     }
   },


### PR DESCRIPTION
Currently after calculating the max height of sidebar and content elements, #body height is only set if "contentAreaHeight" is bigger than #body height

This works in firefox at least, but doesnt work in chrome

This commit instead checks if the max height is bigger than #body - and if so it sets the #body height to the max value