### PR TITLE
Enable PEP257 testing and fix hanging fruit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   # FIXME reenable migration testing
   #- tests/version-migration/migrate.sh
   - make pep8
+  - pep257
   - py.test --cov=. -vv
 notifications:
   email:

--- a/pootle/apps/accounts/adapter.py
+++ b/pootle/apps/accounts/adapter.py
@@ -27,6 +27,7 @@ class PootleAccountAdapter(DefaultAccountAdapter):
       - the html key is removed for performance reasons
       - form_errors is renamed to errors
     """
+
     def ajax_response(self, request, response, redirect_to=None, form=None):
         data = {}
         if redirect_to:

--- a/pootle/apps/accounts/managers.py
+++ b/pootle/apps/accounts/managers.py
@@ -22,6 +22,7 @@ class UserManager(BaseUserManager):
     queries, since they are special users. Code that needs access to these
     users should use the methods get_default_user and get_nobody_user.
     """
+
     PERMISSION_USERS = ('default', 'nobody')
     META_USERS = ('default', 'nobody', 'system')
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -58,6 +58,7 @@ class User(AbstractBaseUser):
     Note that the ``password`` and ``last_login`` fields are inherited
     from ``AbstractBaseUser``.
     """
+
     username = models.CharField(_('Username'), max_length=30, unique=True,
         help_text=_('Required. 30 characters or fewer. Letters, numbers and '
                     '@/./+/-/_ characters'),

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -21,6 +21,7 @@ from pootle_translationproject.models import TranslationProject
 
 class PootleCommand(NoArgsCommand):
     """Base class for handling recursive pootle store management commands."""
+
     shared_option_list = (
         make_option(
             '--project',
@@ -151,6 +152,7 @@ class BaseRunCommand(BaseCommand):
     Based on code from `django-shoes
     <https://bitbucket.org/mlzboy/django-shoes/>`_.
     """
+
     hostport_option_list = (
         make_option(
             '--host',

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -149,7 +149,8 @@ class BaseRunCommand(BaseCommand):
     """Base class to build new server runners.
 
     Based on code from `django-shoes
-    <https://bitbucket.org/mlzboy/django-shoes/>`_."""
+    <https://bitbucket.org/mlzboy/django-shoes/>`_.
+    """
     hostport_option_list = (
         make_option(
             '--host',

--- a/pootle/apps/pootle_app/models/__init__.py
+++ b/pootle/apps/pootle_app/models/__init__.py
@@ -11,4 +11,4 @@ from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import PermissionSet
 
 
-__all__ = ["Directory", "PermissionSet"]
+__all__ = ("Directory", "PermissionSet")

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -195,7 +195,8 @@ class Directory(models.Model, CachedTreeItem):
         to this directory, recurse the path and return the object
         (either a Directory or a Store) named 'c'.
 
-        This does not currently deal with .. path components."""
+        This does not currently deal with .. path components.
+        """
 
         from pootle_store.models import Store
 

--- a/pootle/apps/pootle_app/models/permissions.py
+++ b/pootle/apps/pootle_app/models/permissions.py
@@ -102,7 +102,8 @@ def get_matching_permissions(user, directory, check_default=True):
 def check_user_permission(user, permission_codename, directory,
                           check_default=True):
     """Checks if the current user has the permission to perform
-    ``permission_codename``."""
+    ``permission_codename``.
+    """
     if user.is_superuser:
         return True
 

--- a/pootle/apps/pootle_app/views/admin/util.py
+++ b/pootle/apps/pootle_app/views/admin/util.py
@@ -132,7 +132,8 @@ def form_set_as_table(formset, link=None, linkfield='code'):
 
 def process_modelformset(request, model_class, queryset, **kwargs):
     """With the Django model class `model_class` and the given `queryset`,
-    construct a formset process its submission."""
+    construct a formset process its submission.
+    """
 
     # Create a formset class for the model `model_class` (i.e. it will contain
     # forms whose contents are based on the fields of `model_class`);

--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -42,6 +42,7 @@ class LiveLanguageManager(models.Manager):
     A live language is any language containing at least a project with
     translatable files.
     """
+
     def get_queryset(self):
         return super(LiveLanguageManager, self).get_queryset().filter(
                 translationproject__isnull=False,

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -877,7 +877,7 @@ class ENChecker(checks.TranslationChecker):
     @critical
     def double_quotes_in_tags(self, str1, str2):
         """Checks whether double quotation mark `"` in tags is consistent between the
--        two strings.
+        two strings.
         """
         def get_fingerprint(str, is_source=False, translation=''):
             chunks = unbalanced_tag_braces_regex.split(str)

--- a/pootle/apps/pootle_misc/forms.py
+++ b/pootle/apps/pootle_misc/forms.py
@@ -84,6 +84,7 @@ def make_search_form(*args, **kwargs):
 
 class SearchForm(forms.Form):
     """Normal search form for translation projects."""
+
     search = forms.CharField(
         widget=forms.TextInput(attrs={
             'size': '15',

--- a/pootle/apps/pootle_misc/templatetags/cleanhtml.py
+++ b/pootle/apps/pootle_misc/templatetags/cleanhtml.py
@@ -43,7 +43,8 @@ def clean(text):
 @stringfilter
 def obfuscate(text):
     """Obfuscates the given text in case it is an email address.
-    Based on the implementation used in addons.mozilla.org"""
+    Based on the implementation used in addons.mozilla.org
+    """
 
     if not email_re.match(text):
         return text

--- a/pootle/apps/pootle_misc/templatetags/common_tags.py
+++ b/pootle/apps/pootle_misc/templatetags/common_tags.py
@@ -74,7 +74,7 @@ def top_scorers(*args, **kwargs):
 def format_date_range(date_from, date_to, separator=" - ",
     format_str="{dt:%B} {dt.day}, {dt:%Y}", year_f=", {dt:%Y}",
     month_f="{dt:%B}"):
-    """ Takes a start date, end date, separator and formatting strings and
+    """Takes a start date, end date, separator and formatting strings and
     returns a pretty date range string
     """
     if (isinstance(date_to, datetime.datetime) and

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -433,15 +433,16 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
             return self.localfiletype
 
     def get_file_class(self):
-        """Returns the TranslationStore subclass required for parsing
-        project files."""
+        """Returns the TranslationStore subclass required for parsing project
+        files.
+        """
         return factory_classes[self.localfiletype]
 
     def file_belongs_to_project(self, filename, match_templates=True):
         """Tests if ``filename`` matches project filetype (ie. extension).
 
-        If ``match_templates`` is ``True``, this will also check if the
-        file matches the template filetype.
+        If ``match_templates`` is ``True``, this will also check if the file
+        matches the template filetype.
         """
         template_ext = os.path.extsep + self.get_template_filetype()
         return (filename.endswith(os.path.extsep + self.localfiletype)

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -186,7 +186,8 @@ class StoreDiff(object):
 
     def diff(self):
         """Return a dictionary of change actions or None if there are no
-        changes to be made"""
+        changes to be made.
+        """
         diff = {"index": self.get_indexes_to_update(),
                 "obsolete": self.get_units_to_obsolete(),
                 "add": self.get_units_to_add(),

--- a/pootle/apps/pootle_store/fields.py
+++ b/pootle/apps/pootle_store/fields.py
@@ -110,6 +110,7 @@ class StoreTuple(object):
     since LRUCachingDict is based on a weakref.WeakValueDictionary
     which cannot reference normal tuples
     """
+
     def __init__(self, store, mod_info, realpath):
         self.store = store
         self.mod_info = mod_info
@@ -120,6 +121,7 @@ class TranslationStoreFieldFile(FieldFile):
     """FieldFile is the file-like object of a FileField, that is found in a
     TranslationStoreField.
     """
+
     from translate.misc.lru import LRUCachingDict
     from django.conf import settings
 

--- a/pootle/apps/pootle_store/fields.py
+++ b/pootle/apps/pootle_store/fields.py
@@ -27,7 +27,8 @@ def list_empty(strings):
     """check if list is exclusively made of empty strings.
 
     useful for detecting empty multistrings and storing them as a
-    simple empty string in db."""
+    simple empty string in db.
+    """
     for string in strings:
         if len(string) > 0:
             return False
@@ -36,7 +37,8 @@ def list_empty(strings):
 
 def to_db(value):
     """Flatten the given value (string, list of plurals or multistring) into
-    the database string representation."""
+    the database string representation.
+    """
     if value is None:
         return None
     elif isinstance(value, multistring):
@@ -106,7 +108,8 @@ class MultiStringField(models.Field):
 class StoreTuple(object):
     """Encapsulates toolkit stores in the in memory cache, needed
     since LRUCachingDict is based on a weakref.WeakValueDictionary
-    which cannot reference normal tuples"""
+    which cannot reference normal tuples
+    """
     def __init__(self, store, mod_info, realpath):
         self.store = store
         self.mod_info = mod_info
@@ -115,7 +118,8 @@ class StoreTuple(object):
 
 class TranslationStoreFieldFile(FieldFile):
     """FieldFile is the file-like object of a FileField, that is found in a
-    TranslationStoreField."""
+    TranslationStoreField.
+    """
     from translate.misc.lru import LRUCachingDict
     from django.conf import settings
 
@@ -152,13 +156,15 @@ class TranslationStoreFieldFile(FieldFile):
     @property
     def store(self):
         """Get translation store from dictionary cache, populate if store not
-        already cached."""
+        already cached.
+        """
         self._update_store_cache()
         return self._store_tuple.store
 
     def _update_store_cache(self):
         """Add translation store to dictionary cache, replace old cached
-        version if needed."""
+        version if needed.
+        """
         if self.exists():
             mod_info = self.getpomtime()
         else:
@@ -208,8 +214,9 @@ class TranslationStoreFieldFile(FieldFile):
         return os.path.exists(self.realpath)
 
     def savestore(self):
-        """Saves to temporary file then moves over original file. This
-        way we avoid the need for locking."""
+        """Saves to temporary file then moves over original file. This way we
+        avoid the need for locking.
+        """
         import shutil
         from pootle_misc import ptempfile as tempfile
         tmpfile, tmpfilename = tempfile.mkstemp(suffix=self.filename)
@@ -232,13 +239,15 @@ class TranslationStoreFieldFile(FieldFile):
 
 class TranslationStoreField(FileField):
     """This is the field class to represent a FileField in a model that
-    represents a translation store."""
+    represents a translation store.
+    """
 
     attr_class = TranslationStoreFieldFile
 
     def __init__(self, ignore=None, **kwargs):
         """ignore: postfix to be stripped from filename when trying to
-        determine file format for parsing, useful for .pending files"""
+        determine file format for parsing, useful for .pending files
+        """
         self.ignore = ignore
         super(TranslationStoreField, self).__init__(**kwargs)
 

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -71,7 +71,8 @@ def unhighlight_whitespace(text):
 
 class MultiStringWidget(forms.MultiWidget):
     """Custom Widget for editing multistrings, expands number of text
-    area based on number of plural forms."""
+    area based on number of plural forms.
+    """
 
     def __init__(self, attrs=None, nplurals=1, textarea=True):
         if textarea:

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -604,7 +604,8 @@ class Unit(models.Model, base.TranslationUnit):
 
     def convert(self, unitclass):
         """Convert to a unit of type :param:`unitclass` retaining as much
-        information from the database as the target format can support."""
+        information from the database as the target format can support.
+        """
         newunit = unitclass(self.source)
         newunit.target = self.target
         newunit.markfuzzy(self.isfuzzy())
@@ -2228,7 +2229,8 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
     def refresh_stats(self, include_children=True, cached_methods=None):
         """This TreeItem method is used on directories, translation projects,
-        languages and projects. For stores do nothing"""
+        languages and projects. For stores do nothing
+        """
         return
 
     def all_pootle_paths(self):

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -97,6 +97,7 @@ class QualityCheckManager(models.Manager):
 
 class QualityCheck(models.Model):
     """Database cache of results of qualitychecks on unit."""
+
     name = models.CharField(max_length=64, db_index=True)
     unit = models.ForeignKey("pootle_store.Unit", db_index=True)
     category = models.IntegerField(null=False, default=Category.NO_CATEGORY)
@@ -145,6 +146,7 @@ class Suggestion(models.Model, base.TranslationUnit):
     """Suggested translation for a :cls:`~pootle_store.models.Unit`, provided
     by users or automatically generated after a merge.
     """
+
     target_f = MultiStringField()
     target_hash = models.CharField(max_length=32, db_index=True)
     unit = models.ForeignKey('pootle_store.Unit')
@@ -1350,6 +1352,7 @@ class StoreManager(models.Manager):
 
 class Store(models.Model, CachedTreeItem, base.TranslationStore):
     """A model representing a translation store (i.e. a PO or XLIFF file)."""
+
     UnitClass = Unit
     Name = "Model Store"
     is_dir = False

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -694,7 +694,6 @@ class Unit(models.Model, base.TranslationUnit):
         return changed
 
     def update(self, unit, user=None):
-
         """Update in-DB translation from the given :param:`unit`.
 
         :param user: User to attribute updates to.

--- a/pootle/apps/reports/models.py
+++ b/pootle/apps/reports/models.py
@@ -39,6 +39,7 @@ class PaidTask(models.Model):
 
     ``task_type``, ``amount`` and ``date`` are required.
     """
+
     type_choices = [
         (PaidTaskTypes.TRANSLATION, _('Translation')),
         (PaidTaskTypes.REVIEW, _('Review')),

--- a/pootle/core/forms.py
+++ b/pootle/core/forms.py
@@ -57,8 +57,9 @@ class MathCaptchaForm(forms.Form):
             self.reset_captcha()
 
     def reset_captcha(self):
-        """Generate new question and valid token
-        for it, reset previous answer if any."""
+        """Generate new question and valid token for it, reset previous answer
+        if any.
+        """
         q, a = self._generate_captcha()
         expires = time.time() + \
             getattr(settings, 'CAPTCHA_EXPIRES_SECONDS', 60*60)
@@ -80,8 +81,7 @@ class MathCaptchaForm(forms.Form):
         self.fields['captcha_answer'].label = mark_safe(self.knotty_question)
 
     def _generate_captcha(self):
-        """Generate question and return it along with correct
-        answer."""
+        """Generate question and return it along with correct answer."""
         a, b = randint(1, 9), randint(1, 9)
         return ("%s+%s" % (a, b), a+b)
 
@@ -103,7 +103,8 @@ class MathCaptchaForm(forms.Form):
     def knotty_question(self):
         """Wrap plain_question in some invisibe for humans markup with random
         nonexisted classes, that makes life of spambots a bit harder because
-        form of question is vary from request to request."""
+        form of question is vary from request to request.
+        """
         digits = self._plain_question.split('+')
         return "+".join(['<span class="captcha-random-%s">%s</span>' %
                          (randint(1, 9), d) for d in digits])

--- a/pootle/core/forms.py
+++ b/pootle/core/forms.py
@@ -40,6 +40,7 @@ class MathCaptchaForm(forms.Form):
     For more info see:
     http://www.mysoftparade.com/blog/improved-mathematical-captcha/
     """
+
     A_RE = re.compile("^(\d+)$")
 
     captcha_answer = forms.CharField(max_length=2, required=True,

--- a/pootle/core/mixins/dirtyfields.py
+++ b/pootle/core/mixins/dirtyfields.py
@@ -18,6 +18,7 @@ class DirtyFieldsMixin(object):
     Initial code borrowed from django-dirtyfields, which is
     Copyright (c) Praekelt Foundation and individual contributors
     """
+
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
         post_save.connect(

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -516,8 +516,9 @@ class CachedTreeItem(TreeItem):
         self.update_dirty_cache()
 
     def _update_cache_job(self, keys, decrement):
-        """Update dirty cached stats of current TreeItem and add RQ job for updating
-        dirty cached stats of parent"""
+        """Update dirty cached stats of current TreeItem and add RQ job for
+        updating dirty cached stats of parent
+        """
         if self.can_be_updated():
             # children should be recalculated to avoid using of obsolete directories
             # or stores which could be saved in `children` property

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -60,6 +60,7 @@ class NoCachedStats(Exception):
 
 class CachedMethods(object):
     """Cached method names."""
+
     CHECKS = 'get_checks'
     WORDCOUNT_STATS = 'get_wordcount_stats'
     LAST_ACTION = 'get_last_action'
@@ -558,6 +559,7 @@ class JobWrapper():
     encapsulates work with external to RQ job params which is needed
     because of possible race conditions
     """
+
     def __init__(self, id, connection):
         self.id = id
         self.func = None

--- a/pootle/core/models.py
+++ b/pootle/core/models.py
@@ -87,6 +87,7 @@ class VirtualResource(TreeItem):
     Don't use this object as-is, rather subclass it and adapt the
     implementation details for each context.
     """
+
     def __init__(self, resources, pootle_path, *args, **kwargs):
         self.resources = resources  #: Collection of underlying resources
         self.pootle_path = pootle_path

--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -26,6 +26,7 @@ class PootleJSONEncoder(DjangoJSONEncoder):
     certain types of objects.
     https://docs.djangoproject.com/en/1.4/topics/serialization/#id2
     """
+
     def default(self, obj):
         if isinstance(obj, Promise) or isinstance(obj, Markup):
             return force_unicode(obj)

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -40,6 +40,7 @@ class SuperuserRequiredMixin(object):
 
 class LoginRequiredMixin(object):
     """Require a logged-in user."""
+
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
         return super(LoginRequiredMixin, self).dispatch(*args, **kwargs)
@@ -54,6 +55,7 @@ class TestUserFieldMixin(LoginRequiredMixin):
 
     Note that there's free way for admins.
     """
+
     test_user_field = 'username'
 
     def dispatch(self, *args, **kwargs):
@@ -70,6 +72,7 @@ class TestUserFieldMixin(LoginRequiredMixin):
 
 class NoDefaultUserMixin(object):
     """Removes the `default` special user from views."""
+
     def dispatch(self, request, *args, **kwargs):
         username = kwargs.get('username', None)
         if username is not None and username == 'default':
@@ -84,6 +87,7 @@ class AjaxResponseMixin(object):
 
     This needs to be used with a `FormView`.
     """
+
     def form_invalid(self, form):
         super(AjaxResponseMixin, self).form_invalid(form)
         return JsonResponseBadRequest({'errors': form.errors})
@@ -98,6 +102,7 @@ class APIView(View):
 
     Based on djangbone https://github.com/af/djangbone
     """
+
     # Model on which this view operates. Setting this is required
     model = None
 

--- a/pootle/i18n/override.py
+++ b/pootle/i18n/override.py
@@ -138,8 +138,9 @@ def override_gettext(real_translation):
 
 
 def get_language_bidi():
-    """Override for Django's get_language_bidi that's aware of more
-    RTL languages."""
+    """Override for Django's get_language_bidi that's aware of more RTL
+    languages.
+    """
     return gettext.language_dir(translation.get_language()) == 'rtl'
 
 

--- a/pootle/middleware/captcha.py
+++ b/pootle/middleware/captcha.py
@@ -33,6 +33,7 @@ class CaptchaMiddleware:
     """Middleware to display a captcha question to verify POST submissions
     are made by humans.
     """
+
     def process_request(self, request):
         if (not settings.POOTLE_CAPTCHA_ENABLED or not request.POST or
             request.session.get('ishuman', False)):

--- a/pootle/settings.py
+++ b/pootle/settings.py
@@ -15,7 +15,8 @@ WORKING_DIR = os.path.abspath(os.path.dirname(__file__))
 
 def working_path(filename):
     """Return an absolute path for :param:`filename` by joining it to
-    ``WORKING_DIR``."""
+    ``WORKING_DIR``.
+    """
     return os.path.join(WORKING_DIR, filename)
 
 

--- a/pootle/syspath_override.py
+++ b/pootle/syspath_override.py
@@ -7,7 +7,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-""" Adds pootle directories to the python import path """
+"""Adds pootle directories to the python import path"""
 
 # FIXME: is this useful on an installed codebase or only when running from
 # source?

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ django-extensions
 glue>=0.2.8.1
 django-debug-toolbar>=1.2
 ipython
+pep257

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,4 +4,5 @@
 coveralls
 MySQL-python
 psycopg2
+pep257
 pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,24 @@ python_files=*.py
 addopts=--nomigrations --tb=short tests
 norecursedirs=.git _build tmp* requirements commands/*
 usefixtures=po_directory
+
+[pep257]
+inherit=false
+# Ignore all preselected error codes
+select=
+# Known error codes
+# http://pep257.readthedocs.org/en/latest/error_codes.html
+#
+# Descriptions of default ON error codes
+# D201 - No blank lines allowed before function docstring
+# D206 - Docstring should be indented with spaces, not tabs
+# D207 - Docstring is under-indented
+# D208 - Docstring is over-indented
+# D210 - No whitespaces allowed surrounding docstring text
+# D211 - No blank lines allowed before class docstring
+# D300 - Use “”“triple double quotes”“”
+# D301 - Use r”“” if any backslashes in a docstring
+# D302 - Use u”“” for Unicode docstrings
+add-select=D201,D206,D207,D208,D210,D211,D300,D301,D302
+# If we need to exlude tests uncomment this
+#match-dir=(?!tests).*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,12 @@ select=
 # D300 - Use “”“triple double quotes”“”
 # D301 - Use r”“” if any backslashes in a docstring
 # D302 - Use u”“” for Unicode docstrings
+#
+# Default OFF
+# D202 - No blank lines allowed after function docstring (found 1)
+#   - not convinced that this improves readability
+# D203 - 1 blank line required before class docstring
+#   - incompatible with D211
 add-select=D201,D204,D206,D207,D208,D209,D210,D211,D300,D301,D302
 # If we need to exlude tests uncomment this
 #match-dir=(?!tests).*

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ select=
 #
 # Descriptions of default ON error codes
 # D201 - No blank lines allowed before function docstring
+# D204 - 1 blank line required after class docstring
 # D206 - Docstring should be indented with spaces, not tabs
 # D207 - Docstring is under-indented
 # D208 - Docstring is over-indented
@@ -22,6 +23,6 @@ select=
 # D300 - Use “”“triple double quotes”“”
 # D301 - Use r”“” if any backslashes in a docstring
 # D302 - Use u”“” for Unicode docstrings
-add-select=D201,D206,D207,D208,D209,D210,D211,D300,D301,D302
+add-select=D201,D204,D206,D207,D208,D209,D210,D211,D300,D301,D302
 # If we need to exlude tests uncomment this
 #match-dir=(?!tests).*

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,12 @@ select=
 # D206 - Docstring should be indented with spaces, not tabs
 # D207 - Docstring is under-indented
 # D208 - Docstring is over-indented
+# D209 - Multi-line docstring closing quotes should be on a separate line
 # D210 - No whitespaces allowed surrounding docstring text
 # D211 - No blank lines allowed before class docstring
 # D300 - Use “”“triple double quotes”“”
 # D301 - Use r”“” if any backslashes in a docstring
 # D302 - Use u”“” for Unicode docstrings
-add-select=D201,D206,D207,D208,D210,D211,D300,D301,D302
+add-select=D201,D206,D207,D208,D209,D210,D211,D300,D301,D302
 # If we need to exlude tests uncomment this
 #match-dir=(?!tests).*

--- a/tests/fixtures/models/language.py
+++ b/tests/fixtures/models/language.py
@@ -82,7 +82,7 @@ def russian(english):
 
 @pytest.fixture
 def fish(english):
-    """Require the Fish language ><(((º>"""
+    u"""Require the Fish language ><(((º>"""
     return _require_language(code='fish', fullname='Fish')
 
 


### PR DESCRIPTION
Fixes #4212 but should land post 2.7.3

* Enables PEP257 checking in Travis (cost 7s).  
* Makes current clean checks hard requirements
* Fixes some of the low hanging fruit

Big remaining issues are:
* Missing docstrings
* Single single first line (jury out on if we actually want this
* D4 checks which relate to word choice Return over Returns, Test over Tests.