### PR TITLE
Fix `calculate_checks` command

### DIFF
--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -14,69 +14,108 @@ from optparse import make_option
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from django.conf import settings
-from django.core.urlresolvers import set_script_prefix
-from django.utils.encoding import force_unicode
+from django.utils import timezone
 
-from django_rq import job
-
-from pootle.core.cache import get_cache
 from pootle.core.mixins.treeitem import CachedMethods
-from pootle_store.models import Store
+from pootle_store.models import Store, QualityCheck, Unit
+from pootle_store.util import OBSOLETE
 
-from .refresh_stats import Command as RefreshStatsCommand
-
-
-logger = logging.getLogger('stats')
-cache = get_cache('stats')
+from . import PootleCommand
 
 
-class Command(RefreshStatsCommand):
-    help = "Allow stats and text indices to be refreshed manually."
+class Command(PootleCommand):
+    help = "Allow checks to be recalculated manually."
 
     shared_option_list = (
         make_option('--check', action='append', dest='check_names',
                     help='Check to recalculate'),
     )
+
     cached_methods = [CachedMethods.CHECKS]
+    process_disabled_projects = True
 
-    def handle_noargs(self, **options):
-        calculate_checks.delay(**options)
-        option_list = map(lambda x: '%s=%s' % (x, options[x]),
-                          filter(lambda x: options[x], options))
-        self.stdout.write('calculate checks RQ job added with options: %s. %s.' %
-                          (', '.join(option_list),
-                          'Please make sure rqworker is running'))
+    def handle_all_stores(self, translation_project, **options):
+        check_names = options.get('check_names', None)
+        calculate_checks(check_names=check_names,
+                         translation_project=translation_project)
 
-    def process(self, **options):
-        check_names = options.get('check_names', [])
-        store_filter = options.get('store_filter', {})
-        unit_fk_filter = options.get('unit_fk_filter', {})
-        store_fk_filter = options.get('store_fk_filter', {})
+    def handle_all(self, **options):
+        if not self.projects and not self.languages:
+            logging.info(u"Running %s (noargs)", self.name)
 
-        logger.info('Initializing stores...')
+            check_names = options.get('check_names', None)
+            translation_project = options.get('translation_project', None)
+            try:
 
-        stores = Store.objects.live()
-        if store_filter:
-            stores = stores.filter(**store_filter)
-
-        self._init_stores(stores)
-        self._init_checks()
-        self.calculate_checks(check_names, unit_fk_filter, store_fk_filter)
-
-        logger.info('Setting quality check stats values for all stores...')
-        self._set_qualitycheck_stats(unit_fk_filter)
-        logger.info('Setting empty values for other cache entries...')
-        self._set_empty_values()
+                calculate_checks(check_names=check_names,
+                                 translation_project=translation_project)
+            except Exception:
+                logging.exception(u"Failed to run %s", self.name)
+        else:
+            super(Command, self).handle_all(**options)
 
 
-@job('default', timeout=18000)
-def calculate_checks(**options):
-    # The script prefix needs to be set here because the generated
-    # URLs need to be aware of that and they are cached. Ideally
-    # Django should take care of setting this up, but it doesn't yet:
-    # https://code.djangoproject.com/ticket/16734
-    script_name = (u'/' if settings.FORCE_SCRIPT_NAME is None
-                        else force_unicode(settings.FORCE_SCRIPT_NAME))
-    set_script_prefix(script_name)
-    super(RefreshStatsCommand, Command()).handle_noargs(**options)
+def calculate_checks(check_names=None, translation_project=None):
+    store_fk_filter = {}
+    unit_fk_filter = {}
+
+    if translation_project is not None:
+        store_fk_filter = {
+            'store__translation_project': translation_project,
+        }
+        unit_fk_filter = {
+            'unit__store__translation_project': translation_project,
+        }
+
+    logging.info('Calculating quality checks for all units...')
+    QualityCheck.delete_unknown_checks()
+
+    checks = QualityCheck.objects.filter(**unit_fk_filter)
+    if check_names is not None:
+        checks = checks.filter(name__in=check_names)
+    checks = checks.values('id', 'name', 'unit_id',
+                           'category', 'false_positive')
+    all_units_checks = {}
+    for check in checks:
+        all_units_checks.setdefault(check['unit_id'], {})[check['name']] = check
+
+    unit_filter = {
+        'state__gt': OBSOLETE
+    }
+    unit_filter.update(store_fk_filter)
+    # unit's query is faster without `select_related('store')`
+    units = Unit.simple_objects.filter(**unit_filter) \
+                               .order_by('store__id')
+    store = None
+    # units are ordered by store, we update dirty cache after we switch
+    # to another store
+    for unit_count, unit in enumerate(units.iterator(), start=1):
+        if store is None or unit.store_id != store.id:
+            if store is not None:
+                store.update_dirty_cache()
+            # we get unit.store only if the store differs from previous
+            store = Store.simple_objects.get(id=unit.store_id)
+
+        # HACKISH: set unit.store to avoid extra querying in
+        # `unit.update_quality_checks()` method
+        unit.store = store
+
+        unit_checks = {}
+        if unit.id in all_units_checks:
+            unit_checks = all_units_checks[unit.id]
+
+        if unit.update_qualitychecks(keep_false_positives=True,
+                                     check_names=check_names,
+                                     existing=unit_checks):
+
+            # update unit.mtime but avoid to use unit.save()
+            # because it can trigger unnecessary things:
+            # logging, stats cache updating
+            # TODO: add new action type `quality checks were updated`?
+            Unit.simple_objects.filter(id=unit.id).update(mtime=timezone.now())
+
+        if unit_count % 10000 == 0:
+            logging.info("%d units processed" % unit_count)
+
+    if store is not None:
+        store.update_dirty_cache()

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1020,6 +1020,7 @@ class Unit(models.Model, base.TranslationUnit):
             self.state = UNTRANSLATED
 
         self.store.mark_dirty(CachedMethods.WORDCOUNT_STATS)
+        self.update_qualitychecks(keep_false_positives=True)
         self._state_updated = True
         self._save_action = UNIT_RESURRECTED
 
@@ -1351,6 +1352,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
     obsolete = models.BooleanField(default=False)
 
     objects = StoreManager()
+    simple_objects = models.Manager()
 
     class Meta:
         ordering = ['pootle_path']


### PR DESCRIPTION
`calculate_checks` command was broken in def9bf0029b.
This commits fixes it, allows to recalculate quality checks without
blocking rqworker and refreshes stats for all checks within `update_dirty_cache()`