### PR TITLE
Local TM: Create the index if it is missing

### DIFF
--- a/docs/features/translation_memory.rst
+++ b/docs/features/translation_memory.rst
@@ -61,7 +61,7 @@ translation memory using the :djadmin:`update_tmserver` command:
 
 .. code-block:: bash
 
-   (env) $ pootle update_tmserver --rebuild
+   (env) $ pootle update_tmserver
 
 
 Once populated Pootle will keep Local TM up-to-date.

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -137,6 +137,9 @@ class Command(BaseCommand):
             if es.indices.exists(self.INDEX_NAME):
                 es.indices.delete(index=self.INDEX_NAME)
 
+        if not options['dry_run'] and not es.indices.exists(self.INDEX_NAME):
+            es.indices.create(index=self.INDEX_NAME)
+
         if (not options['rebuild'] and
             not options['overwrite'] and
             es.indices.exists(self.INDEX_NAME)):


### PR DESCRIPTION
This avoids us to have problems when trying to populate a
nonexistent TM.

Fixes #4120.