### PR TITLE
Stats: wrap jobs with close_if_unusable_or_obsolete()

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -57,6 +57,8 @@ Details of changes
 - `InnoDB <https://dev.mysql.com/doc/refman/5.6/en/innodb-storage-engine.html>`_
   is the only accepted MySQL backend. Deployments using MyISAM must
   :doc:`migrate to either MySQL (InnoDB) or PostgreSQL </server/database_migration>`.
+- Close a database connection before and after each rqworker job once it exceeds
+  the maximum age to imitate Django's request/response cycle.
 
 
 ...and lots of refactoring, new tests, cleanups, improved documentation and of

--- a/docs/server/mysql_installation.rst
+++ b/docs/server/mysql_installation.rst
@@ -100,18 +100,28 @@ connecting to the database. For MySQL the correct :setting:`ENGINE
    }
 
 
-Please note that MySQL terminates idle connections after `wait_timeout`.
-Thus setting `:setting:CONN_MAX_AGE<django:DATABASE-CONN_MAX_AGE>` to lower
-value will be fine. Default value is `0`.
-Persistent connections where `:setting:CONN_MAX_AGE<django:DATABASE-CONN_MAX_AGE>`
-is `None` can't be used with MySQL.
-See https://docs.djangoproject.com/en/1.7/ref/databases/#connection-management
+.. _mysql_installation#persistent-connections:
+
+A Note on Persistent Connections
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MySQL terminates idle connections after `wait_timeout
+<https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_wait_timeout>`_
+seconds. Thus setting :setting:`CONN_MAX_AGE <django:CONN_MAX_AGE>` to a lower
+value will be fine (it defaults to ``0``).  Persistent connections where
+:setting:`CONN_MAX_AGE <django:CONN_MAX_AGE>` is ``None`` can't be used with
+MySQL.
+
+To learn more please check `Django's docs on persistent connections and
+connection management
+<https://docs.djangoproject.com/en/1.7/ref/databases/#connection-management>`_.
 
 
 .. code-block:: python
 
    DATABASES = {
        'default': {
+           ...
            'CONN_MAX_AGE': 0,
            ...
        }

--- a/docs/server/mysql_installation.rst
+++ b/docs/server/mysql_installation.rst
@@ -99,3 +99,20 @@ connecting to the database. For MySQL the correct :setting:`ENGINE
        }
    }
 
+
+Please note that MySQL terminates idle connections after `wait_timeout`.
+Thus setting `:setting:CONN_MAX_AGE<django:DATABASE-CONN_MAX_AGE>` to lower
+value will be fine. Default value is `0`.
+Persistent connections where `:setting:CONN_MAX_AGE<django:DATABASE-CONN_MAX_AGE>`
+is `None` can't be used with MySQL.
+See https://docs.djangoproject.com/en/1.7/ref/databases/#connection-management
+
+
+.. code-block:: python
+
+   DATABASES = {
+       'default': {
+           'CONN_MAX_AGE': 0,
+           ...
+       }
+   }

--- a/docs/server/postgresql_installation.rst
+++ b/docs/server/postgresql_installation.rst
@@ -95,3 +95,20 @@ connecting to the database. For PostgreSQL the correct :setting:`ENGINE
            ...
        }
    }
+
+Please note that default value for `:setting:CONN_MAX_AGE
+<django:DATABASE-CONN_MAX_AGE>` is `0`. It means that Django creates a connection
+before every request and closes it in the end. PostgreSQL supports persistent
+connections. It will be fine to set `:setting:CONN_MAX_AGE
+<django:DATABASE-CONN_MAX_AGE>` to `None`.
+See https://docs.djangoproject.com/en/1.7/ref/databases/#connection-management
+
+
+.. code-block:: python
+
+   DATABASES = {
+       'default': {
+           'CONN_MAX_AGE': None,
+           ...
+       }
+   }

--- a/docs/server/postgresql_installation.rst
+++ b/docs/server/postgresql_installation.rst
@@ -96,18 +96,26 @@ connecting to the database. For PostgreSQL the correct :setting:`ENGINE
        }
    }
 
-Please note that default value for `:setting:CONN_MAX_AGE
-<django:DATABASE-CONN_MAX_AGE>` is `0`. It means that Django creates a connection
-before every request and closes it in the end. PostgreSQL supports persistent
-connections. It will be fine to set `:setting:CONN_MAX_AGE
-<django:DATABASE-CONN_MAX_AGE>` to `None`.
-See https://docs.djangoproject.com/en/1.7/ref/databases/#connection-management
 
+.. _postgresql_installation#persistent-connections:
+
+A Note on Persistent Connections
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default value for :setting:`CONN_MAX_AGE <django:DATABASE-CONN_MAX_AGE>` is
+``0``. It means that Django creates a connection before every request and closes
+it at the end. PostgreSQL supports persistent connections, and it will be fine
+to set :setting:`CONN_MAX_AGE <django:DATABASE-CONN_MAX_AGE>` to ``None``.
+
+To learn more please check `Django's docs on persistent connections and
+connection management
+<https://docs.djangoproject.com/en/1.7/ref/databases/#connection-management>`_.
 
 .. code-block:: python
 
    DATABASES = {
        'default': {
+           ...
            'CONN_MAX_AGE': None,
            ...
        }

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -681,7 +681,14 @@ def update_cache_job(instance):
     job = get_current_job()
     job_wrapper = JobWrapper(job.id, job.connection)
     keys, decrement = job_wrapper.get_job_params()
+
+    # close unusable and obsolete connections before and after the job
+    # Note: setting CONN_MAX_AGE parameter can have negative side-effects
+    # CONN_MAX_AGE value should be lower than DB wait_timeout
+    connection.close_if_unusable_or_obsolete()
     instance._update_cache_job(keys, decrement)
+    connection.close_if_unusable_or_obsolete()
+
     job_wrapper.clear_job_params()
 
 


### PR DESCRIPTION
Imitate Django's request/response cycle for rqworker jobs.
Fixes #4094