### PR TITLE
Allow initdb to be run without creating projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - DJANGO_SETTINGS_MODULE=pootle.settings ./setup.py build_checks_templates
   - ./manage.py migrate --noinput --traceback
   - ./manage.py migrate | (egrep "Your models have changes" && exit 1 || exit 0)
-  - ./manage.py initdb --traceback
+  - ./manage.py initdb --traceback --no-projects
   - ./manage.py runserver --traceback &
   - TESTPID=$!
   - sleep 10

--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -66,7 +66,8 @@ Details of changes
 - Close a database connection before and after each rqworker job once it exceeds
   the maximum age to imitate Django's request/response cycle.
 - Language managers can now edit their language's special characters.
-
+- :djadmin:`initdb` now has an :option:`--no-projects` to prevent creating
+  the default projects at set up.
 
 ...and lots of refactoring, new tests, cleanups, improved documentation and of
 course, loads of bugs were fixed.

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -671,6 +671,14 @@ tutorial project.
    best to run** :djadmin:`refresh_stats` **immediately after initdb**.
 
 
+:djadmin:`initdb` accepts the following option:
+
+.. versionadded:: 2.7.3
+
+:option:`--no-projects`:
+   Don't create the default ``terminology`` and ``tutorial`` projects.
+
+
 .. _commands#collectstatic:
 
 collectstatic

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -7,6 +7,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from optparse import make_option
 import os
 
 # This must be run before importing Django.
@@ -20,9 +21,16 @@ from pootle.core.initdb import initdb
 class Command(NoArgsCommand):
     help = 'Populates the database with initial values: users, projects, ...'
 
+    option_list = NoArgsCommand.option_list + (
+        make_option(
+            '--no-projects',
+            action='store_false',
+            dest='create_projects',
+            default=True), )
+
     def handle_noargs(self, **options):
         self.stdout.write('Populating the database.')
-        initdb()
+        initdb(options["create_projects"])
         self.stdout.write('Successfully populated the database.')
         self.stdout.write("To create an admin user, use the `pootle "
                           "createsuperuser` command.")

--- a/pootle/core/initdb.py
+++ b/pootle/core/initdb.py
@@ -20,7 +20,7 @@ from pootle_project.models import Project
 from staticpages.models import StaticPage as Announcement
 
 
-def initdb():
+def initdb(create_projects=True):
     """Populate the database with default initial data.
 
     This creates the default database to get a working Pootle installation.
@@ -29,10 +29,12 @@ def initdb():
     create_essential_users()
     create_root_directories()
     create_template_languages()
-    create_terminology_project()
+    if create_projects:
+        create_terminology_project()
     create_pootle_permissions()
     create_pootle_permission_sets()
-    create_default_projects()
+    if create_projects:
+        create_default_projects()
     create_default_languages()
 
 


### PR DESCRIPTION
This is potentially useful if eg you dont want the tutorial loaded

It also allows travis to run without importing the entire terminology
project if Stores are to be loaded when TPs are created.

...just updating docs...