### PR TITLE
Cleanup optparse make_options and settings

### DIFF
--- a/pootle/apps/accounts/management/commands/merge_user.py
+++ b/pootle/apps/accounts/management/commands/merge_user.py
@@ -17,11 +17,13 @@ class Command(UserCommand):
     args = "user other_user"
     help = "Merge user to other_user"
     shared_option_list = (
-        make_option("--no-delete",
-                    dest='delete',
-                    action="store_false",
-                    default=True,
-                    help="Don't delete user after merging."),
+        make_option(
+            "--no-delete",
+            dest='delete',
+            action="store_false",
+            default=True,
+            help="Don't delete user after merging.",
+        ),
     )
     option_list = UserCommand.option_list + shared_option_list
 

--- a/pootle/apps/accounts/management/commands/verify_user.py
+++ b/pootle/apps/accounts/management/commands/verify_user.py
@@ -21,8 +21,12 @@ class Command(UserCommand):
     args = "[user]"
     help = "Verify a user of the system without requiring email verification"
     shared_option_list = (
-        make_option('--all', dest='all', action="store_true",
-                    help='Verify all users'),
+        make_option(
+            '--all',
+            dest='all',
+            action="store_true",
+            help='Verify all users',
+        ),
     )
     option_list = UserCommand.option_list + shared_option_list
 

--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -22,9 +22,13 @@ from pootle_store.models import Store
 
 class Command(PootleCommand):
     option_list = PootleCommand.option_list + (
-        make_option("--path", action="store", dest="pootle_path",
-                    help="Export a single file"),
-        )
+        make_option(
+            "--path",
+            action="store",
+            dest="pootle_path",
+            help="Export a single file",
+        ),
+    )
     help = "Export a Project, Translation Project, or path. " \
            "Multiple files will be zipped."
 

--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -47,9 +47,8 @@ class Command(PootleCommand):
         if self.projects:
             project_query = project_query.filter(code__in=self.projects)
 
-        path = options.get("pootle_path")
-        if path:
-            return self.handle_path(path, **options)
+        if options['pootle_path'] is not None:
+            return self.handle_path(options['pootle_path'], **options)
 
         # support exporting an entire project
         if self.projects and not self.languages:

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -22,16 +22,32 @@ from pootle_translationproject.models import TranslationProject
 class PootleCommand(NoArgsCommand):
     """Base class for handling recursive pootle store management commands."""
     shared_option_list = (
-        make_option('--project', action='append', dest='projects',
-                    help='Project to refresh'),
-        make_option('--language', action='append', dest='languages',
-                    help='Language to refresh'),
-        make_option("--noinput", action="store_true", default=False,
-                    help=u"Never prompt for input"),
-        make_option("--no-rq", action="store_true", default=False,
-                    help=(u"Run all jobs in a single process, without "
-                          "using rq workers")),
-        )
+        make_option(
+            '--project',
+            action='append',
+            dest='projects',
+            help='Project to refresh',
+        ),
+        make_option(
+            '--language',
+            action='append',
+            dest='languages',
+            help='Language to refresh',
+        ),
+        make_option(
+            "--noinput",
+            action="store_true",
+            default=False,
+            help=u"Never prompt for input",
+        ),
+        make_option(
+            "--no-rq",
+            action="store_true",
+            default=False,
+            help=(u"Run all jobs in a single process, without "
+                  "using rq workers"),
+        ),
+    )
     option_list = NoArgsCommand.option_list + shared_option_list
     process_disabled_projects = False
 
@@ -135,10 +151,21 @@ class BaseRunCommand(BaseCommand):
     Based on code from `django-shoes
     <https://bitbucket.org/mlzboy/django-shoes/>`_."""
     hostport_option_list = (
-        make_option('--host', action='store', dest='host', default='127.0.0.1',
-            help='Hostname to listen on.'),
-        make_option('--port', action='store', dest='port', default=8000,
-            type=int, help='The TCP port to listen on.'),
+        make_option(
+            '--host',
+            action='store',
+            dest='host',
+            default='127.0.0.1',
+            help='Hostname to listen on.',
+        ),
+        make_option(
+            '--port',
+            action='store',
+            dest='port',
+            default=8000,
+            type=int,
+            help='The TCP port to listen on.',
+        ),
     )
 
     option_list = BaseCommand.option_list + hostport_option_list

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -27,8 +27,12 @@ class Command(PootleCommand):
     help = "Allow checks to be recalculated manually."
 
     shared_option_list = (
-        make_option('--check', action='append', dest='check_names',
-                    help='Check to recalculate'),
+        make_option(
+            '--check',
+            action='append',
+            dest='check_names',
+            help='Check to recalculate'
+        ),
     )
 
     cached_methods = [CachedMethods.CHECKS]

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -31,6 +31,7 @@ class Command(PootleCommand):
             '--check',
             action='append',
             dest='check_names',
+            default=None,
             help='Check to recalculate'
         ),
     )
@@ -39,20 +40,17 @@ class Command(PootleCommand):
     process_disabled_projects = True
 
     def handle_all_stores(self, translation_project, **options):
-        check_names = options.get('check_names', None)
-        calculate_checks(check_names=check_names,
+        calculate_checks(check_names=options['check_names'],
                          translation_project=translation_project)
 
     def handle_all(self, **options):
         if not self.projects and not self.languages:
             logging.info(u"Running %s (noargs)", self.name)
 
-            check_names = options.get('check_names', None)
-            translation_project = options.get('translation_project', None)
             try:
 
-                calculate_checks(check_names=check_names,
-                                 translation_project=translation_project)
+                calculate_checks(check_names=options['check_names'],
+                                 translation_project=options['translation_project'])
             except Exception:
                 logging.exception(u"Failed to run %s", self.name)
         else:

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -49,9 +49,7 @@ class Command(PootleCommand):
             logging.info(u"Running %s (noargs)", self.name)
 
             try:
-
-                calculate_checks(check_names=options['check_names'],
-                                 translation_project=options['translation_project'])
+                calculate_checks(check_names=options['check_names'])
             except Exception:
                 logging.exception(u"Failed to run %s", self.name)
         else:

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -35,6 +35,7 @@ class Command(PootleCommand):
             help='Check to recalculate'
         ),
     )
+    option_list = PootleCommand.option_list + shared_option_list
 
     cached_methods = [CachedMethods.CHECKS]
     process_disabled_projects = True

--- a/pootle/apps/pootle_app/management/commands/changed_languages.py
+++ b/pootle/apps/pootle_app/management/commands/changed_languages.py
@@ -27,9 +27,13 @@ class Command(NoArgsCommand):
     help = "List languages that were changed since last synchronization"
 
     option_list = BaseRunCommand.option_list + (
-        make_option('--after-revision', action='store', dest='after_revision',
-                    type=int,
-                    help='Show languages changed after any arbitrary revision'),
+        make_option(
+            '--after-revision',
+            action='store',
+            dest='after_revision',
+            type=int,
+            help='Show languages changed after any arbitrary revision',
+        ),
     )
 
     def handle_noargs(self, **options):

--- a/pootle/apps/pootle_app/management/commands/contributors.py
+++ b/pootle/apps/pootle_app/management/commands/contributors.py
@@ -25,8 +25,13 @@ User = get_user_model()
 
 class Command(PootleCommand):
     option_list = PootleCommand.option_list + (
-        make_option("--from-revision", type=int, default=0, dest="revision",
-                    help="Only count contributions newer than this revision"),
+        make_option(
+            "--from-revision",
+            type=int,
+            default=0,
+            dest="revision",
+            help="Only count contributions newer than this revision",
+        ),
     )
 
     help = "Print a list of contributors."

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -43,12 +43,24 @@ class Command(PootleCommand):
     help = "Dump data."
 
     shared_option_list = (
-        make_option('--stats', action='store_true', dest='stats',
-                    help='Dump stats'),
-        make_option('--data', action='store_true', dest='data',
-                    help='Data all data'),
-        make_option('--stop-level', action='store', dest='stop_level',
-                    default=-1),
+        make_option(
+            '--stats',
+            action='store_true',
+            dest='stats',
+            help='Dump stats',
+        ),
+        make_option(
+            '--data',
+            action='store_true',
+            dest='data',
+            help='Data all data',
+        ),
+        make_option(
+            '--stop-level',
+            action='store',
+            dest='stop_level',
+            default=-1,
+        ),
         )
     option_list = PootleCommand.option_list + shared_option_list
 

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -47,12 +47,14 @@ class Command(PootleCommand):
             '--stats',
             action='store_true',
             dest='stats',
+            default=False,
             help='Dump stats',
         ),
         make_option(
             '--data',
             action='store_true',
             dest='data',
+            default=False,
             help='Data all data',
         ),
         make_option(
@@ -60,21 +62,19 @@ class Command(PootleCommand):
             action='store',
             dest='stop_level',
             default=-1,
+            type=int,
         ),
         )
     option_list = PootleCommand.option_list + shared_option_list
 
     def handle_all(self, **options):
         if not self.projects and not self.languages:
-            stats = options.get('stats', False)
-            data = options.get('data', False)
-            stop_level = int(options.get('stop_level', -1))
 
-            if stats:
-                self.dump_stats(stop_level=stop_level)
+            if options['stats']:
+                self.dump_stats(stop_level=options['stop_level'])
                 return
-            if data:
-                self.dump_all(stop_level=stop_level)
+            if options['data']:
+                self.dump_all(stop_level=options['stop_level'])
                 return
 
             raise CommandError("Set --data or --stats option.")
@@ -82,16 +82,13 @@ class Command(PootleCommand):
             super(Command, self).handle_all(**options)
 
     def handle_translation_project(self, tp, **options):
-        stats = options.get('stats', False)
-        data = options.get('data', False)
-        stop_level = int(options.get('stop_level', -1))
-        if stats:
+        if options['stats']:
             res = {}
-            self._dump_stats(tp.directory, res, stop_level=stop_level)
+            self._dump_stats(tp.directory, res, stop_level=options['stop_level'])
             return
 
-        if data:
-            self._dump_item(tp.directory, 0, stop_level=stop_level)
+        if options['data']:
+            self._dump_item(tp.directory, 0, stop_level=options['stop_level'])
             return
 
         raise CommandError("Set --data or --stats option.")

--- a/pootle/apps/pootle_app/management/commands/list_languages.py
+++ b/pootle/apps/pootle_app/management/commands/list_languages.py
@@ -27,6 +27,7 @@ class Command(NoArgsCommand):
                 action="store",
                 dest="modified_since",
                 type=int,
+                default=0,
                 help="Only process translations newer than specified "
                      "revision"),
     )
@@ -43,9 +44,8 @@ class Command(NoArgsCommand):
         tps = TranslationProject.objects.distinct()
         tps = tps.exclude(language__code='templates').order_by('language__code')
 
-        revision = options.get("modified_since", 0)
-        if revision:
-            tps = tps.filter(submission__unit__revision__gt=revision)
+        if options['modified_since'] > 0:
+            tps = tps.filter(submission__unit__revision__gt=options['modified_since'])
 
         if projects:
             tps = tps.filter(project__code__in=projects)

--- a/pootle/apps/pootle_app/management/commands/list_languages.py
+++ b/pootle/apps/pootle_app/management/commands/list_languages.py
@@ -17,12 +17,18 @@ from django.core.management.base import NoArgsCommand
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
-            make_option('--project', action='append', dest='projects',
-                        help='Limit to PROJECTS'),
-            make_option("--modified-since", action="store", dest="modified_since",
-                        type=int,
-                        help="Only process translations newer than specified "
-                             "revision"),
+            make_option(
+                '--project',
+                action='append',
+                dest='projects',
+                help='Limit to PROJECTS'),
+            make_option(
+                "--modified-since",
+                action="store",
+                dest="modified_since",
+                type=int,
+                help="Only process translations newer than specified "
+                     "revision"),
     )
     help = "List language codes."
 

--- a/pootle/apps/pootle_app/management/commands/list_projects.py
+++ b/pootle/apps/pootle_app/management/commands/list_projects.py
@@ -24,6 +24,7 @@ class Command(NoArgsCommand):
             action="store",
             dest="modified_since",
             type=int,
+            default=0,
             help="Only process translations newer than specified revision",
         ),
     )
@@ -34,10 +35,9 @@ class Command(NoArgsCommand):
     def list_projects(self, **options):
         """List all projects on the server."""
 
-        revision = options.get("modified_since", 0)
-        if revision:
+        if options['modified_since'] > 0:
             from pootle_translationproject.models import TranslationProject
-            tps = TranslationProject.objects.filter(submission__id__gt=revision) \
+            tps = TranslationProject.objects.filter(submission__id__gt=options['modified_since']) \
                                             .distinct().values("project__code")
 
             for tp in tps:

--- a/pootle/apps/pootle_app/management/commands/list_projects.py
+++ b/pootle/apps/pootle_app/management/commands/list_projects.py
@@ -19,9 +19,12 @@ from pootle_project.models import Project
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
-        make_option("--modified-since",
-            action="store", dest="modified_since", type=int,
-            help="Only process translations newer than specified revision"
+        make_option(
+            "--modified-since",
+            action="store",
+            dest="modified_since",
+            type=int,
+            help="Only process translations newer than specified revision",
         ),
     )
 

--- a/pootle/apps/pootle_app/management/commands/list_projects.py
+++ b/pootle/apps/pootle_app/management/commands/list_projects.py
@@ -22,7 +22,7 @@ class Command(NoArgsCommand):
         make_option(
             "--modified-since",
             action="store",
-            dest="modified_since",
+            dest="revision",
             type=int,
             default=0,
             help="Only process translations newer than specified revision",
@@ -35,9 +35,9 @@ class Command(NoArgsCommand):
     def list_projects(self, **options):
         """List all projects on the server."""
 
-        if options['modified_since'] > 0:
+        if options['revision'] > 0:
             from pootle_translationproject.models import TranslationProject
-            tps = TranslationProject.objects.filter(submission__id__gt=options['modified_since']) \
+            tps = TranslationProject.objects.filter(submission__id__gt=options['revision']) \
                                             .distinct().values("project__code")
 
             for tp in tps:

--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -23,8 +23,12 @@ class Command(NoArgsCommand):
     help = "Refresh score"
 
     shared_option_list = (
-        make_option('--reset', action='store_true', dest='reset',
-                    help='Reset all scores to zero'),
+        make_option(
+            '--reset',
+            action='store_true',
+            dest='reset',
+            help='Reset all scores to zero',
+        ),
     )
 
     option_list = NoArgsCommand.option_list + shared_option_list

--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -27,6 +27,7 @@ class Command(NoArgsCommand):
             '--reset',
             action='store_true',
             dest='reset',
+            default=False,
             help='Reset all scores to zero',
         ),
     )
@@ -34,9 +35,8 @@ class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + shared_option_list
 
     def handle_noargs(self, **options):
-        reset = options.get('reset', False)
 
-        if reset:
+        if options['reset']:
             User = get_user_model()
             User.objects.all().update(score=0)
             ScoreLog.objects.all().delete()

--- a/pootle/apps/pootle_app/management/commands/revision.py
+++ b/pootle/apps/pootle_app/management/commands/revision.py
@@ -32,7 +32,7 @@ class Command(NoArgsCommand):
     help = "Print the number of the current revision."
 
     def handle_noargs(self, **options):
-        if options.get('restore'):
+        if options['restore']:
             from pootle_store.models import Unit
             Revision.set(Unit.max_revision())
 

--- a/pootle/apps/pootle_app/management/commands/revision.py
+++ b/pootle/apps/pootle_app/management/commands/revision.py
@@ -20,8 +20,13 @@ from pootle.core.models import Revision
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
-        make_option('--restore', action='store_true', default=False, dest='restore',
-                    help='Restore the current revision number from the DB.'),
+        make_option(
+            '--restore',
+            action='store_true',
+            default=False,
+            dest='restore',
+            help='Restore the current revision number from the DB.',
+        ),
     )
 
     help = "Print the number of the current revision."

--- a/pootle/apps/pootle_app/management/commands/run_cherrypy.py
+++ b/pootle/apps/pootle_app/management/commands/run_cherrypy.py
@@ -25,7 +25,7 @@ class Command(BaseRunCommand):
             dest='threads',
             default=5,
             type=int,
-            help='Number of working threads. Default: 5',
+            help='Number of working threads. Default: %default',
         ),
         make_option(
             '--name',

--- a/pootle/apps/pootle_app/management/commands/run_cherrypy.py
+++ b/pootle/apps/pootle_app/management/commands/run_cherrypy.py
@@ -47,14 +47,14 @@ class Command(BaseRunCommand):
             action='store',
             dest='ssl_certificate',
             default='',
-            help='Path to the server\'s SSL certificate.',
+            help="Path to the server's SSL certificate.",
         ),
         make_option(
             '--ssl_private_key',
             action='store',
             dest='ssl_private_key',
             default='',
-            help='Path to the server\'s SSL private key.',
+            help="Path to the server's SSL private key.",
         ),
     )
 

--- a/pootle/apps/pootle_app/management/commands/run_cherrypy.py
+++ b/pootle/apps/pootle_app/management/commands/run_cherrypy.py
@@ -19,20 +19,43 @@ class Command(BaseRunCommand):
     help = "Runs Pootle with the CherryPy server."
 
     option_list = BaseRunCommand.option_list + (
-        make_option('--threads', action='store', dest='threads', default=5,
+        make_option(
+            '--threads',
+            action='store',
+            dest='threads',
+            default=5,
             type=int,
-            help='Number of working threads. Default: 5'),
-        make_option('--name', action='store', dest='server_name', default='',
-            help='Name of the worker process.'),
-        make_option('--queue', action='store', dest='request_queue_size',
-            default=5, type=int,
-            help='Maximum number of queued connections.'),
-        make_option('--ssl_certificate', action='store',
-            dest='ssl_certificate', default='',
-            help='Path to the server\'s SSL certificate.'),
-        make_option('--ssl_private_key', action='store',
-            dest='ssl_private_key', default='',
-            help='Path to the server\'s SSL private key.'),
+            help='Number of working threads. Default: 5',
+        ),
+        make_option(
+            '--name',
+            action='store',
+            dest='server_name',
+            default='',
+            help='Name of the worker process.',
+        ),
+        make_option(
+            '--queue',
+            action='store',
+            dest='request_queue_size',
+            default=5,
+            type=int,
+            help='Maximum number of queued connections.',
+        ),
+        make_option(
+            '--ssl_certificate',
+            action='store',
+            dest='ssl_certificate',
+            default='',
+            help='Path to the server\'s SSL certificate.',
+        ),
+        make_option(
+            '--ssl_private_key',
+            action='store',
+            dest='ssl_private_key',
+            default='',
+            help='Path to the server\'s SSL private key.',
+        ),
     )
 
     def serve_forever(self, *args, **options):

--- a/pootle/apps/pootle_app/management/commands/sync_stores.py
+++ b/pootle/apps/pootle_app/management/commands/sync_stores.py
@@ -41,21 +41,16 @@ class Command(PootleCommand):
     help = "Save new translations to disk manually."
 
     def handle_all_stores(self, translation_project, **options):
-        overwrite = options.get('overwrite', False)
-        skip_missing = options.get('skip_missing', False)
-        force = options.get('force', False)
-
-
         translation_project.sync(
-                conservative=not overwrite,
-                skip_missing=skip_missing,
-                only_newer=not force
+                conservative=not options['overwrite'],
+                skip_missing=options['skip_missing'],
+                only_newer=not options['force']
         )
 
     def handle_store(self, store, **options):
-        overwrite = options.get('overwrite', False)
-        skip_missing = options.get('skip_missing', False)
-        force = options.get('force', False)
-
-        store.sync(conservative=not overwrite, update_structure=overwrite,
-                   skip_missing=skip_missing, only_newer=not force)
+        store.sync(
+            conservative=not options['overwrite'],
+            update_structure=options['overwrite'],
+            skip_missing=options['skip_missing'],
+            only_newer=not options['force']
+        )

--- a/pootle/apps/pootle_app/management/commands/sync_stores.py
+++ b/pootle/apps/pootle_app/management/commands/sync_stores.py
@@ -15,14 +15,29 @@ from pootle_app.management.commands import PootleCommand
 
 class Command(PootleCommand):
     option_list = PootleCommand.option_list + (
-        make_option('--overwrite', action='store_true', dest='overwrite',
-                    default=False, help="Don't just save translations, but "
-                    "overwrite files to reflect state in database"),
-        make_option('--skip-missing', action='store_true', dest='skip_missing',
-                    default=False, help="Ignore missing files on disk"),
-        make_option('--force', action='store_true', dest='force',
-                    default=False, help="Don't ignore stores synced after last change"),
-        )
+        make_option(
+            '--overwrite',
+            action='store_true',
+            dest='overwrite',
+            default=False,
+            help="Don't just save translations, but "
+                 "overwrite files to reflect state in database",
+        ),
+        make_option(
+            '--skip-missing',
+            action='store_true',
+            dest='skip_missing',
+            default=False,
+            help="Ignore missing files on disk",
+        ),
+        make_option(
+            '--force',
+            action='store_true',
+            dest='force',
+            default=False,
+            help="Don't ignore stores synced after last change",
+        ),
+    )
     help = "Save new translations to disk manually."
 
     def handle_all_stores(self, translation_project, **options):

--- a/pootle/apps/pootle_app/management/commands/test_checks.py
+++ b/pootle/apps/pootle_app/management/commands/test_checks.py
@@ -25,13 +25,28 @@ class Command(NoArgsCommand):
     help = "Tests quality checks against string pairs."
 
     shared_option_list = (
-        make_option('--check', action='append', dest='checks',
-                    help='Check name to check for'),
-        make_option('--source', dest='source', help='Source string'),
-        make_option('--unit', dest='unit', help='Unit id'),
-        make_option('--target', dest='target',
-                    help='Translation string'),
-        )
+        make_option(
+            '--check',
+            action='append',
+            dest='checks',
+            help='Check name to check for',
+        ),
+        make_option(
+            '--source',
+            dest='source',
+            help='Source string',
+        ),
+        make_option(
+            '--unit',
+            dest='unit',
+            help='Unit id',
+        ),
+        make_option(
+            '--target',
+            dest='target',
+            help='Translation string',
+        ),
+    )
     option_list = NoArgsCommand.option_list + shared_option_list
 
     def handle_noargs(self, **options):

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -20,15 +20,22 @@ from pootle_translationproject.models import scan_translation_projects
 
 class Command(PootleCommand):
     option_list = PootleCommand.option_list + (
-        make_option('--overwrite', action='store_true', dest='overwrite',
-                    default=False,
-                    help="Don't just update untranslated units "
-                         "and add new units, but overwrite database "
-                         "translations to reflect state in files."),
-        make_option('--force', action='store_true', dest='force', default=False,
-                    help="Unconditionally process all files (even if they "
-                         "appear unchanged)."),
-        )
+        make_option(
+            '--overwrite',
+            action='store_true',
+            dest='overwrite',
+            default=False,
+            help="Don't just update untranslated units "
+                 "and add new units, but overwrite database "
+                 "translations to reflect state in files."),
+        make_option(
+            '--force',
+            action='store_true',
+            dest='force',
+            default=False,
+            help="Unconditionally process all files (even if they "
+                 "appear unchanged)."),
+    )
     help = "Update database stores from files."
 
     def handle_translation_project(self, translation_project, **options):

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -51,10 +51,10 @@ class Command(PootleCommand):
         return False
 
     def handle_store(self, store, **options):
-        overwrite = options.get('overwrite', False)
-        force = options.get('force', False)
-
-        store.update(overwrite=overwrite, only_newer=not force)
+        store.update(
+            overwrite=options['overwrite'],
+            only_newer=not options['force']
+        )
 
     def handle_all(self, **options):
         scan_translation_projects(languages=self.languages,

--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -24,12 +24,14 @@ class Command(BaseCommand):
     help = 'Builds and bundles static assets using webpack'
 
     option_list = BaseCommand.option_list + (
-        make_option('--dev',
+        make_option(
+            '--dev',
             action='store_true',
             dest='dev',
             default=False,
-            help='Enable development builds and watch for changes.'),
-        )
+            help='Enable development builds and watch for changes.',
+        ),
+    )
 
     def handle(self, *args, **options):
         default_static_dir = os.path.join(settings.WORKING_DIR, 'static')

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -235,14 +235,24 @@ def run_app(project, default_settings_path, settings_template,
     args, remainder = parser.parse_known_args(sys.argv[1:])
 
     # Add pootle args
-    parser.add_argument("--config",
-                        default=default_settings_path,
-                        help=u"Use the specified configuration file.")
-    parser.add_argument("--noinput", action="store_true", default=False,
-                        help=u"Never prompt for input")
-    parser.add_argument("--no-rq", action="store_true", default=False,
-                        help=(u"Run all jobs in a single process, without "
-                              "using rq workers"))
+    parser.add_argument(
+        "--config",
+        default=default_settings_path,
+        help=u"Use the specified configuration file.",
+    )
+    parser.add_argument(
+        "--noinput",
+        action="store_true",
+        default=False,
+        help=u"Never prompt for input",
+    )
+    parser.add_argument(
+        "--no-rq",
+        action="store_true",
+        default=False,
+        help=(u"Run all jobs in a single process, without "
+              "using rq workers"),
+    )
 
     # Parse the init command by hand to prevent raising a SystemExit while
     # parsing


### PR DESCRIPTION
This cleans up the configuration of the various options and tries to remove ``options.get('x')`` in favour of ``options['x']``