### PR TITLE
Projects dropdown: visually differentiate disabled projects

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -36,6 +36,16 @@ Details of changes
   is now built on the client. This requires refreshing all server stats using
   the :djadmin:`refresh_stats_rq` command (:issue:`3835`).
 
+- Disabled projects are visually differentiated in the projects drop-down
+  (:issue:`3996`).
+  Since the in-cache data structure supporting this changed, it's necessary to
+  clear the cache. Assuming your ``default`` cache lives in the DB number ``1``,
+  you can clear it as follows:
+
+  .. code-block:: bash
+
+    $ redis-cli -n 1 KEYS "*method-cache:Project:cached_dict:*" | xargs redis-cli -n 1 DEL
+
 - Pulled latest translations.
 
 

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -62,9 +62,11 @@ class ProjectManager(models.Manager):
         projects = cache.get(cache_key)
         if not projects:
             logging.debug('Cache miss for %s', cache_key)
+            projects_dict = self.for_user(user).order_by('fullname') \
+                                               .values('code', 'fullname',
+                                                       'disabled')
             projects = OrderedDict(
-                self.for_user(user).order_by('fullname')
-                                   .values_list('code', 'fullname')
+                (project.pop('code'), project) for project in projects_dict
             )
             cache.set(cache_key, projects, settings.POOTLE_CACHE_TIMEOUT)
 

--- a/pootle/static/css/breadcrumbs.css
+++ b/pootle/static/css/breadcrumbs.css
@@ -108,6 +108,12 @@
 }
 /* END HACK */
 
+.select2-results .project-disabled
+{
+    font-style: italic;
+    opacity: 0.5;
+}
+
 .select2-results .folder
 {
     font-weight: bold;

--- a/pootle/static/js/browser.js
+++ b/pootle/static/js/browser.js
@@ -134,6 +134,13 @@ var formatResource = function (path, container, query) {
 };
 
 
+function formatProject(path, container, query) {
+  const state = path.element[0].dataset.state;
+
+  return `<span class="text project-${state}">${path.text}</span>`;
+};
+
+
 var removeCtxEntries = function (results, container, query) {
   if (query.term) {
     return _.filter(results, function (result) {
@@ -156,7 +163,8 @@ var browser = {
       placeholder: gettext("All Languages")
     });
     makeNavDropdown(sel.project, {
-      placeholder: gettext("All Projects")
+      placeholder: gettext("All Projects"),
+      formatResult: formatProject,
     });
     makeNavDropdown(sel.resource, {
       placeholder: gettext("Entire Project"),

--- a/pootle/templates/core/_breadcrumbs.html
+++ b/pootle/templates/core/_breadcrumbs.html
@@ -20,8 +20,12 @@
   <select id="js-select-project" data-initial-code="{{ project.code }}"
     style="visibility: hidden;">
     <option value=""></option>
-    {% for proj_code, proj_name in ALL_PROJECTS.items %}
-    <option value="{{ proj_code }}">{{ proj_name }}</option>
+    {% for proj_code, proj in ALL_PROJECTS.items %}
+    <option
+      value="{{ proj_code }}"
+      data-state="{{ proj.disabled|yesno:'disabled,enabled' }}">
+      {{ proj.fullname }}
+    </option>
     {% endfor %}
   </select>
 </li>


### PR DESCRIPTION
Note this changes the data for projects stored in the cache, so it needs to be cleared for the new structure to work correctly.

PRing so everyone is aware of the change in the cache. Would be great if someone can come up with a better way to communicate this, especially across versions.

Fixes #3996.