### PR TITLE
Make disabled projects accessible by admin

### DIFF
--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -120,9 +120,8 @@ class TranslationProjectManager(models.Manager):
         return self.filter(directory__obsolete=False, project__disabled=False)
 
     def disabled(self):
-        """Filters translation projects that have obsolete directories or they
-        belong to disabled projects."""
-        return self.filter(Q(directory__obsolete=True) | Q(project__disabled=True))
+        """Filters translation projects belong to disabled projects."""
+        return self.filter(project__disabled=True)
 
     def for_user(self, user):
         """Filters translation projects for a specific user.
@@ -228,7 +227,7 @@ class TranslationProject(models.Model, CachedTreeItem):
 
     @property
     def disabled(self):
-        return self.directory.obsolete or self.project.disabled
+        return self.project.disabled
 
     @property
     def is_terminology_project(self):

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -62,9 +62,10 @@ def get_path_obj(func):
 
         if language_code and project_code:
             try:
-                path_obj = TranslationProject.objects.live().get(
-                    language__code=language_code,
-                    project__code=project_code,
+                path_obj = TranslationProject.objects.get_for_user(
+                    user=request.user,
+                    language_code=language_code,
+                    project_code=project_code,
                 )
             except TranslationProject.DoesNotExist:
                 path_obj = None


### PR DESCRIPTION
This PR includes:
- patch for `refresh_stats_rq` command to allow it calculate stats for disabled projects;
- fix which allows an admin user to browse through disabled projects and shows full stats.

Fixes #3997 
