### PR TITLE
Logging login errors and re-raising as RuntimeError

### DIFF
--- a/pootle/apps/accounts/urls.py
+++ b/pootle/apps/accounts/urls.py
@@ -10,10 +10,14 @@
 from django.conf.urls import patterns, url
 
 
-from .views import SocialVerificationView
+from .views import PootleLoginView, SocialVerificationView
 
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
+    url(r"^login/$",
+        PootleLoginView.as_view(),
+        name="account_login"),
     url(r'^social/verify/$',
         SocialVerificationView.as_view(),
         name='pootle-social-verify'),

--- a/pootle/apps/accounts/views.py
+++ b/pootle/apps/accounts/views.py
@@ -7,14 +7,34 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import logging
+
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 
 from allauth.account.views import LoginView
+from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.helpers import _add_social_account
 from allauth.socialaccount.models import SocialLogin
 
 from .forms import SocialVerificationForm
+
+
+logger = logging.getLogger(__name__)
+
+
+class PootleLoginView(LoginView):
+
+    def form_valid(self, form):
+        success_url = self.get_success_url()
+        try:
+            return form.login(self.request, redirect_url=success_url)
+        except ImmediateHttpResponse as e:
+            return e.response
+        except Exception as e:
+            logger.exception("%s %s" % (e.__class__.__name__, e))
+            raise RuntimeError("An error occurred logging you in. Please "
+                               "contact your system administrator")
 
 
 class SocialVerificationView(LoginView):


### PR DESCRIPTION
If an error occurs during login - eg if there are duplicate emails - the login
UI exposes the error (or hangs if settings.DEBUG = True).

This commit catches the error so that the user gets an appropriate message and
sysadmin can see what error occurred.

Touch #3796