### PR TITLE
Use suggestions on upload conflicts

### DIFF
--- a/pootle/apps/import_export/utils.py
+++ b/pootle/apps/import_export/utils.py
@@ -30,13 +30,6 @@ def import_file(file):
 
     try:
         store, created = Store.objects.get_or_create(pootle_path=pootle_path)
-        if rev < store.get_max_unit_revision():
-            # TODO we could potentially check at the unit level and only reject
-            # units older than most recent. But that's in store.update().
-            raise ValueError(
-                _("File '%s' was rejected because its X-Pootle-Revision is too old.")
-                % (file.name)
-            )
     except Exception as e:
         raise ValueError(
             _("Could not create '%s'. Missing Project/Language? (%s)")

--- a/tests/data/po/tutorial/en/tutorial.po
+++ b/tests/data/po/tutorial/en/tutorial.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Pootle Tests\n"
+
+
+#: Hello, world
+msgid "Hello, world"
+msgstr ""

--- a/tests/data/po/tutorial/en/tutorial_update.po
+++ b/tests/data/po/tutorial/en/tutorial_update.po
@@ -7,9 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Pootle Tests\n"
 "X-Pootle-Path: /en/tutorial/tutorial.po\n"
-"X-Pootle-Revision: 0\n"
-
+"X-Pootle-Revision: 1\n"
 
 #: Hello, world
 msgid "Hello, world"
-msgstr ""
+msgstr "Hello, world UPDATED"

--- a/tests/data/po/tutorial/en/tutorial_update_conflict.po
+++ b/tests/data/po/tutorial/en/tutorial_update_conflict.po
@@ -9,7 +9,6 @@ msgstr ""
 "X-Pootle-Path: /en/tutorial/tutorial.po\n"
 "X-Pootle-Revision: 0\n"
 
-
 #: Hello, world
 msgid "Hello, world"
-msgstr ""
+msgstr "Hello, world CONFLICT"

--- a/tests/data/po/tutorial/en/tutorial_update_new_unit.po
+++ b/tests/data/po/tutorial/en/tutorial_update_new_unit.po
@@ -7,9 +7,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Pootle Tests\n"
 "X-Pootle-Path: /en/tutorial/tutorial.po\n"
-"X-Pootle-Revision: 0\n"
-
+"X-Pootle-Revision: 1\n"
 
 #: Hello, world
 msgid "Hello, world"
-msgstr ""
+msgstr "Hello, world"
+
+
+#: Goodbye, world
+msgid "Goodbye, world"
+msgstr "Goodbye, world"

--- a/tests/data/po/tutorial/en/tutorial_update_old_unit.po
+++ b/tests/data/po/tutorial/en/tutorial_update_old_unit.po
@@ -9,7 +9,10 @@ msgstr ""
 "X-Pootle-Path: /en/tutorial/tutorial.po\n"
 "X-Pootle-Revision: 0\n"
 
-
 #: Hello, world
 msgid "Hello, world"
-msgstr ""
+msgstr "Hello, world"
+
+#: Goodbye, world
+msgid "Goodbye, world"
+msgstr "Goodbye, world"

--- a/tests/fixtures/models/store.py
+++ b/tests/fixtures/models/store.py
@@ -75,6 +75,13 @@ def af_tutorial_po(settings, afrikaans_tutorial, system):
 
 
 @pytest.fixture
+def en_tutorial_po(settings, english_tutorial, system):
+    """Require the /en/tutorial/tutorial.po store."""
+    return _require_store(english_tutorial,
+                          settings.POOTLE_TRANSLATION_DIRECTORY, 'tutorial.po')
+
+
+@pytest.fixture
 def it_tutorial_po(settings, italian_tutorial, system):
     """Require the /it/tutorial/tutorial.po store."""
     return _require_store(italian_tutorial,

--- a/tests/fixtures/models/translation_project.py
+++ b/tests/fixtures/models/translation_project.py
@@ -40,6 +40,12 @@ def arabic_tutorial_obsolete(arabic, tutorial):
 
 
 @pytest.fixture
+def english_tutorial(english, tutorial):
+    """Require English Tutorial."""
+    return _require_tp(english, tutorial)
+
+
+@pytest.fixture
 def french_tutorial(french, tutorial):
     """Require French Tutorial."""
     return _require_tp(french, tutorial)

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -12,6 +12,9 @@ import time
 
 import pytest
 
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from translate.storage.factory import getclass
 from pootle.core.models import Revision
 
 from .unit import _update_translation
@@ -170,3 +173,86 @@ def test_update_set_last_sync_revision(ru_update_set_last_sync_revision_po):
     assert store.last_sync_revision == next_revision
     unit = store.getitem(item_index)
     assert unit.revision == store.last_sync_revision + 1
+
+
+@pytest.mark.django_db
+def test_update_upload_new_revision(en_tutorial_po):
+    en_tutorial_po.update(overwrite=False, only_newer=False)
+    update_file = "tests/data/po/tutorial/en/tutorial_update.po"
+    with open(update_file, "r") as f:
+        upload = SimpleUploadedFile(os.path.basename(update_file),
+                                    f.read(),
+                                    "text/x-gettext-translation")
+    test_store = getclass(upload)(upload.read())
+    en_tutorial_po.update(overwrite=True, store=test_store)
+    assert en_tutorial_po.units[0].target == "Hello, world UPDATED"
+
+
+@pytest.mark.django_db
+def test_update_upload_old_revision_unit_conflict(en_tutorial_po):
+    en_tutorial_po.update(overwrite=False, only_newer=False)
+    update_file = "tests/data/po/tutorial/en/tutorial_update.po"
+
+    # load initial update
+    with open(update_file, "r") as f:
+        upload = SimpleUploadedFile(os.path.basename(update_file),
+                                    f.read(),
+                                    "text/x-gettext-translation")
+    test_store = getclass(upload)(upload.read())
+    en_tutorial_po.update(overwrite=True, store=test_store)
+
+    # load update with expired revision and conflicting unit
+    update_file = "tests/data/po/tutorial/en/tutorial_update_conflict.po"
+    with open(update_file, "r") as f:
+        upload = SimpleUploadedFile(os.path.basename(update_file),
+                                    f.read(),
+                                    "text/x-gettext-translation")
+    test_conflict_store = getclass(upload)(upload.read())
+    en_tutorial_po.update(overwrite=True, store=test_conflict_store)
+
+    # unit target is not updated
+    assert en_tutorial_po.units[0].target == "Hello, world UPDATED"
+
+    # but suggestion is added
+    suggestion = en_tutorial_po.units[0].get_suggestions()[0].target
+    assert suggestion == "Hello, world CONFLICT"
+
+
+@pytest.mark.django_db
+def test_update_upload_new_revision_new_unit(en_tutorial_po):
+    en_tutorial_po.update(overwrite=False, only_newer=False)
+    update_file = "tests/data/po/tutorial/en/tutorial_update_new_unit.po"
+    with open(update_file, "r") as f:
+        upload = SimpleUploadedFile(os.path.basename(update_file),
+                                    f.read(),
+                                    "text/x-gettext-translation")
+    test_store = getclass(upload)(upload.read())
+    en_tutorial_po.update(overwrite=True, store=test_store)
+
+    # the new unit has been added
+    assert en_tutorial_po.units[1].target == 'Goodbye, world'
+
+
+@pytest.mark.django_db
+def test_update_upload_old_revision_new_unit(en_tutorial_po):
+    en_tutorial_po.update(overwrite=False, only_newer=False)
+    update_file = "tests/data/po/tutorial/en/tutorial_update.po"
+
+    # load initial update
+    with open(update_file, "r") as f:
+        upload = SimpleUploadedFile(os.path.basename(update_file),
+                                    f.read(),
+                                    "text/x-gettext-translation")
+    test_store = getclass(upload)(upload.read())
+
+    # load old revision with new unit
+    update_file = "tests/data/po/tutorial/en/tutorial_update_old_unit.po"
+    with open(update_file, "r") as f:
+        upload = SimpleUploadedFile(os.path.basename(update_file),
+                                    f.read(),
+                                    "text/x-gettext-translation")
+    test_store = getclass(upload)(upload.read())
+    en_tutorial_po.update(overwrite=True, store=test_store)
+
+    # the new unit has not been added
+    assert len(en_tutorial_po.units) == 1


### PR DESCRIPTION
If user uploads translation file with version number less than a unit to be
updated (ie unit has been edited ttw since translation file was downloaded),
then add the uploaded unit as a suggestion instead of updating.

Touch #3975