### PR TITLE
Static pages: integrated CodeMirror editor

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -31,6 +31,8 @@ complete information.
 Details of changes
 ==================
 
+- The editor for static pages now highlights the content's markup
+  (:issue:`3346`).
 - Pulled latest translations.
 
 

--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -10,6 +10,7 @@
 from django.conf import settings
 from django.utils import translation
 
+from pootle.core.markup import get_markup_filter_name
 from pootle.core.utils.json import jsonify
 from pootle_language.models import Language
 from pootle_project.models import Project
@@ -47,6 +48,7 @@ def pootle_context(request):
             'POOTLE_INSTANCE_ID': settings.POOTLE_INSTANCE_ID,
             'POOTLE_CONTACT_ENABLED': (settings.POOTLE_CONTACT_ENABLED and
                                        settings.POOTLE_CONTACT_EMAIL),
+            'POOTLE_MARKUP_FILTER': get_markup_filter_name(),
             'POOTLE_SIGNUP_ENABLED': settings.POOTLE_SIGNUP_ENABLED,
             'SCRIPT_NAME': settings.SCRIPT_NAME,
             'POOTLE_CACHE_TIMEOUT': settings.POOTLE_CACHE_TIMEOUT,

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -65,6 +65,8 @@ class PageModelMixin(object):
         if self.page_type == ANN_TYPE:
             form.fields['virtual_path'].help_text = u'/pages/' + ANN_VPATH
 
+        form.fields['body'].widget.attrs['class'] = 'js-staticpage-editor'
+
         return form
 
     def form_valid(self, form):

--- a/pootle/static/css/admin.css
+++ b/pootle/static/css/admin.css
@@ -45,6 +45,12 @@ textarea#id_DESCRIPTION
 
 /* STATIC PAGES */
 
+.CodeMirror
+{
+    border: 1px solid #dadada;
+    font-size: 1.25em;
+}
+
 .staticpages-form textarea
 {
     width: 100%;

--- a/pootle/static/js/admin/general/app.js
+++ b/pootle/static/js/admin/general/app.js
@@ -8,6 +8,7 @@
 
 import dashboard from './dashboard';
 import permissions from './permissions';
+import staticpages from './staticpages';
 
 window.PTL = window.PTL || {};
 
@@ -21,6 +22,9 @@ PTL.commonAdmin = {
         break;
       case 'permissions':
         permissions.init();
+        break;
+      case 'staticpages':
+        staticpages.init(opts.opts);
         break;
     }
   },

--- a/pootle/static/js/admin/general/staticpages.js
+++ b/pootle/static/js/admin/general/staticpages.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import CodeMirror from 'codemirror';
+import 'codemirror/lib/codemirror.css';
+
+
+/**
+ * Maps markup module names from settings to CodeMirror mode names
+ */
+function getMode(markup) {
+  return {
+    html: 'htmlmixed',
+    restructuredtext: 'rst',
+  }[markup] || markup;
+}
+
+
+const staticpages = {
+
+  init(opts) {
+    const element = document.querySelector(opts.el);
+    const mode = getMode(opts.markup);
+
+    // Using webpack's `bundle` loader so each mode goes into a separate chunk
+    const bundledResult = require(`bundle!codemirror/mode/${mode}/${mode}.js`);
+    bundledResult(() => {
+      CodeMirror.fromTextArea(element, {
+        mode: mode,
+        lineWrapping: true,
+      });
+    });
+  },
+
+}
+
+
+export default staticpages;

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "babel-core": "^5.4.7",
     "babel-loader": "^5.1.3",
+    "bundle-loader": "^0.5.4",
     "css-loader": "^0.9.0",
     "lodash": "^2.4.1",
     "style-loader": "^0.8.0",
@@ -18,6 +19,7 @@
     "autolinker": "^0.11.2",
     "autosize": "^3.0.6",
     "classnames": "^1.2.0",
+    "codemirror": "^5.7.0",
     "flummox": "^3.5.1",
     "imports-loader": "^0.6.3",
     "md5": "^2.0.0",

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -117,6 +117,10 @@ plugins.push.apply(plugins, [
     'process.env': {NODE_ENV: JSON.stringify(env)}
   }),
   new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+  new webpack.ContextReplacementPlugin(
+    /codemirror[\/\\]mode$/,
+    /htmlmixed|markdown|rst|textile/
+  ),
   new webpack.ProvidePlugin({
     'window.Backbone': 'backbone',
   }),
@@ -131,6 +135,8 @@ var config = {
   entry: entries,
   output: {
     path: __dirname,
+    // FIXME: this should take the deployment app's script name into account
+    publicPath: DEBUG ? '/static/js/' : '/assets/js/',
     filename: './[name]/app.bundle.js'
   },
   module: {

--- a/pootle/templates/admin/staticpages/base_edit.html
+++ b/pootle/templates/admin/staticpages/base_edit.html
@@ -10,3 +10,20 @@
   </div>
 </div>
 {% endblock %}
+
+{% block scripts_extra %}
+{% assets 'js_admin_general_app' %}
+<script type="text/javascript" src="{{ ASSET_URL }}"></script>
+{% endassets %}
+<script type="text/javascript">
+  $(function () {
+    PTL.commonAdmin.init({
+      page: 'staticpages',
+      opts: {
+        el: '.js-staticpage-editor',
+        markup: PTL.settings.MARKUP_FILTER,
+      }
+    });
+  });
+</script>
+{% endblock %}

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -28,6 +28,7 @@
     PTL.settings = {
       CONTACT_ENABLED: {{ settings.POOTLE_CONTACT_ENABLED|yesno:'true, false' }},
       SIGNUP_ENABLED: {{ settings.POOTLE_SIGNUP_ENABLED|yesno:'true, false' }},
+      MARKUP_FILTER: '{{ settings.POOTLE_MARKUP_FILTER }}',
       SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|safe }},
     };
     </script>


### PR DESCRIPTION
This PR integrates the CodeMirror editor for static pages, and compiles support for modes into separate chunks.

The highlighting changes according to the configured markup module configured in the settings. It'd be great if you can test with `DEBUG` set as `True` and `False`.

Fixes #3346.