### PR TITLE
update_tmserver: Clarify command behavior

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -34,6 +34,8 @@ Details of changes
 - The editor for static pages now highlights the content's markup
   (:issue:`3346`).
 - Pulled latest translations.
+- :djadmin:`update_tmserver`: renamed :option:`--overwrite` to
+  :option:`--refresh`.
 
 
 ...and lots of refactoring, new tests, cleanups, improved documentation and of

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -394,6 +394,7 @@ Translation Memory
 These commands allow you to setup and manage :doc:`Translation Memory
 </features/translation_memory>`.
 
+
 .. django-admin:: update_tmserver
 
 update_tmserver
@@ -401,17 +402,26 @@ update_tmserver
 
 .. versionadded:: 2.7
 
+.. versionchanged:: 2.7.3 Renamed :option:`--overwrite` to :option:`--refresh`.
+
 Updates the ``default`` server in :setting:`POOTLE_TM_SERVER`.  The command
 reads translations from the current Pootle install and builds the TM resources
 in the TM server.
 
-By default the command will only add new translations to the server.  To
-rebuild the server from scratch use :option:`--rebuild`, this will completely
-remove the TM and rebuild it.  To ensure that the TM server remains available
-when you rebuild you can add :option:`--overwrite`.
+If no options are provided, the command will only add new translations to the
+server. Use :option:`--refresh` to also update existing translations that have
+been changed, besides adding any new translation. To completely remove the TM
+and rebuild it adding all existing translations use :option:`--rebuild`.
 
 To see how many units will be loaded into the server use :option:`--dry-run`,
-no actual data will be loaded.
+no actual data will be loaded or deleted (the TM will be left unchanged):
+
+.. code-block:: bash
+
+    $ pootle update_tmserver --dry-run
+    $ pootle update_tmserver --refresh --dry-run
+    $ pootle update_tmserver --rebuild --dry-run
+
 
 .. _commands#vfolders:
 

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -29,13 +29,12 @@ BULK_CHUNK_SIZE = 5000
 class Command(BaseCommand):
     help = "Load Local Translation Memory"
     option_list = BaseCommand.option_list + (
-        make_option('--overwrite',
+        make_option('--refresh',
                     action="store_true",
-                    dest='overwrite',
+                    dest='refresh',
                     default=False,
-                    help='Process all items, not just the new ones (useful to '
-                         'overwrite properties while keeping the index in a '
-                         'working condition)'),
+                    help='Process all items, not just the new ones, so '
+                         'existing translations are refreshed'),
         make_option('--rebuild',
                     action="store_true",
                     dest='rebuild',
@@ -141,7 +140,7 @@ class Command(BaseCommand):
             es.indices.create(index=self.INDEX_NAME)
 
         if (not options['rebuild'] and
-            not options['overwrite'] and
+            not options['refresh'] and
             es.indices.exists(self.INDEX_NAME)):
             result = es.search(
                 index=self.INDEX_NAME,


### PR DESCRIPTION
--overwrite has been renamed to --refresh as it is more explanatory.

Rewrote docs to make it clear what is the command behavior for each
scenario. The note on "TM server remains available when you rebuild"
has been removed as it is not true, see #4135.

Fixes #4136.