### PR TITLE
Adding --no-rq flag to pootle command

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -99,6 +99,9 @@ Command changes and additions
 - Added a :djadmin:`update_user_email` command to update a user's email
   address.
 
+- Added a :option:`--no-rq` option to run commands in a single process without
+  using RQ workers.
+
 ...and lots of refactoring, cleanups to remove old Django versions specifics,
 improved documentation and of course, loads of bugs were fixed.
 

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -49,6 +49,38 @@ project, run:
     $ pootle refresh_stats --project=tutorial --language=zu --language=eu
 
 
+Running commands with --no-rq option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7.1
+
+Some of the commands work asynchronously and will schedule jobs to RQ workers,
+rather than running them in the command process. You can change this behaviour
+using the :option:`--no-rq` command line option.
+
+This can be useful for running pootle commands in bash scripts or automating
+installation/upgrade/migration. It can also be useful for debugging otherwise
+asynchronous jobs.
+
+For example, to run :djadmin:`refresh_stats` in the command process and wait
+for the process to terminate:
+
+.. code-block:: bash
+
+    $ pootle refresh_stats --no-rq
+
+.. warning:: Do not ``pootle runserver --no-rq`` on a production server as this
+    will result in very poor performance.
+
+It is *not* generally safe to run commands in this mode if you have RQ workers
+active at the same time, as there is a risk that they conflict with other jobs
+dispatched to the workers.
+
+If there are RQ workers running, the command will ask for confirmation before
+proceeding. This can be overridden using the :option:`--noinput` flag, in
+which case the command will run even if there are.
+
+
 .. django-admin:: refresh_stats
 
 refresh_stats

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -14,6 +14,7 @@ from optparse import make_option
 
 from django.core.management.base import BaseCommand, NoArgsCommand
 
+from pootle.runner import set_sync_mode
 from pootle_project.models import Project
 from pootle_translationproject.models import TranslationProject
 
@@ -25,6 +26,11 @@ class PootleCommand(NoArgsCommand):
                     help='Project to refresh'),
         make_option('--language', action='append', dest='languages',
                     help='Language to refresh'),
+        make_option("--noinput", action="store_true", default=False,
+                    help=u"Never prompt for input"),
+        make_option("--no-rq", action="store_true", default=False,
+                    help=(u"Run all jobs in a single process, without "
+                          "using rq workers")),
         )
     option_list = NoArgsCommand.option_list + shared_option_list
     process_disabled_projects = False
@@ -101,6 +107,9 @@ class PootleCommand(NoArgsCommand):
         logging.info('All done for %s in %s', self.name, end - start)
 
     def handle_all(self, **options):
+        if options.get("no_rq", False):
+            set_sync_mode(options.get('noinput', False))
+
         if self.process_disabled_projects:
             project_query = Project.objects.all()
         else:

--- a/pootle/core/utils/redis_rq.py
+++ b/pootle/core/utils/redis_rq.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from redis.connection import ConnectionError
+
+from django_rq.queues import get_queue
+from django_rq.workers import Worker
+
+
+def redis_is_running():
+    """Checks is redis is running
+
+    :returns: `True` if redis is running, `False` otherwise.
+    """
+    try:
+        queue = get_queue()
+        Worker.all(queue.connection)
+    except ConnectionError:
+        return False
+    return True
+
+
+def rq_workers_are_running():
+    """Checks if there are any rq workers running
+
+    :returns: `True` if there are rq workers running, `False` otherwise.
+    """
+    if redis_is_running():
+        queue = get_queue()
+        if len(queue.connection.smembers(Worker.redis_workers_keys)):
+            return True
+    return False


### PR DESCRIPTION
This commit adds a --no-rq flag to the pootle command

Before running, it checks if there is a rqworker running and if so:

   - if --noinput is set it issues a warning
   - otherwise, it issues warning and asks user if they wish to proceed

This is useful for the following use cases:
  - (bash) scripting installation/migration
  - debugging - eg with the python debugger (pdb)

I havent added docs but i will if we are happy to add this.