### PR TITLE
l10n: Fix mute/unmute checks events in timeline

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -636,11 +636,9 @@ def timeline(request, unit):
                 entry.update({
                     'check_name': check_name,
                     'check_display_name': check_names[check_name],
-                    'checks_url': reverse('pootle-checks-descriptions'),
-                    'action': {
-                                SubmissionTypes.MUTE_CHECK: 'Muted',
-                                SubmissionTypes.UNMUTE_CHECK: 'Unmuted'
-                              }.get(item.type, '')
+                    'checks_url': u''.join([
+                        reverse('pootle-checks-descriptions'), '#', check_name,
+                    ]),
                 })
             else:
                 entry['new_value'] = to_python(item.new_value)

--- a/pootle/templates/editor/units/xhr_timeline.html
+++ b/pootle/templates/editor/units/xhr_timeline.html
@@ -34,7 +34,15 @@
               <span class="timeline-field-body" lang="{{ language.code }}">{{ entry.new_value }}</span>
             {% elif entry.field == 0 %}
               {% if entry.check_name %}
-                {{ entry.action }} <a href="{{ entry.checks_url }}#{{ entry.check_name }}">{{ entry.check_display_name}}</a> {% trans "check" %}
+                {% if entry.type == 6 %}
+                {% blocktrans with check_url=entry.checks_url check_name=entry.check_display_name trimmed %}
+                  Muted <a href="{{ check_url }}">{{ check_name }}</a> check
+                  {% endblocktrans %}
+                {% elif entry.type == 7 %}
+                  {% blocktrans with check_url=entry.checks_url check_name=entry.check_display_name trimmed %}
+                  Unmuted <a href="{{ check_url }}">{{ check_name }}</a> check
+                  {% endblocktrans %}
+                {% endif %}
               {% endif %}
             {% else %}
               {{ entry.old_value }} <span class="timeline-arrow"></span> {{ entry.new_value }}


### PR DESCRIPTION
Hardcoding types on template doesn't seem like the best way to do this, but putting HTML code in views is neither pretty.