### PR TITLE
Fix plural of multistring getting lost

### DIFF
--- a/pootle/apps/pootle_store/fields.py
+++ b/pootle/apps/pootle_store/fields.py
@@ -42,7 +42,12 @@ def to_db(value):
         if list_empty(value.strings):
             return ''
         else:
-            return SEPARATOR.join(value.strings)
+            if getattr(value, "plural", False):
+                strings = value.strings[:]
+                strings.append(PLURAL_PLACEHOLDER)
+                return SEPARATOR.join(strings)
+            else:
+                return SEPARATOR.join(value.strings)
     elif isinstance(value, list):
         if list_empty(value):
             return ''


### PR DESCRIPTION
The to_db function of MultiStringField does not add
the plural place holder. This means that plural sources
that have only one string (as is the case in Qt TS files)
loose there plural attribute and will then be mistreated as
singular strings.

**NOTE**: I only tested this with pootle-2.5 since I don't have a working 2.7 installation right now, but the affected code is still the same