### PR TITLE
bug #4202 - Fix user widget stats to show correctly on RTL languages

### DIFF
--- a/pootle/static/css/odometer.css
+++ b/pootle/static/css/odometer.css
@@ -19,6 +19,11 @@
     float: right;
 }
 
+html[dir='rtl'] .odometer-inside
+{
+    direction: ltr;
+}
+
 .odometer.odometer-auto-theme,
 .odometer.odometer-theme-default
 {


### PR DESCRIPTION
Fixes the problem with forcing odometer to be always LTR. Numbers are always left to right.

![screenshot from 2015-11-27 19-32-41](https://cloud.githubusercontent.com/assets/849640/11445034/2640282a-953e-11e5-82f0-3ec949cc18d9.png)

