### PR TITLE
Add verify_user command

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -92,6 +92,8 @@ Command changes and additions
   any submissions, comments and reviews that they have made. This is useful to
   revert spam or a malicious user.
 
+- Added a :djadmin:`verify_user` command to automatically verify a user account
+
 ...and lots of refactoring, cleanups to remove old Django versions specifics,
 improved documentation and of course, loads of bugs were fixed.
 

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -682,6 +682,31 @@ username for a user of your site.
     $ pootle purge_user username
 
 
+.. django-admin:: verify_user
+
+verify_user
+^^^^^^^^^^^
+
+.. versionadded:: 2.7.1
+
+Verify a user without the user having to go through email verification process.
+
+This is useful if you are migrating users that have already been verified, or
+if you want to create a superuser that can log in immediately.
+
+This command requires either a mandatory ``username`` argument, which should be a
+valid username for a user of your site, or the :option:`--all` flag if you wish to
+verify all users of your site.
+
+.. code-block:: bash
+
+    $ pootle verify_user username
+
+
+:option:`--all`
+  Verify all users of the site
+
+
 .. _commands#running:
 
 Running WSGI servers

--- a/pootle/apps/accounts/management/commands/__init__.py
+++ b/pootle/apps/accounts/management/commands/__init__.py
@@ -37,6 +37,9 @@ class UserCommand(BaseCommand):
         return self.usage(self.subcommand).replace('%prog', self.prog_name)
 
     def check_args(self, *args):
-        if len(args) != len(self.args.split(" ")):
+        min_args = len([a for a in self.args.split(" ")
+                        if not a.startswith("[")])
+        max_args = len(self.args.split(" "))
+        if not (min_args <= len(args) <= max_args):
             raise CommandError("Wrong number of arguments\n\n%s"
                                % self.usage_string())

--- a/pootle/apps/accounts/management/commands/verify_user.py
+++ b/pootle/apps/accounts/management/commands/verify_user.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from optparse import make_option
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import CommandError
+
+from . import UserCommand
+import accounts
+
+
+class Command(UserCommand):
+    args = "[user]"
+    help = "Verify a user of the system without requiring email verification"
+    shared_option_list = (
+        make_option('--all', dest='all', action="store_true",
+                    help='Verify all users'),
+    )
+    option_list = UserCommand.option_list + shared_option_list
+
+    def handle(self, *args, **kwargs):
+        self.check_args(*args)
+        verify_all = kwargs.get("all")
+
+        # Either [user] OR --all should be set
+        both_or_neither = ((args and verify_all)
+                           or (not args and not verify_all))
+        if both_or_neither:
+            raise CommandError("You must either provide a [user] to verify or "
+                               "use '--all' to verify all users\n\n%s"
+                               % self.usage_string())
+
+        if verify_all:
+            for user in get_user_model().objects.hide_meta():
+                try:
+                    accounts.utils.verify_user(user)
+                    print("Verified user '%s'" % user.username)
+                except ValueError as e:
+                    print(e.message)
+        else:
+            try:
+                accounts.utils.verify_user(self.get_user(args[0]))
+                print("User '%s' has been verified" % args[0])
+            except ValueError as e:
+                raise CommandError(e.message)

--- a/tests/fixtures/models/user.py
+++ b/tests/fixtures/models/user.py
@@ -71,6 +71,21 @@ def member(db):
 
 
 @pytest.fixture
+def trans_member(transactional_db):
+    """Require a member user."""
+    return _require_user('trans_member', 'Transactional member')
+
+
+@pytest.fixture
+def member_with_email(transactional_db):
+    """Require a member user."""
+    user = _require_user('member_with_email', 'Member with email')
+    user.email = "member_with_email@this.test"
+    user.save()
+    return user
+
+
+@pytest.fixture
 def member2(db):
     """Require a member2 user."""
     return _require_user('member2', 'Member2')

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -7,7 +7,11 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from django.contrib.auth import get_user_model
+
 import pytest
+
+from allauth.account.models import EmailAddress
 
 import accounts
 from pootle_store.util import FUZZY, TRANSLATED
@@ -179,3 +183,89 @@ def test_delete_purge_user(en_tutorial_po_member_updated,
     _test_user_purging(en_tutorial_po_member_updated,
                        member, evil_member,
                        lambda m: m.delete(purge=True))
+
+
+@pytest.mark.django_db
+def test_verify_user(member_with_email):
+    """Test verifying user using `verify_user` function"""
+
+    # Member is not currently verified
+    with pytest.raises(EmailAddress.DoesNotExist):
+        EmailAddress.objects.get(user=member_with_email, verified=True)
+
+    # Verify user
+    accounts.utils.verify_user(member_with_email)
+
+    # Get the verified email object
+    EmailAddress.objects.get(user=member_with_email,
+                             email="member_with_email@this.test",
+                             primary=True, verified=True)
+
+
+@pytest.mark.django_db
+def test_verify_user_without_existing_email(trans_member):
+    """Test verifying user using `verify_user` function"""
+
+    member = trans_member
+
+    # Member has no allauth.EmailAddress object
+    with pytest.raises(EmailAddress.DoesNotExist):
+        EmailAddress.objects.get(user=member)
+
+    # Give member an email - but don't save, as this would trigger
+    # allauth.EmailAddress creation
+    member.email = "member@this.test"
+
+    # Verify user
+    accounts.utils.verify_user(member)
+
+    # Get the verified email object
+    EmailAddress.objects.get(user=member, email="member@this.test",
+                             primary=True, verified=True)
+
+    # This does not update the member object!
+    assert get_user_model().objects.get(pk=member.pk).email == ""
+
+
+@pytest.mark.django_db
+def test_verify_user_with_primary_and_non_primary_email_object(trans_member):
+    """Test verifying user using `verify_user` function that has an
+    allauth.EmailAddress object but is not yet verified
+    """
+    member = trans_member
+
+    # Give member an email
+    member.email = "member@this.test"
+
+    # Create the unverified non-primary email object
+    EmailAddress.objects.create(user=member, email=member.email,
+                                primary=False, verified=False)
+
+    # Create unverified primary email object
+    EmailAddress.objects.create(user=member, email="otheremail@this.test",
+                                primary=True, verified=False)
+
+    # Verify user
+    accounts.utils.verify_user(member)
+
+    # Get the verified email object - the primary address is used
+    EmailAddress.objects.get(user=member, email="otheremail@this.test",
+                             primary=True, verified=True)
+
+
+@pytest.mark.django_db
+def test_verify_user_already_verified(member_with_email):
+    """Test verifying user using `verify_user` function that has an
+    allauth.EmailAddress object but is not yet verified
+    """
+    # Verify user
+    accounts.utils.verify_user(member_with_email)
+
+    # Verify user again - raises ValueError
+    with pytest.raises(ValueError):
+        accounts.utils.verify_user(member_with_email)
+
+    # Get the verified email object
+    EmailAddress.objects.get(user=member_with_email,
+                             email=member_with_email.email,
+                             primary=True, verified=True)


### PR DESCRIPTION
This will allow a sysadmin to verify a user account on the command line without the user having to go through the normal email verification process.

This is useful when creating a superuser account and also for migrating a site with already verified users

The command can be called with either a username or the --all flag to verify all users

Depends on PR #4002 

Tests added and docs updated