### PR TITLE
Docs: Add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,47 @@
+How to contribute
+=================
+
+Reporting bugs
+--------------
+
+Write your bug report so that you ensure developers are fixing the bug rather
+than spending time trying to understand your bug report.  If we can't see it or
+replicate it, likely we can't fix it.
+
+Checklist:
+
+#. Bug description is clear yet concise.
+#. Clear instructions to reliably replicate the issue.
+#. Screenshots rather than descriptions of screens.
+#. Full traceback if one occured.
+#. Links to the issue.
+
+Commits and pull requests
+-------------------------
+
+Keep the commit log as healthy as the code. It is one of the first places new
+contributors will look at the project.
+
+#. No more than one change per commit. There should be no changes in a commit
+   which are unrelated to its message.
+#. Every commit should pass all tests on its own.
+#. Follow `these conventions <http://chris.beams.io/posts/git-commit/>`_ when
+   writing the commit message.
+
+When filing a Pull Request, make sure it is rebased on top of most recent
+master. If you need to modify it or amend it in some way, you should always
+appropriately fixup the issues in git and force-push your changes to your fork.
+
+Also see: `Github Help: Using Pull Requests
+<https://help.github.com/articles/using-pull-requests/>`_
+
+Translations
+------------
+
+Please translate `online <http://pootle.locamotion.org/projects/pootle/>`_
+
+Need help?
+----------
+
+You can always ask for help in the `#pootle-dev
+<irc://irc.freenode.net/#pootle-dev>`_ IRC channel.


### PR DESCRIPTION
This lifts heavily from https://github.com/translate/pootle/wiki/Styleguide-%28proposal%29

I've written this more to provide some guideance to users who will see it in the Github link when they create a new Github issue.  Based in some part on a few unhelpful issues being reported without basic info thus creating the need to ask questions that could have been addressed by the reporter.

Please review this for readability.  The idea is to keep is clean and clear.

I realise it duplicates other stuff, but I'd prefer to have something working now then mash all those fixes together.

If there is something desperate you feel should be here, please flag it, but likley I'll ask that you write that so that it doesn't block this landing.