### PR TITLE
Warn find and fix duplicate emails

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -83,6 +83,8 @@ Command changes and additions
 - Added a :djadmin:`contributors` command to get the list of contributors
   (:issue:`3867`).
 
+- Added a :djadmin:`find_duplicate_emails` command to find duplicate emails.
+
 - Added a :djadmin:`merge_user` command to get merge submissions, comments and
   reviews from one user account to another. This is useful for fixing users
   that have multiple accounts and want them to be combined. No profile data
@@ -93,6 +95,9 @@ Command changes and additions
   revert spam or a malicious user.
 
 - Added a :djadmin:`verify_user` command to automatically verify a user account
+
+- Added a :djadmin:`update_user_email` command to update a user's email
+  address.
 
 ...and lots of refactoring, cleanups to remove old Django versions specifics,
 improved documentation and of course, loads of bugs were fixed.

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -642,6 +642,23 @@ Managing users
 --------------
 
 
+.. django-admin:: find_duplicate_emails
+
+find_duplicate_emails
+^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7.1
+
+As of Pootle version 2.8, it will no longer be possible to have users with
+duplicate emails. This command will find any user accounts that have duplicate
+emails. It also shows the last login time for each affected user and indicates
+if they are superusers of the site.
+
+.. code-block:: bash
+
+    $ pootle find_duplicate_emails
+
+
 .. django-admin:: merge_user
 
 merge_user
@@ -680,6 +697,26 @@ username for a user of your site.
 .. code-block:: bash
 
     $ pootle purge_user username
+
+
+.. django-admin:: update_user_email
+
+update_user_email
+^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7.1
+
+
+.. code-block:: bash
+
+    $ pootle update_user_email username email
+
+This command can be used if you wish to update a user's email address. This
+might be useful if you have users with duplicate email addresses.
+
+This command requires a mandatory ``username`` argument, which should be a valid
+username for a user of your site, and a mandatory ``email`` argument which
+should to update a valid email address.
 
 
 .. django-admin:: verify_user

--- a/pootle/apps/accounts/management/commands/find_duplicate_emails.py
+++ b/pootle/apps/accounts/management/commands/find_duplicate_emails.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from accounts.utils import get_duplicate_emails
+
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **kwargs):
+        duplicates = get_duplicate_emails()
+        if not duplicates:
+            self.stdout.write("There are no accounts with duplicate emails\n")
+            return
+
+        for email in duplicates:
+            users = User.objects.filter(email=email)
+            if email:
+                self.stdout.write("The following users have the email: %s\n"
+                                  % email)
+            else:
+                self.stdout.write("The following users have no email set:\n")
+            for user in users:
+                args = (user.username,
+                        " " * (25 - len(user.username)),
+                        user.last_login.strftime('%Y-%m-%d %H:%M'),
+                        (user.is_superuser
+                         and "\t\tthis user is a Superuser" or ""))
+                self.stdout.write(" %s%slast login: %s%s\n" % args)
+            self.stdout.write("\n")

--- a/pootle/apps/accounts/management/commands/update_user_email.py
+++ b/pootle/apps/accounts/management/commands/update_user_email.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import CommandError
+from django.core.validators import ValidationError
+
+import accounts
+
+from . import UserCommand
+
+
+User = get_user_model()
+
+
+class Command(UserCommand):
+    args = "user email"
+    help = "Update user email address"
+
+    def handle(self, *args, **kwargs):
+        super(Command, self).handle(*args, **kwargs)
+        try:
+            accounts.utils.update_user_email(self.get_user(args[0]), args[1])
+        except ValidationError as e:
+            raise CommandError(e.message)
+        self.stdout.write("Email updated: %s, %s\n" % args)

--- a/pootle/apps/accounts/managers.py
+++ b/pootle/apps/accounts/managers.py
@@ -12,6 +12,8 @@ __all__ = ('UserManager', )
 from django.contrib.auth.models import BaseUserManager
 from django.utils import timezone
 
+import accounts
+
 
 class UserManager(BaseUserManager):
     """Pootle User manager.
@@ -36,6 +38,7 @@ class UserManager(BaseUserManager):
             raise ValueError('The given username must be set')
 
         email = self.normalize_email(email)
+        accounts.utils.validate_email_unique(email)
         user = self.model(username=username, email=email,
                           is_active=True, is_superuser=is_superuser,
                           last_login=now, date_joined=now, **extra_fields)


### PR DESCRIPTION
This PR adds:

 - a utility for finding, fixing and validating duplicate emails
 - a system check for warning about duplicate emails
 - commands to:
    - find_duplicate_emails
    - update_user_email

This is a temporary solution to help users before enforcing email uniqueness in db schema (touch #4035)