### PR TITLE
Remember expanded details in overview page

### DIFF
--- a/pootle/core/url_helpers.py
+++ b/pootle/core/url_helpers.py
@@ -172,6 +172,10 @@ def get_previous_url(request):
             if '?' in referer_url:
                 referer_url = referer_url[:referer_url.index('?')]
 
+                # But append ?details if present
+                if parsed_referer.query == "details":
+                    referer_url = referer_url + "?details"
+
             return referer_url
 
     return reverse('pootle-home')

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -61,6 +61,8 @@ const stats = {
       e.preventDefault();
       this.refreshStats();
     });
+
+    this.reopenChecks();
   },
 
   refreshStats() {
@@ -261,7 +263,7 @@ const stats = {
     } else {
       // this is a single store stats, let's expand its details
       // only on first page load, and unless it is already expanded
-      if (firstPageLoad && !this.isExpanded) {
+      if (firstPageLoad && !this.checksStateIsOpen()) {
         this.toggleChecks();
       }
 
@@ -328,6 +330,8 @@ const stats = {
     this.$expandIcon.attr('title', newText);
 
     this.$extraDetails.slideToggle('slow', 'easeOutQuad');
+
+    this.checksStatePush();
   },
 
   loadChecks() {
@@ -366,11 +370,37 @@ const stats = {
 
       $('#js-stats-checks').show();
     }
-
     this.hasChecksData = true;
     this.toggleChecksVisibility();
-  }
+  },
 
+  checksStateIsOpen() {
+    return (window.location.search === '?details');
+  },
+
+  checksStatePush() {
+    if (window.history && window.history.pushState) {
+      if (!this.isExpanded) {
+	window.history.pushState("", "", this.pootlePath);
+      } else {
+	window.history.pushState("", "", "?details");
+      }
+    }
+  },
+
+  reopenChecks() {
+    var self = this;
+    if (this.checksStateIsOpen() && !this.isExpanded) {
+      this.toggleChecks();
+    }
+    window.onpopstate = function (e) {
+      if (self.checksStateIsOpen() && !self.isExpanded) {
+        self.toggleChecks();
+      } else if (!self.checksStateIsOpen() && self.isExpanded) {
+        self.toggleChecks();
+      }
+    }
+  }
 };
 
 


### PR DESCRIPTION
When user expands details, this is remembered if the user returns.

This implementation uses history.pushState

fixes #3784