### PR TITLE
Set attribution on User.delete

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -22,6 +22,7 @@ Major Changes
 
 - Updated translations.
 - Added django-transaction-hooks
+- Changed user delete behaviour
 
 
 Below we provide much more detail. These are by no means exhaustive, view the
@@ -65,12 +66,31 @@ Django transaction hooks
   - postgres: transaction_hooks.backends.postgresql_psycopg2
 
 
+Changed user delete behaviour
+-----------------------------
+
+On deleting a user account their submissions, suggestions and reviews are now
+re-assigned to the "nobody" user.
+
+If you wish to remove the user's contributions also, you can use the
+:djadmin:`purge_user` command, or call ``user.delete(purge=True)`` to delete the
+user programatically.
+
+
 Command changes and additions
 -----------------------------
 
 - Added a :djadmin:`contributors` command to get the list of contributors
   (:issue:`3867`).
 
+- Added a :djadmin:`merge_user` command to get merge submissions, comments and
+  reviews from one user account to another. This is useful for fixing users
+  that have multiple accounts and want them to be combined. No profile data
+  is merged.
+
+- Added a :djadmin:`purge_user` command to purge a user from the site and revert
+  any submissions, comments and reviews that they have made. This is useful to
+  revert spam or a malicious user.
 
 ...and lots of refactoring, cleanups to remove old Django versions specifics,
 improved documentation and of course, loads of bugs were fixed.

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -636,6 +636,52 @@ and the process will start a watchdog to track any client-side scripts for
 changes. Use this only when developing Pootle.
 
 
+.. _commands#user-management:
+
+Managing users
+--------------
+
+
+.. django-admin:: merge_user
+
+merge_user
+^^^^^^^^^^
+
+.. versionadded:: 2.7.1
+
+This can be used if you have a user with two accounts and need to merge one
+account into another. This will re-assign all submissions, units and
+suggestions, but not any of the user's profile data.
+
+This command requires 2 mandatory arguments, ``src_username`` and
+``target_username``, both should be valid usernames for users of your site.
+Submissions from the first are re-assigned to the second. The users' profile
+data is not merged.
+
+.. code-block:: bash
+
+    $ pootle merge_user src_username target_username
+
+
+.. django-admin:: purge_user
+
+purge_user
+^^^^^^^^^^
+
+.. versionadded:: 2.7.1
+
+This command can be used if you wish to permanently remove a user and revert
+the edits, comments and reviews that the user has made. This is useful for
+removing a spam account or other malicious user.
+
+This command requires a mandatory ``username`` argument, which should be a valid
+username for a user of your site.
+
+.. code-block:: bash
+
+    $ pootle purge_user username
+
+
 .. _commands#running:
 
 Running WSGI servers

--- a/pootle/apps/accounts/management/commands/__init__.py
+++ b/pootle/apps/accounts/management/commands/__init__.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+
+User = get_user_model()
+
+
+class UserCommand(BaseCommand):
+    """Base class for handling user commands."""
+
+    args = "user"
+
+    def handle(self, *args, **kwargs):
+        self.check_args(*args)
+
+    def create_parser(self, prog_name, subcommand):
+        self.prog_name = prog_name
+        self.subcommand = subcommand
+        return super(UserCommand, self).create_parser(prog_name, subcommand)
+
+    def get_user(self, username):
+        try:
+            return User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise CommandError("User %s does not exist" % username)
+
+    def usage_string(self):
+        return self.usage(self.subcommand).replace('%prog', self.prog_name)
+
+    def check_args(self, *args):
+        if len(args) != len(self.args.split(" ")):
+            raise CommandError("Wrong number of arguments\n\n%s"
+                               % self.usage_string())

--- a/pootle/apps/accounts/management/commands/merge_user.py
+++ b/pootle/apps/accounts/management/commands/merge_user.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import accounts
+
+from . import UserCommand
+
+
+class Command(UserCommand):
+    args = "user other_user"
+    help = "Merge user to other_user"
+
+    def handle(self, *args, **kwargs):
+        super(Command, self).handle(*args, **kwargs)
+        accounts.utils.UserMerger(self.get_user(username=args[0]),
+                                  self.get_user(username=args[1])).merge()

--- a/pootle/apps/accounts/management/commands/purge_user.py
+++ b/pootle/apps/accounts/management/commands/purge_user.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from . import UserCommand
+
+
+class Command(UserCommand):
+    args = "user"
+    help = "Delete user and all related objects"
+
+    def handle(self, *args, **kwargs):
+        super(Command, self).handle(*args, **kwargs)
+        self.get_user(args[0]).delete(purge=True)

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -38,6 +38,7 @@ from pootle_statistics.models import Submission, SubmissionTypes
 from pootle_store.models import SuggestionStates, Unit
 
 from .managers import UserManager
+from .utils import UserMerger, UserPurger
 
 
 CURRENCIES = (('USD', 'USD'), ('EUR', 'EUR'), ('CNY', 'CNY'), ('JPY', 'JPY'))
@@ -240,6 +241,13 @@ class User(AbstractBaseUser):
         """
         if self.is_meta:
             raise ProtectedError('Cannot remove meta user instances', None)
+
+        purge = kwargs.pop("purge", False)
+
+        if purge:
+            UserPurger(self).purge()
+        else:
+            UserMerger(self, User.objects.get_nobody_user()).merge()
 
         super(User, self).delete(*args, **kwargs)
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -35,7 +35,7 @@ from pootle.core.cache import make_method_key
 from pootle.core.utils.json import jsonify
 from pootle_language.models import Language
 from pootle_statistics.models import Submission, SubmissionTypes
-from pootle_store.models import SuggestionStates
+from pootle_store.models import SuggestionStates, Unit
 
 from .managers import UserManager
 
@@ -320,8 +320,23 @@ class User(AbstractBaseUser):
         return 'https://secure.gravatar.com/avatar/%s?s=%d&d=mm' % \
             (self.email_hash, size)
 
+    def get_suggestion_reviews(self):
+        return self.submission_set.get_unit_suggestion_reviews()
+
     def get_unit_rows(self):
         return min(max(self.unit_rows, 5), 49)
+
+    def get_unit_states_changed(self):
+        return self.submission_set.get_unit_state_changes()
+
+    def get_units_created(self):
+        """Units that were created by this user.
+
+        :return: Queryset of `Unit`s that were created by this user.
+        """
+        return (Unit.objects
+                    .filter(pk__in=(self.submission_set.get_unit_creates()
+                                        .values_list("unit", flat=True))))
 
     def pending_suggestion_count(self, tp):
         """Returns the number of pending suggestions for the user in the given

--- a/pootle/apps/accounts/utils.py
+++ b/pootle/apps/accounts/utils.py
@@ -7,9 +7,19 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import functools
+import logging
+import sys
+
 from django.contrib.auth import get_user_model
 
 from allauth.account.models import EmailAddress
+
+from pootle_store.models import SuggestionStates
+from pootle_store.util import FUZZY, UNTRANSLATED
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_user_by_email(email):
@@ -30,3 +40,312 @@ def get_user_by_email(email):
             return User.objects.get(email__iexact=email)
         except User.DoesNotExist:
             return None
+
+
+def write_stdout(start_msg, end_msg="DONE\n", fail_msg="FAILED\n"):
+
+    def class_wrapper(f):
+
+        @functools.wraps(f)
+        def method_wrapper(self, *args, **kwargs):
+            sys.stdout.write(start_msg % self.__dict__)
+            try:
+                f(self, *args, **kwargs)
+            except Exception as e:
+                sys.stdout.write(fail_msg % self.__dict__)
+                raise e
+            sys.stdout.write(end_msg % self.__dict__)
+        return method_wrapper
+    return class_wrapper
+
+
+class UserMerger(object):
+
+    def __init__(self, src_user, target_user):
+        """Purges src_user from site reverting any changes that they have made.
+
+        :param src_user: `User` instance to merge from.
+        :param target_user: `User` instance to merge to.
+        """
+        self.src_user = src_user
+        self.target_user = target_user
+
+    @write_stdout("Merging user: "
+                  "%(src_user)s --> %(target_user)s...\n",
+                  "User merged: %(src_user)s --> %(target_user)s \n")
+    def merge(self):
+        """Merges one user to another.
+
+        The following are fields are updated (model: fields):
+        - units: submitted_by, commented_by, reviewed_by
+        - submissions: submitter
+        - suggestions: user, reviewer
+        """
+        self.merge_submitted()
+        self.merge_commented()
+        self.merge_reviewed()
+        self.merge_submissions()
+        self.merge_suggestions()
+        self.merge_reviews()
+
+    @write_stdout(" * Merging units comments: "
+                  "%(src_user)s --> %(target_user)s... ")
+    def merge_commented(self):
+        """Merge commented_by attribute on units
+        """
+        for unit in self.src_user.commented.iterator():
+            unit.commented_by = self.target_user
+            unit.save()
+            logger.debug("Unit commented_by updated: %s" % repr(unit))
+
+    @write_stdout(" * Merging units reviewed: "
+                  "%(src_user)s --> %(target_user)s... ")
+    def merge_reviewed(self):
+        """Merge reviewed_by attribute on units
+        """
+        # Update submitted_by, commented_by and reviewed_by on units
+        for unit in self.src_user.reviewed.iterator():
+            unit.reviewed_by = self.target_user
+            unit.save()
+            logger.debug("Unit reviewed_by updated: %s" % repr(unit))
+
+    @write_stdout(" * Merging suggestion reviews: "
+                  "%(src_user)s --> %(target_user)s... ")
+    def merge_reviews(self):
+        """Merge reviewer attribute on suggestions
+        """
+        for suggestion in self.src_user.reviews.iterator():
+            suggestion.reviewer = self.target_user
+            suggestion.save()
+            logger.debug("Suggestion reviewer updated: %s" % suggestion)
+
+    @write_stdout(" * Merging remaining submissions: "
+                  "%(src_user)s --> %(target_user)s... ")
+    def merge_submissions(self):
+        """Merge submitter attribute on submissions
+        """
+        # Update submitter on submissions
+        for submission in self.src_user.submission_set.iterator():
+            submission.submitter = self.target_user
+
+            # Before we can save we first have to remove existing score_logs
+            # for this submission - they will be recreated on save with correct
+            # user.
+            for score_log in submission.scorelog_set.iterator():
+                score_log.delete()
+            submission.save()
+            logger.debug("Submission submitter updated: %s" % submission)
+
+    @write_stdout(" * Merging units submitted_by: "
+                  "%(src_user)s --> %(target_user)s... ")
+    def merge_submitted(self):
+        """Merge submitted_by attribute on units
+        """
+        for unit in self.src_user.submitted.iterator():
+            unit.submitted_by = self.target_user
+            unit.save()
+            logger.debug("Unit submitted_by updated: %s" % repr(unit))
+
+    @write_stdout(" * Merging suggestions: "
+                  "%(src_user)s --> %(target_user)s... ")
+    def merge_suggestions(self):
+        """Merge user attribute on suggestions
+        """
+        # Update user and reviewer on suggestions
+        for suggestion in self.src_user.suggestions.iterator():
+            suggestion.user = self.target_user
+            suggestion.save()
+            logger.debug("Suggestion user updated: %s" % suggestion)
+
+
+class UserPurger(object):
+
+    def __init__(self, user):
+        """Purges user from site reverting any changes that they have made.
+
+        :param user: `User` to purge.
+        """
+        self.user = user
+
+    @write_stdout("Purging user: %(user)s... \n", "User purged: %(user)s \n")
+    def purge(self):
+        """Purges user from site reverting any changes that they have made.
+
+        The following steps are taken:
+        - Delete units created by user and without other submissions.
+        - Revert units edited by user.
+        - Revert reviews made by user.
+        - Revert unit comments by user.
+        - Revert unit state changes by user.
+        - Delete any remaining submissions and suggestions.
+        """
+
+        self.remove_units_created()
+        self.revert_units_edited()
+        self.revert_units_reviewed()
+        self.revert_units_commented()
+        self.revert_units_state_changed()
+
+        # Delete remaining submissions.
+        for submission in self.user.submission_set.iterator():
+            submission.delete()
+            logger.debug("Submission deleted: %s" % submission)
+
+        # Delete remaining suggestions.
+        for suggestion in self.user.suggestions.iterator():
+            suggestion.delete()
+            logger.debug("Suggestion deleted: %s" % suggestion)
+
+    @write_stdout(" * Removing units created by: %(user)s... ")
+    def remove_units_created(self):
+        """Remove units created by user that have not had further
+        activity.
+        """
+
+        # Delete units created by user without submissions by others.
+        for unit in self.user.get_units_created().iterator():
+
+            # Find submissions by other users on this unit.
+            other_subs = unit.submission_set.exclude(submitter=self.user)
+
+            if not other_subs.exists():
+                unit.delete()
+                logger.debug("Unit deleted: %s" % repr(unit))
+
+    @write_stdout(" * Reverting unit comments by: %(user)s... ")
+    def revert_units_commented(self):
+        """Revert comments made by user on units to previous comment or else
+        just remove the comment.
+        """
+
+        # Revert unit comments where self.user is latest commenter.
+        for unit in self.user.commented.iterator():
+
+            # Find comments by other self.users
+            comments = unit.get_comments().exclude(submitter=self.user)
+
+            if comments.exists():
+                # If there are previous comments by others update the
+                # translator_comment, commented_by, and commented_on
+                last_comment = comments.latest('pk')
+                unit.translator_comment = last_comment.new_value
+                unit.commented_by = last_comment.submitter
+                unit.commented_on = last_comment.creation_time
+                logger.debug("Unit comment reverted: %s" % repr(unit))
+            else:
+                unit.translator_comment = ""
+                unit.commented_by = None
+                unit.commented_on = None
+                logger.debug("Unit comment removed: %s" % repr(unit))
+
+            # Increment revision
+            unit._comment_updated = True
+            unit.save()
+
+    @write_stdout(" * Reverting units edited by: %(user)s... ")
+    def revert_units_edited(self):
+        """Revert unit edits made by a user to previous edit.
+        """
+        # Revert unit target where user is the last submitter.
+        for unit in self.user.submitted.iterator():
+
+            # Find the last submission by different user that updated the
+            # unit.target.
+            edits = unit.get_edits().exclude(submitter=self.user)
+
+            if edits.exists():
+                last_edit = edits.latest("pk")
+                unit.target_f = last_edit.new_value
+                unit.submitted_by = last_edit.submitter
+                unit.submitted_on = last_edit.creation_time
+                logger.debug("Unit edit reverted: %s" % repr(unit))
+            else:
+                # if there is no previous submissions set the target to ""
+                # and set the unit.submitted_by to None
+                unit.target_f = ""
+                unit.submitted_by = None
+                unit.submitted_on = unit.creation_time
+                logger.debug("Unit edit removed: %s" % repr(unit))
+
+            # Increment revision
+            unit._target_updated = True
+            unit.save()
+
+    @write_stdout(" * Reverting units reviewed by: %(user)s... ")
+    def revert_units_reviewed(self):
+        """Revert reviews made by user on suggestions to previous state.
+        """
+
+        # Revert reviews by this user.
+        for review in self.user.get_suggestion_reviews().iterator():
+            suggestion = review.suggestion
+            if suggestion.user == self.user:
+                # If the suggestion was also created by this user then remove
+                # both review and suggestion.
+                suggestion.delete()
+                logger.debug("Suggestion removed: %s" % (suggestion))
+            elif suggestion.reviewer == self.user:
+                # If the suggestion is showing as reviewed by the user, then
+                # set the suggestion back to pending and update
+                # reviewer/review_time.
+                suggestion.state = SuggestionStates.PENDING
+                suggestion.reviewer = None
+                suggestion.review_time = None
+                suggestion.save()
+                logger.debug("Suggestion reverted: %s" % (suggestion))
+
+            # Remove the review.
+            review.delete()
+
+        for unit in self.user.reviewed.iterator():
+            reviews = (unit.get_suggestion_reviews()
+                           .exclude(submitter=self.user))
+            if reviews.exists():
+                previous_review = reviews.latest('pk')
+                unit.reviewed_by = previous_review.submitter
+                unit.reviewed_on = previous_review.creation_time
+                logger.debug("Unit reviewed_by reverted: %s"
+                             % (repr(unit)))
+            else:
+                unit.reviewed_by = None
+                unit.reviewed_on = None
+
+                # Increment revision
+                unit._target_updated = True
+                logger.debug("Unit reviewed_by removed: %s"
+                             % (repr(unit)))
+            unit.save()
+
+    @write_stdout(" * Reverting unit state changes by: %(user)s... ")
+    def revert_units_state_changed(self):
+        """Revert unit edits made by a user to previous edit.
+        """
+        for submission in self.user.get_unit_states_changed().iterator():
+            unit = submission.unit
+
+            # We have to get latest by pk as on mysql precision is not to
+            # microseconds - so creation_time can be ambiguous
+            if submission != unit.get_state_changes().latest('pk'):
+                # If the unit has been changed more recently we don't need to
+                # revert the unit state.
+                submission.delete()
+                return
+            submission.delete()
+            other_submissions = (unit.get_state_changes()
+                                     .exclude(submitter=self.user))
+            if other_submissions.exists():
+                new_state = other_submissions.latest('pk').new_value
+            else:
+                new_state = UNTRANSLATED
+            if new_state != unit.state:
+                if unit.state == FUZZY:
+                    unit.markfuzzy(False)
+                elif new_state == FUZZY:
+                    unit.markfuzzy(True)
+                unit.state = new_state
+
+                # Increment revision
+                unit._state_updated = True
+                unit.save()
+                logger.debug("Unit state reverted: %s"
+                             % (repr(unit)))

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -847,6 +847,20 @@ class Unit(models.Model, base.TranslationUnit):
     def get_active_qualitychecks(self):
         return self.qualitycheck_set.filter(false_positive=False)
 
+##################### Related Submissions ########################
+
+    def get_edits(self):
+        return self.submission_set.get_unit_edits()
+
+    def get_comments(self):
+        return self.submission_set.get_unit_comments()
+
+    def get_state_changes(self):
+        return self.submission_set.get_unit_state_changes()
+
+    def get_suggestion_reviews(self):
+        return self.submission_set.get_unit_suggestion_reviews()
+
 ##################### TranslationUnit ############################
 
     def update_tmserver(self):

--- a/pootle/static/js/admin/components/UserForm.js
+++ b/pootle/static/js/admin/components/UserForm.js
@@ -49,7 +49,7 @@ let UserForm = React.createClass({
     let model = this.getResource();
     let { errors } = this.state;
     let { formData } = this.state;
-    let deleteHelpText = gettext('Note: deleting the user will make its suggestions and translations become attributed to an anonymous user (nobody).');
+    let deleteHelpText = gettext('Note: when deleting a user their contributions to the site, eg comments, suggestions and translations, are attributed to the anonymous user (nobody).');
 
     return (
       <form method="post"

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -268,7 +268,7 @@ def test_apiview_put(rf):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_apiview_delete(rf):
+def test_apiview_delete(rf, trans_nobody):
     """Tests deleting an object using the API."""
     view = UserAPIView.as_view()
 

--- a/tests/data/po/tutorial/en/tutorial_update_evil.po
+++ b/tests/data/po/tutorial/en/tutorial_update_evil.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Pootle Tests\n"
+"X-Pootle-Path: /en/tutorial/tutorial.po\n"
+"X-Pootle-Revision: 5\n"
+
+#: Hello, world
+msgid "Hello, world"
+msgstr "Hello, world EVIL"
+
+
+#: Goodbye, world
+msgid "Goodbye, world"
+msgstr "Goodbye, world EVIL"

--- a/tests/fixtures/models/user.py
+++ b/tests/fixtures/models/user.py
@@ -39,6 +39,12 @@ def nobody(db):
 
 
 @pytest.fixture
+def trans_nobody(transactional_db):
+    """Require the default anonymous user for use in a transactional test."""
+    return _require_user('nobody', 'any anonymous user')
+
+
+@pytest.fixture
 def default(transactional_db):
     """Require the default authenticated user."""
     return _require_user('default', 'any authenticated user',

--- a/tests/fixtures/models/user.py
+++ b/tests/fixtures/models/user.py
@@ -68,3 +68,15 @@ def admin(transactional_db):
 def member(db):
     """Require a member user."""
     return _require_user('member', 'Member')
+
+
+@pytest.fixture
+def member2(db):
+    """Require a member2 user."""
+    return _require_user('member2', 'Member2')
+
+
+@pytest.fixture
+def evil_member(transactional_db):
+    """Require a evil_member user."""
+    return _require_user('evil_member', 'Evil member')

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+import accounts
+from pootle_store.util import FUZZY, TRANSLATED
+
+from tests.fixtures.models.store import (TEST_EVIL_UPDATE_PO,
+                                         _create_submission_and_suggestion,
+                                         _create_comment_on_unit)
+
+
+def _make_evil_member_updates(store, evil_member):
+    # evil_member makes following changes:
+    #   - rejects member's suggestion on unit
+    #   - changes unit
+    #   - adds another suggestion on unit
+    #   - accepts their own suggestion
+    #   - adds a comment on unit
+    #   - adds another unit
+    member_suggestion = store.units[0].get_suggestions().first()
+    unit = store.units[0]
+    unit.reject_suggestion(member_suggestion,
+                           store.units[0].store.translation_project,
+                           evil_member)
+    _create_submission_and_suggestion(store,
+                                      evil_member,
+                                      filename=TEST_EVIL_UPDATE_PO,
+                                      suggestion="EVIL SUGGESTION")
+    evil_suggestion = store.units[0].get_suggestions().first()
+    store.units[0].accept_suggestion(evil_suggestion,
+                                     store.units[0].store.translation_project,
+                                     evil_member)
+    _create_comment_on_unit(store.units[0], evil_member, "EVIL COMMENT")
+
+
+def _test_user_merged(unit, src_user, target_user):
+    # TODO: test reviews and comments
+    if src_user.id:
+        assert src_user.submitted.count() == 0
+        assert src_user.suggestions.count() == 0
+
+    assert target_user.submitted.first() == unit
+    assert target_user.suggestions.first() == unit.get_suggestions().first()
+
+
+def _test_before_evil_user_updated(store, member, teststate=False):
+    unit = store.units[0]
+
+    # Unit state is fuzzy
+    assert unit.state == FUZZY
+
+    # Unit target was updated.
+    assert unit.target_f == "Hello, world UPDATED"
+    assert unit.submitted_by == member
+
+    # But member also added a suggestion to the unit.
+    assert unit.get_suggestions().count() == 1
+    assert unit.get_suggestions().first().user == member
+
+    # And added a comment on the unit.
+    assert unit.translator_comment == "NICE COMMENT"
+    assert unit.commented_by == member
+
+    # Only 1 unit round here.
+    assert store.units.count() == 1
+
+
+def _test_after_evil_user_updated(store, evil_member):
+    unit = store.units[0]
+
+    # Unit state is TRANSLATED
+    assert unit.state == TRANSLATED
+
+    # Evil member has accepted their own suggestion.
+    assert unit.target_f == "EVIL SUGGESTION"
+    assert unit.submitted_by == evil_member
+
+    # And rejected member's.
+    assert unit.get_suggestions().count() == 0
+
+    # And added their own comment.
+    assert unit.translator_comment == "EVIL COMMENT"
+    assert unit.commented_by == evil_member
+
+    # Evil member has added another unit.
+    assert store.units.count() == 2
+    assert store.units[1].target_f == "Goodbye, world EVIL"
+    assert store.units[1].submitted_by == evil_member
+
+
+def _test_user_purging(store, member, evil_member, purge):
+
+    first_revision = store.get_max_unit_revision()
+    unit = store.units[0]
+
+    # Get intitial change times
+    initial_submission_time = unit.submitted_on
+    initial_comment_time = unit.commented_on
+    initial_review_time = unit.reviewed_on
+
+    # Test state before evil user has updated.
+    _test_before_evil_user_updated(store, member, True)
+
+    # Update as evil member
+    _make_evil_member_updates(store, evil_member)
+
+    # Revision has increased
+    latest_revision = store.get_max_unit_revision()
+    assert latest_revision > first_revision
+
+    unit = store.units[0]
+
+    # Test submitted/commented/reviewed times on the unit
+    # This is an unreliable test on mysql due to datetime precision
+    if unit.submitted_on.time().microsecond != 0:
+
+        # Times have changed
+        assert unit.submitted_on != initial_submission_time
+        assert unit.commented_on != initial_comment_time
+        assert unit.reviewed_on != initial_review_time
+
+    # Test state after evil user has updated.
+    _test_after_evil_user_updated(store, evil_member)
+
+    # Purge evil_member
+    purge(evil_member)
+
+    # Revision has increased again.
+    assert store.get_max_unit_revision() > latest_revision
+
+    unit = store.units[0]
+
+    # Times are back to previous times - by any precision
+    assert unit.submitted_on == initial_submission_time
+    assert unit.commented_on == initial_comment_time
+    assert unit.reviewed_on == initial_review_time
+
+    # State is be back to how it was before evil user updated.
+    _test_before_evil_user_updated(store, member)
+
+
+@pytest.mark.django_db
+def test_merge_user(en_tutorial_po, member, member2):
+    """Test merging user to another user."""
+    unit = _create_submission_and_suggestion(en_tutorial_po, member)
+    accounts.utils.UserMerger(member, member2).merge()
+    _test_user_merged(unit, member, member2)
+
+
+@pytest.mark.django_db
+def test_delete_user(en_tutorial_po, member, nobody):
+    """Test default behaviour of User.delete - merge to nobody"""
+    unit = _create_submission_and_suggestion(en_tutorial_po, member)
+    member.delete()
+    _test_user_merged(unit, member, nobody)
+
+
+@pytest.mark.django_db
+def test_purge_user(en_tutorial_po_member_updated,
+                    member, evil_member):
+    """Test purging user using `purge_user` function"""
+    _test_user_purging(en_tutorial_po_member_updated,
+                       member, evil_member,
+                       lambda m: accounts.utils.UserPurger(m).purge())
+
+
+@pytest.mark.django_db
+def test_delete_purge_user(en_tutorial_po_member_updated,
+                           member, evil_member):
+    """Test purging user using `User.delete(purge=True)`"""
+    _test_user_purging(en_tutorial_po_member_updated,
+                       member, evil_member,
+                       lambda m: m.delete(purge=True))


### PR DESCRIPTION
This commit:
  - Adds `merge_user` function to merge user's related_objects to other user
  - On `User.delete()` `merge_user` is called to merge to "nobody" account
  - Adds `purge_user` function:
      - Reverts edits
      - Reverts comments
      - Reverts reviews
      - Removes units created by user with no other activity
  - Adds "purge" parameter to `User.delete` `(default=False)
  - Adds `merge_user` and `purge_user` management commands
  - Adds tests to test `User.delete`, merging and purging

touch #3797