### PR TITLE
Use additional local (external) TMs

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -21,6 +21,7 @@ Major Changes
 =============
 
 - Pulled latest translations.
+- Added support for Elasticsearch-based external Translation Memory servers.
 
 
 Below we provide much more detail. These are by no means exhaustive, view the
@@ -34,8 +35,21 @@ Details of changes
 - The editor for static pages now highlights the content's markup
   (:issue:`3346`).
 - Pulled latest translations.
-- :djadmin:`update_tmserver`: renamed :option:`--overwrite` to
-  :option:`--refresh`.
+- :djadmin:`update_tmserver`:
+
+  - Renamed :option:`--overwrite` to :option:`--refresh`.
+  - Added support for Elasticsearch-based external Translation Memory servers,
+    which can be populated from translation files. This effectively brings the
+    ability to display TM results from different TM servers, sorting them by
+    their score.
+
+- :setting:`POOTLE_TM_SERVER`:
+
+  - The ``default`` TM server on  has been renamed to ``local``. Make sure to
+    adjust your settings.
+  - Added a new :setting:`WEIGHT <POOTLE_TM_SERVER-WEIGHT>` option to raise or
+    lower the TM results score for each specific TM server.
+
 - The Apertium MT backend has been dropped.
 
 

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -403,8 +403,10 @@ update_tmserver
 .. versionadded:: 2.7
 
 .. versionchanged:: 2.7.3 Renamed :option:`--overwrite` to :option:`--refresh`.
+   Now it is also possible to import translations from files.
 
-Updates the ``default`` server in :setting:`POOTLE_TM_SERVER`.  The command
+
+Updates the ``local`` server in :setting:`POOTLE_TM_SERVER`.  The command
 reads translations from the current Pootle install and builds the TM resources
 in the TM server.
 
@@ -412,6 +414,10 @@ If no options are provided, the command will only add new translations to the
 server. Use :option:`--refresh` to also update existing translations that have
 been changed, besides adding any new translation. To completely remove the TM
 and rebuild it adding all existing translations use :option:`--rebuild`.
+
+If no specific TM server is specified using :option:`--tm`, then the default
+``local`` TM will be used. If the specified TM server doesn't exist it will
+be automatically created for you.
 
 To see how many units will be loaded into the server use :option:`--dry-run`,
 no actual data will be loaded or deleted (the TM will be left unchanged):
@@ -421,6 +427,55 @@ no actual data will be loaded or deleted (the TM will be left unchanged):
     $ pootle update_tmserver --dry-run
     $ pootle update_tmserver --refresh --dry-run
     $ pootle update_tmserver --rebuild --dry-run
+
+
+This command also allows to read translations from files and build the TM
+resources in the external TM server. In order to do so it is mandatory to
+provide the :option:`--tm` and :option:`--project` options, along with some
+filename argument to import translations from. The provided project name will
+be displayed on TM matches in the translation editor:
+
+.. code-block:: bash
+
+   (env) $ pootle update_tmserver --tm=libreoffice --project="LibreOffice 4.3 UI" TM_LibreOffice_4.3.gl.tmx
+
+
+By default the command will only add new translations to the server. To rebuild
+the server from scratch use :option:`--rebuild` to completely remove the TM and
+rebuild it before importing the translations:
+
+.. code-block:: bash
+
+   (env) $ pootle update_tmserver --rebuild --tm=mozilla --project="Foo 1.7" foo.po
+
+
+Option :option:`--refresh` doesn't apply when adding translations from files
+on disk.
+
+To see how many units will be loaded into the server use :option:`--dry-run`,
+no actual data will be loaded:
+
+.. code-block:: bash
+
+   (env) $ pootle update_tmserver --dry-run --tm=mozilla --project="Foo 1.7" foo.po
+   175045 translations to index
+
+
+This command is capable of importing translations from several files in
+different formats at once:
+
+.. code-block:: bash
+
+   (env) $ pootle update_tmserver --tm=mozilla --project="Foo 1.7" foo.po bar.tmx eggs.xliff bacon.ts
+
+
+Use :option:`--target-language` to specify the target language ISO code for the
+imported translations in case it is not possible to guess it from the
+translation files or if the code is incorrect:
+
+.. code-block:: bash
+
+   (env) $ pootle update_tmserver --target-language=af --tm=mozilla --project="Foo 1.7" foo.po bar.tmx
 
 
 .. _commands#vfolders:

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -281,32 +281,62 @@ Translation environment configuration settings.
 
 .. setting:: POOTLE_TM_SERVER
 
-.. versionadded:: 2.7
-
 ``POOTLE_TM_SERVER``
+  .. versionadded:: 2.7
+
+  .. versionchanged:: 2.7.3
+
+     Added the :setting:`WEIGHT <POOTLE_TM_SERVER-WEIGHT>` option. Also added
+     another default TM used to import external translations from files.
+
+
   Default:
 
   .. code-block:: python
 
     {
-        'default': {
+        'local': {
             'ENGINE': 'pootle.core.search.backends.ElasticSearchBackend',
             'HOST': 'localhost',
             'PORT': 9200,
             'INDEX_NAME': 'translations',
+            'WEIGHT': 1,
+            'MIN_SCORE': 'AUTO',
+        },
+        'external': {
+            'ENGINE': 'pootle.core.search.backends.ElasticSearchBackend',
+            'HOST': 'localhost',
+            'PORT': 9200,
+            'INDEX_NAME': 'external-translations',
+            'WEIGHT': 0.9,
             'MIN_SCORE': 'AUTO',
         },
     }
+
 
   This is configured to access a standard Elasticsearch setup.  Change the
   settings for any non-standard setup.  Change ``HOST`` and ``PORT`` settings
   as required.
 
   Use ``MIN_SCORE`` to set the Levenshtein Distance score.  Set it to ``AUTO``
-  so that Eslasticsearch will adjust the required score depending on the length
+  so that Elasticsearch will adjust the required score depending on the length
   of the string being translated. Elasticsearch documentation provides further
   details on `Fuzzy matching
   <https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness>`_.
+
+  The default ``local`` TM is automatically updated every time a new
+  translation is submitted. The other TMs are not automatically updated so they
+  can be trusted to provide selected high quality translations.
+
+  .. setting:: POOTLE_TM_SERVER-INDEX_NAME
+
+  Every TM server must have its own unique ``INDEX_NAME``.
+
+  .. setting:: POOTLE_TM_SERVER-WEIGHT
+
+  ``WEIGHT`` provides a weighting factor to alter the final score for TM
+  results from this TM server. Valid values are between ``0.0`` and ``1.0``,
+  both included. Defaults to ``1.0`` if not provided.
 
 
 .. setting:: POOTLE_MT_BACKENDS

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -217,6 +217,10 @@ class Command(BaseCommand):
 
         # If files to import have been provided.
         if len(args):
+            if self.is_local_tm:
+                raise CommandError('You cannot add translations from files to '
+                                   'a local TM.')
+
             self.target_language = options.pop('target_language')
             self.project = options.pop('project')
 
@@ -226,6 +230,9 @@ class Command(BaseCommand):
             self.parser = FileParser(index=self.INDEX_NAME,
                                      language=self.target_language,
                                      project=self.project)
+        elif not self.is_local_tm:
+            raise CommandError('You cannot add translations from database to '
+                               'an external TM.')
         else:
             self.parser = DBParser(index=self.INDEX_NAME)
 

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -16,6 +16,7 @@ import sys
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from elasticsearch import helpers, Elasticsearch
+from translate.storage import factory
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
@@ -26,31 +27,14 @@ from pootle_store.models import Unit
 BULK_CHUNK_SIZE = 5000
 
 
-class Command(BaseCommand):
-    help = "Load Local Translation Memory"
-    option_list = BaseCommand.option_list + (
-        make_option('--refresh',
-                    action="store_true",
-                    dest='refresh',
-                    default=False,
-                    help='Process all items, not just the new ones, so '
-                         'existing translations are refreshed'),
-        make_option('--rebuild',
-                    action="store_true",
-                    dest='rebuild',
-                    default=False,
-                    help='Drop the entire index on start and update '
-                         'everything from scratch'),
-        make_option('--dry-run',
-                    action="store_true",
-                    dest='dry_run',
-                    default=False,
-                    help='Report only the number of translations to index '
-                         'and quit'),
-    )
+class DBParser(object):
 
-    def _parse_translations(self, **options):
+    def __init__(self, *args, **kwargs):
+        super(DBParser, self).__init__(*args, **kwargs)
+        self.INDEX_NAME = kwargs.pop('index', None)
 
+    def get_units(self, *filenames):
+        """Gets the units to import and its total count."""
         units_qs = Unit.simple_objects \
             .exclude(target_f__isnull=True) \
             .exclude(target_f__exact='') \
@@ -73,7 +57,121 @@ class Command(BaseCommand):
                 'store__translation_project__language__code'
             ).order_by()
 
-        total = units_qs.count()
+        return units_qs.iterator(), units_qs.count()
+
+    def get_unit_data(self, unit):
+        """Return dict with data to import for a single unit."""
+        fullname = (unit['submitted_by__full_name'] or
+                    unit['submitted_by__username'])
+
+        email_md5 = None
+        if unit['submitted_by__email']:
+            email_md5 = md5(unit['submitted_by__email']).hexdigest()
+
+        return {
+            '_index': self.INDEX_NAME,
+            '_type': unit['store__translation_project__language__code'],
+            '_id': unit['id'],
+            'revision': int(unit['revision']),
+            'project': unit['store__translation_project__project__fullname'],
+            'path': unit['store__pootle_path'],
+            'username': unit['submitted_by__username'],
+            'fullname': fullname,
+            'email_md5': email_md5,
+            'source': unit['source_f'],
+            'target': unit['target_f'],
+        }
+
+
+class FileParser(object):
+
+    def __init__(self, *args, **kwargs):
+        super(FileParser, self).__init__(*args, **kwargs)
+        self.INDEX_NAME = kwargs.pop('index', None)
+        self.target_language = kwargs.pop('language', None)
+        self.project = kwargs.pop('project', None)
+
+    def get_units(self, *filenames):
+        """Gets the units to import and its total count."""
+        units = []
+
+        for filename in filenames:
+            store = factory.getobject(filename)
+            if not store.gettargetlanguage() and not self.target_language:
+                raise CommandError("Unable to determine target language for "
+                                   "'%s'. Try again specifying a fallback "
+                                   "target language with --target-language" %
+                                   filename)
+
+            self.filename = filename
+            units.extend([unit for unit in store.units if unit.istranslated()])
+
+        return units, len(units)
+
+    def get_unit_data(self, unit):
+        """Return dict with data to import for a single unit."""
+        target_language = unit.gettargetlanguage()
+        if target_language is None:
+            target_language = self.target_language
+
+        return {
+            '_index': self.INDEX_NAME,
+            '_type': target_language,
+            '_id': unit.getid(),
+            'revision': 0,
+            'project': self.project,
+            'path': self.filename,
+            'username': None,
+            'fullname': None,
+            'email_md5': None,
+            'source': unit.source,
+            'target': unit.target,
+        }
+
+
+class Command(BaseCommand):
+    help = "Load Translation Memory with translations"
+    option_list = BaseCommand.option_list + (
+        make_option('--refresh',
+                    action='store_true',
+                    dest='refresh',
+                    default=False,
+                    help='Process all items, not just the new ones, so '
+                         'existing translations are refreshed'),
+        make_option('--rebuild',
+                    action='store_true',
+                    dest='rebuild',
+                    default=False,
+                    help='Drop the entire TM on start and update everything '
+                         'from scratch'),
+        make_option('--dry-run',
+                    action='store_true',
+                    dest='dry_run',
+                    default=False,
+                    help='Report the number of translations to index and quit'),
+        # External TM specific options.
+        make_option('--tm',
+                    action='store',
+                    dest='tm',
+                    default='local',
+                    help="TM to use. TM must exist on settings. TM will be "
+                         "created on the server if it doesn't exist"),
+        make_option('--target-language',
+                    action='store',
+                    dest='target_language',
+                    default='',
+                    help="Target language to fallback to use in case it can't "
+                         "be guessed for any of the input files."),
+        make_option('--project',
+                    action='store',
+                    dest='project',
+                    default='',
+                    help='Project to use when displaying TM matches for this '
+                         'translations.'),
+    )
+
+    def _parse_translations(self, *args, **options):
+        units, total = self.parser.get_units(*args)
 
         if total == 0:
             self.stdout.write("No translations to index")
@@ -86,63 +184,59 @@ class Command(BaseCommand):
 
         self.stdout.write("")
 
-        for i, unit in enumerate(units_qs.iterator(), start=1):
-            fullname = (unit['submitted_by__full_name'] or
-                        unit['submitted_by__username'])
-            project = unit['store__translation_project__project__fullname']
-
-            email_md5 = None
-            if unit['submitted_by__email']:
-                email_md5 = md5(unit['submitted_by__email']).hexdigest()
-
+        for i, unit in enumerate(units, start=1):
             if (i % 1000 == 0) or (i == total):
                 percent = "%.1f" % (i * 100.0 / total)
                 self.stdout.write("%s (%s%%)" % (i, percent), ending='\r')
                 self.stdout.flush()
 
-            yield {
-                "_index": self.INDEX_NAME,
-                "_type": unit['store__translation_project__language__code'],
-                "_id": unit['id'],
-                'revision': int(unit['revision']),
-                'project': project,
-                'path': unit['store__pootle_path'],
-                'username': unit['submitted_by__username'],
-                'fullname': fullname,
-                'email_md5': email_md5,
-                'source': unit['source_f'],
-                'target': unit['target_f'],
-            }
+            yield self.parser.get_unit_data(unit)
 
         if i != total:
             self.stdout.write("Expected %d, loaded %d." % (total, i))
 
-
-    def handle(self, *args, **options):
+    def _initialize(self, *args, **options):
         if not getattr(settings, 'POOTLE_TM_SERVER', False):
-            raise CommandError("POOTLE_TM_SERVER is missing from your settings.")
+            raise CommandError('POOTLE_TM_SERVER setting is missing.')
 
-        self.INDEX_NAME = settings.POOTLE_TM_SERVER['default']['INDEX_NAME']
-        es = Elasticsearch([{
-                'host': settings.POOTLE_TM_SERVER['default']['HOST'],
-                'port': settings.POOTLE_TM_SERVER['default']['PORT']
+        try:
+            self.tm_settings = settings.POOTLE_TM_SERVER[options.get('tm')]
+        except KeyError:
+            raise CommandError('Specified Translation Memory is not defined '
+                               'in POOTLE_TM_SERVER.')
+
+        self.INDEX_NAME = self.tm_settings['INDEX_NAME']
+        self.is_local_tm = options.get('tm') == 'local'
+
+        self.es = Elasticsearch([{
+                'host': self.tm_settings['HOST'],
+                'port': self.tm_settings['PORT'],
             }],
             retry_on_timeout=True
         )
 
+        # If files to import have been provided.
+        if len(args):
+            self.target_language = options.pop('target_language')
+            self.project = options.pop('project')
+
+            if not self.project:
+                raise CommandError('You must specify a project with '
+                                   '--project.')
+            self.parser = FileParser(index=self.INDEX_NAME,
+                                     language=self.target_language,
+                                     project=self.project)
+        else:
+            self.parser = DBParser(index=self.INDEX_NAME)
+
+    def _set_latest_indexed_revision(self, **options):
         self.last_indexed_revision = -1
-
-        if options['rebuild'] and not options['dry_run']:
-            if es.indices.exists(self.INDEX_NAME):
-                es.indices.delete(index=self.INDEX_NAME)
-
-        if not options['dry_run'] and not es.indices.exists(self.INDEX_NAME):
-            es.indices.create(index=self.INDEX_NAME)
 
         if (not options['rebuild'] and
             not options['refresh'] and
-            es.indices.exists(self.INDEX_NAME)):
-            result = es.search(
+            self.es.indices.exists(self.INDEX_NAME)):
+
+            result = self.es.search(
                 index=self.INDEX_NAME,
                 body={
                     'query': {
@@ -159,6 +253,27 @@ class Command(BaseCommand):
             )
             self.last_indexed_revision = result['facets']['stat1']['max']
 
-        self.stdout.write("Last indexed revision = %s" % self.last_indexed_revision)
+        self.parser.last_indexed_revision = self.last_indexed_revision
 
-        success, _ = helpers.bulk(es, self._parse_translations(**options))
+        self.stdout.write("Last indexed revision = %s" %
+                          self.last_indexed_revision)
+
+    def handle(self, *args, **options):
+        self._initialize(*args, **options)
+
+        if (options['rebuild'] and
+            not options['dry_run'] and
+            self.es.indices.exists(self.INDEX_NAME)):
+
+            self.es.indices.delete(index=self.INDEX_NAME)
+
+        if (not options['dry_run'] and
+            not self.es.indices.exists(self.INDEX_NAME)):
+
+            self.es.indices.create(index=self.INDEX_NAME)
+
+        if self.is_local_tm:
+            self._set_latest_indexed_revision(**options)
+
+        success, _ = helpers.bulk(self.es,
+                                  self._parse_translations(*args, **options))

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -262,6 +262,43 @@ def check_settings(app_configs=None, **kwargs):
                     id="pootle.W015",
                 ))
 
+    if settings.POOTLE_TM_SERVER:
+        tm_indexes = []
+
+        for server in settings.POOTLE_TM_SERVER:
+            if 'INDEX_NAME' not in settings.POOTLE_TM_SERVER[server]:
+                errors.append(checks.Critical(
+                    _("POOTLE_TM_SERVER['%s'] has no INDEX_NAME.", server),
+                    hint=_("Set an INDEX_NAME for POOTLE_TM_SERVER['%s'].",
+                           server),
+                    id="pootle.C008",
+                ))
+            elif settings.POOTLE_TM_SERVER[server]['INDEX_NAME'] in tm_indexes:
+                errors.append(checks.Warning(
+                    _("Duplicate '%s' INDEX_NAME in POOTLE_TM_SERVER.",
+                      settings.POOTLE_TM_SERVER[server]['INDEX_NAME']),
+                    hint=_("Set different INDEX_NAME for all servers in "
+                           "POOTLE_TM_SERVER."),
+                    id="pootle.W018",
+                ))
+            else:
+                tm_indexes.append(settings.POOTLE_TM_SERVER[server]['INDEX_NAME'])
+
+            if 'WEIGHT' not in settings.POOTLE_TM_SERVER[server]:
+                errors.append(checks.Warning(
+                    _("POOTLE_TM_SERVER['%s'] has no WEIGHT.", server),
+                    hint=_("Set a WEIGHT for POOTLE_TM_SERVER['%s'].", server),
+                    id="pootle.W019",
+                ))
+            elif not (0.0 <= settings.POOTLE_TM_SERVER[server]['WEIGHT'] <= 1.0):
+                errors.append(checks.Warning(
+                    _("POOTLE_TM_SERVER['%s'] has a WEIGHT less than 0.0 or "
+                      "greater than 1.0", server),
+                    hint=_("Set a WEIGHT between 0.0 and 1.0 (both included) "
+                           "for POOTLE_TM_SERVER['%s'].", server),
+                    id="pootle.W020",
+                ))
+
     return errors
 
 

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -25,6 +25,9 @@ class ElasticSearchBackend(SearchBackend):
         super(ElasticSearchBackend, self).__init__(config_name)
         self._es = self._get_es_server()
         self._create_index_if_missing()
+        if self._es is not None:
+            self.weight = min(max(self._settings.get('WEIGHT', self.weight),
+                                  0.0), 1.0)
 
     def _server_setup_and_alive(self):
         if self._es is None:
@@ -86,6 +89,7 @@ class ElasticSearchBackend(SearchBackend):
                         'username': hit['_source']['username'],
                         'fullname': hit['_source']['fullname'],
                         'email_md5': hit['_source']['email_md5'],
+                        'score': hit['_score'] * self.weight,
                     })
                 else:
                     counter[translation_pair] += 1

--- a/pootle/core/search/base.py
+++ b/pootle/core/search/base.py
@@ -16,11 +16,26 @@ SERVER_SETTINGS_NAME = 'POOTLE_TM_SERVER'
 class SearchBackend(object):
     def __init__(self, config_name=None, **kwargs):
         self._setup_settings(config_name)
+        self.weight = 1.0
 
     def _setup_settings(self, config_name):
         self._settings = getattr(settings, SERVER_SETTINGS_NAME, None)
         if config_name is not None:
             self._settings = self._settings[config_name]
+
+    @property
+    def is_auto_updatable(self):
+        """Tells if TM is automatically updated from DB translations.
+
+        Basically this tells if TM is the 'local' TM.
+        """
+        for key, value in getattr(settings, SERVER_SETTINGS_NAME, {}).items():
+            if (value['INDEX_NAME'] == self._settings['INDEX_NAME'] and
+                key == 'local'):
+
+                return True
+
+        return False
 
     def search(self, unit):
         """Search for TM results.

--- a/pootle/core/search/broker.py
+++ b/pootle/core/search/broker.py
@@ -59,8 +59,14 @@ class SearchBroker(SearchBackend):
         for item in results:
             item['count'] = counter[item['source']+item['target']]
 
+        # Results are in the order of the TM servers, so they must be sorted by
+        # score so the better matches are presented to the user.
+        results = sorted(results, reverse=True,
+                         key=lambda item: item['score'])
+
         return results
 
     def update(self, language, obj):
         for server in self._servers:
-            self._servers[server].update(language, obj)
+            if self._servers[server].is_auto_updatable:
+                self._servers[server].update(language, obj)

--- a/pootle/settings/60-translation.conf
+++ b/pootle/settings/60-translation.conf
@@ -57,13 +57,26 @@ AMAGAMA_URL = 'https://amagama-live.translatehouse.org/api/v1/'
 # on the projects hosted on Pootle.
 # You may want to set AMAGAMA_URL to '' (empty string) if using this service.
 POOTLE_TM_SERVER = {
-    'default': {
+    'local': {
         'ENGINE': 'pootle.core.search.backends.ElasticSearchBackend',
         'HOST': 'localhost',
         'PORT': 9200,
+        # Every TM server must have its own unique index.
         'INDEX_NAME': 'translations',
+        # Provides a weighting factor to alter the final score for TM results
+        # from this TM server. Valid values are between ``0.0`` and ``1.0``,
+        # both included. Defaults to ``1.0`` if not provided.
+        'WEIGHT': 1.0,
         # For valid values for MIN_SCORE see
         # http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
+        'MIN_SCORE': 'AUTO',
+    },
+    'external': {
+        'ENGINE': 'pootle.core.search.backends.ElasticSearchBackend',
+        'HOST': 'localhost',
+        'PORT': 9200,
+        'INDEX_NAME': 'external-translations',
+        'WEIGHT': 0.9,
         'MIN_SCORE': 'AUTO',
     },
 }


### PR DESCRIPTION
This adds the ability to create additional translation memories, and use
them on the editor. Results are now pondered using the result score
and a weighting factor specific to each TM server (between 0 and 1).

Fixes #4102.