### PR TITLE
Adding database flags for pootle init

### DIFF
--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -500,6 +500,67 @@ Manually Installing Pootle
 These commands expose the database installation and upgrade process from the
 command line.
 
+.. django-admin:: init
+
+init
+^^^^
+
+Create the initial configuration for Pootle.
+
+Available options:
+
+:option:`--config`
+  The configuration file to write to.
+
+  Default: ``~/.pootle/pootle.conf``.
+
+:option:`--db`
+
+.. versionadded:: 2.7.1
+
+  The database backend that you are using
+
+  Default: ``sqlite``.
+  Available options: ``sqlite``, ``mysql``, ``postgresql``.
+
+:option:`--db-name`
+
+.. versionadded:: 2.7.1
+
+  The database name or path to database file if you are using sqlite.
+
+  Default for sqlite: ``dbs/pootle.db``.
+  Default for mysql/postgresql: ``pootledb``.
+
+:option:`--db-user`
+
+.. versionadded:: 2.7.1
+
+  Name of the database user. Not used with sqlite.
+
+  Default: ``pootle``.
+
+:option:`--db-password`
+
+.. versionadded:: 2.7.1
+
+  Database user's password. Not used with sqlite.
+
+:option:`--db-host`
+
+.. versionadded:: 2.7.1
+
+  Database host to connect to. Not used with sqlite.
+
+  Default: ``localhost``.
+
+:option:`--db-port`
+
+.. versionadded:: 2.7.1
+
+  Port to connect to database on. Defaults to database backend's default port.
+  Not used with sqlite.
+
 
 .. _commands#migrate:
 

--- a/docs/server/installation.rst
+++ b/docs/server/installation.rst
@@ -212,6 +212,10 @@ an alternative path as an argument if required.
 .. warning:: This default configuration is enough to experiment with Pootle.
    **Don't use this configuration in a production environment**.
 
+You can specify the parameters to set up your database if you don't want to use
+the default setup, see the :djadmin:`init command <init>` for the
+available options.
+
 The initial configuration includes the settings that you're most likely to
 change. For further customization, see the :ref:`full list of available
 settings <settings#available>`.

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -23,14 +23,16 @@ KEY_LENGTH = 50
 DEFAULT_SETTINGS_PATH = '~/.pootle/pootle.conf'
 
 #: Template that will be used to initialize settings from
-SETTINGS_TEMPLATE_FILENAME = 'settings/90-local.conf.sample'
+SETTINGS_TEMPLATE_FILENAME = 'settings/90-local.conf.template'
 
 # Python 2+3 support for input()
 if sys.version_info[0] < 3:
     input = raw_input
 
 
-def init_settings(settings_filepath, template_filename, db="sqlite"):
+def init_settings(settings_filepath, template_filename,
+                  db="sqlite", db_name="dbs/pootle.db", db_user="",
+                  db_password="", db_host="", db_port=""):
     """Initializes a sample settings file for new installations.
 
     :param settings_filepath: The target file path where the initial settings
@@ -38,6 +40,13 @@ def init_settings(settings_filepath, template_filename, db="sqlite"):
     :param template_filename: Template file used to initialize settings from.
     :param db: Database engine to use
         (default=sqlite, choices=[mysql, postgresql]).
+    :param db_name: Database name (default: pootledb) or path to database file
+        if using sqlite (default: dbs/pootle.db)
+    :param db_user: Name of the database user. Not used with sqlite.
+    :param db_password: Password for the database user. Not used with sqlite.
+    :param db_host: Database host. Defaults to localhost. Not used with sqlite.
+    :param db_port: Database port. Defaults to backend default. Not used with
+        sqlite.
     """
     from base64 import b64encode
 
@@ -45,12 +54,15 @@ def init_settings(settings_filepath, template_filename, db="sqlite"):
     if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    fp = open(settings_filepath, 'w')
-
-    output = open(template_filename).read()
-    # We can't use regular python string formatting here.
-    output = output.replace("${default_key}",
-                            b64encode(os.urandom(KEY_LENGTH)).decode("utf-8"))
+    if db == "sqlite":
+        db_name = "working_path('%s')" % (db_name or "dbs/pootle.db")
+        db_user = db_password = db_host = db_port = "''"
+    else:
+        db_name = "'%s'" % (db_name or "pootledb")
+        db_user = "'%s'" % (db_user or "pootle")
+        db_password = "'%s'" % db_password
+        db_host = "'%s'" % db_host
+        db_port = "'%s'" % db_port
 
     db_module = {
         'sqlite': 'sqlite3',
@@ -58,15 +70,20 @@ def init_settings(settings_filepath, template_filename, db="sqlite"):
         'postgresql': 'postgresql_psycopg2',
         }[db]
 
-    output = output.replace("'ENGINE': 'transaction_hooks.backends.sqlite3'",
-                            "'ENGINE': 'transaction_hooks.backends.%s'" % db_module)
+    context = {
+        "default_key": ("'%s'"
+                        % b64encode(os.urandom(KEY_LENGTH)).decode("utf-8")),
+        "db_engine": "'transaction_hooks.backends.%s'" % db_module,
+        "db_name": db_name,
+        "db_user": db_user,
+        "db_password": db_password,
+        "db_host": db_host,
+        "db_port": db_port,
+    }
 
-    if db != "sqlite":
-        output = output.replace("'NAME': working_path('dbs/pootle.db')",
-                                "'NAME': ''")
-
-    fp.write(output)
-    fp.close()
+    with open(settings_filepath, 'w') as settings:
+        with open(template_filename) as template:
+            settings.write(template.read() % context)
 
 
 def configure_app(project, config_path, django_settings_module, runner_name):
@@ -113,6 +130,7 @@ def run_app(project, default_settings_path, settings_template,
         will be set to.
     """
     runner_name = os.path.basename(sys.argv[0])
+    src_dir = os.path.abspath(os.path.dirname(__file__))
 
     parser = ArgumentParser()
 
@@ -122,8 +140,27 @@ def run_app(project, default_settings_path, settings_template,
     parser.add_argument("--noinput", action="store_true", default=False,
                         help=u"Never prompt for input")
     parser.add_argument("--version", action="version", version=get_version())
+
     parser.add_argument("--db", default="sqlite",
-                        help=u"Use the specified database backend")
+                        help=(u"Use the specified database backend (default: "
+                              "'sqlite'; other options: 'mysql', "
+                              "'postgresql')."))
+    parser.add_argument("--db-name", default="",
+                        help=(u"Database name (default: 'pootledb') or path "
+                              "to database file if using sqlite (default: "
+                              "'%s/dbs/pootle.db')" % src_dir))
+    parser.add_argument("--db-user", default="",
+                        help=(u"Name of the database user. Not used with "
+                              "sqlite."))
+    parser.add_argument("--db-password", default="",
+                        help=(u"Password for the database user. Not used with "
+                              "sqlite."))
+    parser.add_argument("--db-host", default="",
+                        help=(u"Database host. Defaults to localhost. Not "
+                              "used with sqlite."))
+    parser.add_argument("--db-port", default="",
+                        help=(u"Database port. Defaults to backend default. "
+                              "Not used with sqlite."))
 
     args, remainder = parser.parse_known_args(sys.argv[1:])
 
@@ -148,14 +185,17 @@ def run_app(project, default_settings_path, settings_template,
                                           "'postgresql'" % args.db)
 
         try:
-            init_settings(config_path, settings_template, args.db)
+            init_settings(config_path, settings_template,
+                          args.db, args.db_name, args.db_user,
+                          args.db_password, args.db_host, args.db_port)
         except (IOError, OSError) as e:
             raise e.__class__('Unable to write default settings file to %r'
                 % config_path)
 
-        if args.db in ["mysql", "postgresql"]:
-            print("Configuration file created at %r: you must now update "
-                  "the settings for %s database" % (config_path, args.db))
+        if args.db in ['mysql', 'postgresql'] and not args.db_password:
+            print("Configuration file created at %r. You have not specified a "
+                  "password for your database. You may want to update the "
+                  "database settings now" % config_path)
         else:
             print("Configuration file created at %r" % config_path)
         exit(0)

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -26,7 +26,7 @@ POOTLE_TITLE = 'Pootle Translation Server'
 TIME_ZONE = 'UTC'
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = '${default_key}'
+SECRET_KEY = %(default_key)s
 
 # A list of strings representing the host/domain names that this Pootle server
 # can serve. This is a Django's security measure. More details at
@@ -46,17 +46,17 @@ ALLOWED_HOSTS = [
 DATABASES = {
     'default': {
         # Replace 'sqlite3' with 'postgresql_psycopg2' or 'mysql'.
-        'ENGINE': 'transaction_hooks.backends.sqlite3',
+        'ENGINE': %(db_engine)s,
         # Database name or path to database file if using sqlite3.
-        'NAME': working_path('dbs/pootle.db'),
+        'NAME': %(db_name)s,
         # Not used with sqlite3.
-        'USER': '',
+        'USER': %(db_user)s,
         # Not used with sqlite3.
-        'PASSWORD': '',
+        'PASSWORD': %(db_password)s,
         # Set to empty string for localhost. Not used with sqlite3.
-        'HOST': '',
+        'HOST': %(db_host)s,
         # Set to empty string for default. Not used with sqlite3.
-        'PORT': '',
+        'PORT': %(db_port)s,
         # See https://docs.djangoproject.com/en/1.6/topics/db/transactions/
         # required for Django 1.6 + sqlite
         'ATOMIC_REQUESTS': True,


### PR DESCRIPTION
This commit adds the following flags to pootle init for setting up
database config from the command line:
 - --db-name
 - --db-user
 - --db-password
 - --db-host
 - --db-port

It also does the following:
 - renames settings/90-local.conf.sample to
   settings/90-local.conf.template to reflect that its template
 - Adds documentation for the `pootle init` command

Fixes #4015