### PR TITLE
Static pages: implemented live preview

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -32,8 +32,8 @@ complete information.
 Details of changes
 ==================
 
-- The editor for static pages now highlights the content's markup
-  (:issue:`3346`).
+- The editor for static pages now highlights the content's markup and displays a
+  live preview of the rendered contents (:issue:`3346`, :issue:`3766`).
 - Pulled latest translations.
 - :djadmin:`update_tmserver`:
 

--- a/pootle/apps/staticpages/urls.py
+++ b/pootle/apps/staticpages/urls.py
@@ -39,7 +39,16 @@ admin_patterns = patterns('',
 )
 
 
+xhr_patterns = patterns('',
+    url(r'^preview/?$',
+        'staticpages.views.preview_content',
+        name='pootle-xhr-preview'),
+)
+
+
 urlpatterns = patterns('',
     url(r'^pages/',
         include(page_patterns)),
+    url(r'^xhr/',
+        include(xhr_patterns)),
 )

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -17,6 +17,7 @@ from django.views.generic import (CreateView, DeleteView, TemplateView,
                                   UpdateView)
 
 from pootle.core.http import JsonResponse, JsonResponseBadRequest
+from pootle.core.markup.filters import apply_markup_filter
 from pootle.core.views import SuperuserRequiredMixin
 from pootle_misc.util import ajax_required
 
@@ -223,3 +224,16 @@ def legal_agreement(request):
 
     rendered_form = _get_rendered_agreement(request, form_class())
     return JsonResponse({'form': rendered_form})
+
+
+@ajax_required
+def preview_content(request):
+    """Returns content rendered based on the configured markup settings."""
+    if 'text' not in request.POST:
+        return JsonResponseBadRequest({
+            'msg': _('Text is missing'),
+        })
+
+    return JsonResponse({
+        'rendered': apply_markup_filter(request.POST['text']),
+    })

--- a/pootle/static/js/admin/general/components/ContentEditor.js
+++ b/pootle/static/js/admin/general/components/ContentEditor.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+import CodeMirror from 'components/CodeMirror';
+import { getName } from 'utils/markup';
+
+
+const ContentEditor = React.createClass({
+
+  propTypes: {
+    markup: React.PropTypes.string,
+    // Temporarily needed to support submitting forms not controlled by JS
+    name: React.PropTypes.string,
+    onChange: React.PropTypes.func,
+    style: React.PropTypes.object,
+    value: React.PropTypes.string,
+  },
+
+  render() {
+    const { markup } = this.props;
+    const markupName = getName(markup);
+
+    return (
+      <div
+        className="content-editor"
+        style={this.props.style}
+      >
+        <CodeMirror
+          markup={markup}
+          name={this.props.name}
+          value={this.props.value}
+          onChange={this.props.onChange}
+          placeholder={gettext(`Allowed markup: ${markupName}`)}
+        />
+      </div>
+    );
+  },
+
+});
+
+
+export default ContentEditor;

--- a/pootle/static/js/admin/general/components/ContentPreview.js
+++ b/pootle/static/js/admin/general/components/ContentPreview.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+
+const ContentPreview = React.createClass({
+
+  propTypes: {
+    value: React.PropTypes.string.isRequired,
+
+    style: React.PropTypes.object,
+  },
+
+  render() {
+    return (
+      <div
+        className="content-preview"
+        style={this.props.style}
+      >
+        {this.props.value ?
+          <div
+            className="staticpage"
+            dangerouslySetInnerHTML={{__html: this.props.value}}
+          /> :
+          <div className="placeholder">
+            {gettext('Preview will be displayed here.')}
+          </div>
+        }
+      </div>
+    );
+  },
+
+});
+
+
+export default ContentPreview;

--- a/pootle/static/js/admin/general/components/LiveEditor.css
+++ b/pootle/static/js/admin/general/components/LiveEditor.css
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+/* ContentEditor */
+
+.content-editor
+{
+    border: 1px solid #dadada;
+}
+
+.content-editor .CodeMirror
+{
+    border: 0;
+    cursor: text;
+}
+
+
+/* ContentPreview */
+
+.content-preview
+{
+    border: 1px solid #dadada;
+}
+
+.content-preview .staticpage
+{
+    margin: 0 auto;
+    padding: 0;
+}
+
+.placeholder
+{
+    font-style: italic;
+    color: #999;
+}
+
+
+/* LiveEditor */
+
+.live-editor
+{
+    display: flex;
+    flex-direction: column;
+}
+
+.content-editor,
+.content-preview
+{
+    flex: 1;
+}
+
+.content-preview
+{
+    overflow-y: scroll;
+}
+
+.content-editor
+{
+    margin-bottom: 1.5em;
+}
+
+.content-editor .CodeMirror
+{
+    height: 100%;
+}
+
+@media screen and (min-width: 1600px)
+{
+    .live-editor
+    {
+        flex-direction: row;
+    }
+
+    .content-editor
+    {
+        border-right: 0;
+        margin-bottom: 0;
+    }
+}

--- a/pootle/static/js/admin/general/components/LiveEditor.js
+++ b/pootle/static/js/admin/general/components/LiveEditor.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+import _ from 'underscore';
+
+import { outerHeight } from 'utils/dimensions';
+import fetch from 'utils/fetch';
+
+import ContentEditor from './ContentEditor';
+import ContentPreview from './ContentPreview';
+
+import './LiveEditor.css';
+
+
+const SPLIT_WIDTH = 1600;
+const CONTENT_MARGIN = 30;  // ~1.5em+
+const WRAPPER_MARGIN = 40;  // ~2em
+
+
+export const LiveEditor = React.createClass({
+
+  propTypes: {
+    markup: React.PropTypes.string.isRequired,
+    // Temporarily needed to support submitting forms not controlled by JS
+    name: React.PropTypes.string.isRequired,
+    initialValue: React.PropTypes.string.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      value: this.props.initialValue,
+      renderedValue: '',
+    }
+  },
+
+  componentWillMount() {
+    if (this.props.markup === 'html') {
+      this.loadPreview = () => this.setState({ renderedValue: this.state.value });
+    } else {
+      this.loadPreview = _.debounce(this.loadRemotePreview, 300);
+    }
+
+    this.updateDimensions();
+  },
+
+  componentDidMount() {
+    this.loadPreview();
+
+    window.addEventListener('resize', this.updateDimensions);
+  },
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateDimensions);
+  },
+
+  handleChange(newValue) {
+    this.setState({ value: newValue });
+    this.loadPreview();
+  },
+
+  loadRemotePreview() {
+    fetch({
+      url: '/xhr/preview/',
+      body: {
+        text: this.state.value,
+      },
+    }).then((response) => {
+      this.setState({ renderedValue: response.rendered });
+    });
+  },
+
+  updateDimensions() {
+    // FIXME: this can perfectly be part of the single state atom, and be
+    // available to any component needing it via context.
+    this.setState({
+      height: window.innerHeight,
+      width: window.innerWidth,
+    });
+  },
+
+  getContentHeight() {
+    const topHeight = (
+      outerHeight(document.querySelector('#navbar')) +
+      outerHeight(document.querySelector('#header-meta')) +
+      outerHeight(document.querySelector('#header-tabs'))
+    );
+    const footerHeight = outerHeight(document.querySelector('#footer'));
+
+    const formFieldNodes = document.querySelectorAll('.js-staticpage-non-content');
+    const formFields = Array.prototype.slice.call(formFieldNodes, 0);
+    const fieldsHeight = (
+      formFields.reduce((total, fieldEl) => total + outerHeight(fieldEl), 0)
+    );
+
+    const usedHeight = topHeight + fieldsHeight + footerHeight + WRAPPER_MARGIN;
+    const contentHeight = this.state.height - usedHeight;
+
+    // Actual size is divided by two in the horizontal split
+    if (this.state.width <= SPLIT_WIDTH) {
+      return (contentHeight - CONTENT_MARGIN) / 2;
+    }
+
+    return contentHeight;
+  },
+
+  render() {
+    const { renderedValue, value } = this.state;
+    const contentHeight = Math.max(100, this.getContentHeight());
+    const contentStyle = {
+      height: contentHeight,
+      minHeight: contentHeight,  // Required for Firefox
+      maxHeight: contentHeight,  // Required for Firefox
+    };
+
+    return (
+      <div className="live-editor">
+        <ContentEditor
+          markup={this.props.markup}
+          name={this.props.name}
+          onChange={this.handleChange}
+          style={contentStyle}
+          value={value}
+        />
+        <ContentPreview
+          style={contentStyle}
+          value={renderedValue}
+        />
+      </div>
+    );
+  },
+
+});
+
+
+export default LiveEditor;

--- a/pootle/static/js/admin/general/staticpages.js
+++ b/pootle/static/js/admin/general/staticpages.js
@@ -8,17 +8,17 @@
 
 import React from 'react';
 
-import CodeMirror from 'components/CodeMirror';
+import LiveEditor from './components/LiveEditor';
 
 
 const staticpages = {
 
   init(opts) {
     React.render(
-      <CodeMirror
+      <LiveEditor
+        initialValue={opts.initialValue}
         markup={opts.markup}
         name={opts.htmlName}
-        value={opts.initialValue}
       />,
       document.querySelector('.js-staticpage-editor')
     );

--- a/pootle/static/js/shared/utils/markup.js
+++ b/pootle/static/js/shared/utils/markup.js
@@ -16,3 +16,16 @@ export function getMode(markup) {
     restructuredtext: 'rst',
   }[markup] || markup;
 }
+
+
+/**
+ * Returns a human-readable name for the markup module
+ */
+export function getName(markup) {
+  return {
+    html: 'HTML',
+    markdown: 'Markdown',
+    restructuredtext: 'reStructuredText',
+    textile: 'Textile',
+  }[markup] || markup;
+}

--- a/pootle/templates/admin/staticpages/_field.html
+++ b/pootle/templates/admin/staticpages/_field.html
@@ -1,4 +1,4 @@
-<div class="control-group">
+<div class="control-group js-staticpage-non-content">
   {{ field.label_tag }}
   <div class="controls">
     {% if not help_pre %}{{ field }}{% endif %}

--- a/pootle/templates/admin/staticpages/_form.html
+++ b/pootle/templates/admin/staticpages/_form.html
@@ -14,7 +14,7 @@
     {% include 'admin/staticpages/_field.html' with field=form.active %}
     {% if form.url %}
     {% include 'admin/staticpages/_field.html' with field=form.url %}
-    <div class="control-group-separator">
+    <div class="control-group-separator js-staticpage-non-content">
       <span class="help_text">{% trans "or" %}</span>
     </div>
     {% endif %}
@@ -23,11 +23,10 @@
       {{ form.body.label_tag }}
       <div class="controls">
         <div class="js-staticpage-editor"></div>
-        {{ form.body.help_text }}
       </div>
     </div>
 
-    <div class="control-group">
+    <div class="control-group js-staticpage-non-content">
       <div class="controls controls-btn">
         <input type="submit" class="btn" value="{% trans 'Save' %}" />
         <ul>


### PR DESCRIPTION
This PR implements the live preview feature for static pages.

I'm putting this up for testing and further feedback. While at its current state this is fully functional, I'd still like to make a couple of changes before considering to merge it:
* Fix the styling of the content editing/previewing boxes and adjust their heights
* Make the `<ContentPreview />` component _dumb_ (i.e. do not hold any local state, just accept props)

Fixes #3766.