### PR TITLE
Overriding django.core.mail.send_mail to set outgoing email headers

### DIFF
--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -16,6 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from contact_form.forms import ContactForm as OriginalContactForm
 
 from pootle.core.forms import MathCaptchaForm
+from pootle.core.mail import send_mail
 
 
 class ContactForm(MathCaptchaForm, OriginalContactForm):
@@ -55,6 +56,15 @@ class ContactForm(MathCaptchaForm, OriginalContactForm):
 
     def recipient_list(self):
         return [settings.POOTLE_CONTACT_EMAIL]
+
+    def save(self, fail_silently=False):
+        """Build and send the email message."""
+
+        kwargs = self.get_message_dict()
+        kwargs["headers"] = {"Reply-To": kwargs["from_email"]}
+        kwargs["from_email"] = settings.DEFAULT_FROM_EMAIL
+        send_mail(fail_silently=fail_silently, **kwargs)
+
 
 # Alters form's field order. Use `self.field_order` when in Django 1.9+
 ContactForm.base_fields = OrderedDict(

--- a/pootle/core/mail.py
+++ b/pootle/core/mail.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.conf import settings
+from django.core.mail import get_connection, EmailMultiAlternatives
+
+
+def send_mail(subject, message, from_email, recipient_list,
+              fail_silently=False, auth_user=None, auth_password=None,
+              connection=None, html_message=None, headers=None):
+    """Override django send_mail function to allow use of custom email headers.
+    """
+
+    connection = connection or get_connection(username=auth_user,
+                                              password=auth_password,
+                                              fail_silently=fail_silently)
+
+    mail = EmailMultiAlternatives(subject, message,
+                                  from_email, recipient_list,
+                                  connection=connection, headers=headers)
+
+    if html_message:
+        mail.attach_alternative(html_message, 'text/html')
+
+    return mail.send()


### PR DESCRIPTION
Use `settings.DEFAULT_FROM_EMAIL` as from_email and set the reply-to
header to user's email

Fixes #4176