### PR TITLE
Change Submission ordering to [creation_time, pk]

### DIFF
--- a/pootle/apps/pootle_statistics/migrations/0002_update_submission_ordering.py
+++ b/pootle/apps/pootle_statistics/migrations/0002_update_submission_ordering.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_statistics', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='submission',
+            options={'ordering': ['creation_time', 'pk'], 'get_latest_by': 'creation_time'},
+        ),
+    ]


### PR DESCRIPTION
Ordering submissions by creation_time alone is unreliable on mysql as it only has precision to the second and there is a risk of multiple submissions having the same time