### PR TITLE
Merge delete

### DIFF
--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -659,6 +659,9 @@ This command requires 2 mandatory arguments, ``src_username`` and
 Submissions from the first are re-assigned to the second. The users' profile
 data is not merged.
 
+By default ``src_username`` will be deleted after the contributions have been
+merged. You can prevent this by using the :option:`--no-delete` option.
+
 .. code-block:: bash
 
     $ pootle merge_user src_username target_username

--- a/pootle/apps/accounts/management/commands/merge_user.py
+++ b/pootle/apps/accounts/management/commands/merge_user.py
@@ -7,6 +7,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from optparse import make_option
+
 import accounts
 
 from . import UserCommand
@@ -15,8 +17,22 @@ from . import UserCommand
 class Command(UserCommand):
     args = "user other_user"
     help = "Merge user to other_user"
+    shared_option_list = (
+        make_option("--no-delete",
+                    dest='delete',
+                    action="store_false",
+                    default=True,
+                    help="Don't delete user after merging."),
+    )
+    option_list = UserCommand.option_list + shared_option_list
 
     def handle(self, *args, **kwargs):
         super(Command, self).handle(*args, **kwargs)
-        accounts.utils.UserMerger(self.get_user(username=args[0]),
+        src_user = self.get_user(username=args[0])
+        accounts.utils.UserMerger(src_user,
                                   self.get_user(username=args[1])).merge()
+
+        if kwargs.get("delete"):
+            self.stdout.write("Deleting user: %s...\n" % src_user.username)
+            src_user.delete()
+            self.stdout.write("User deleted: %s\n" % src_user.username)


### PR DESCRIPTION
This commit makes merge_user delete user after merge.

To retain user after merge you can use --no-delete option

Docs updated.

Fixes #4059 