### PR TITLE
Cleanups: drop use of % in logging

### DIFF
--- a/pootle/apps/accounts/utils.py
+++ b/pootle/apps/accounts/utils.py
@@ -173,11 +173,11 @@ class UserPurger(object):
         self.revert_units_state_changed()
 
         # Delete remaining submissions.
-        logger.debug("Deleting remaining submissions for: %s" % self.user)
+        logger.debug("Deleting remaining submissions for: %s", self.user)
         self.user.submission_set.all().delete()
 
         # Delete remaining suggestions.
-        logger.debug("Deleting remaining suggestions for: %s" % self.user)
+        logger.debug("Deleting remaining suggestions for: %s", self.user)
         self.user.suggestions.all().delete()
 
     @write_stdout(" * Removing units created by: %(user)s... ")
@@ -194,7 +194,7 @@ class UserPurger(object):
 
             if not other_subs.exists():
                 unit.delete()
-                logger.debug("Unit deleted: %s" % repr(unit))
+                logger.debug("Unit deleted: %s", repr(unit))
 
     @write_stdout(" * Reverting unit comments by: %(user)s... ")
     def revert_units_commented(self):
@@ -215,12 +215,12 @@ class UserPurger(object):
                 unit.translator_comment = last_comment.new_value
                 unit.commented_by = last_comment.submitter
                 unit.commented_on = last_comment.creation_time
-                logger.debug("Unit comment reverted: %s" % repr(unit))
+                logger.debug("Unit comment reverted: %s", repr(unit))
             else:
                 unit.translator_comment = ""
                 unit.commented_by = None
                 unit.commented_on = None
-                logger.debug("Unit comment removed: %s" % repr(unit))
+                logger.debug("Unit comment removed: %s", repr(unit))
 
             # Increment revision
             unit._comment_updated = True
@@ -242,14 +242,14 @@ class UserPurger(object):
                 unit.target_f = last_edit.new_value
                 unit.submitted_by = last_edit.submitter
                 unit.submitted_on = last_edit.creation_time
-                logger.debug("Unit edit reverted: %s" % repr(unit))
+                logger.debug("Unit edit reverted: %s", repr(unit))
             else:
                 # if there is no previous submissions set the target to "" and
                 # set the unit.submitted_by to None
                 unit.target_f = ""
                 unit.submitted_by = None
                 unit.submitted_on = unit.creation_time
-                logger.debug("Unit edit removed: %s" % repr(unit))
+                logger.debug("Unit edit removed: %s", repr(unit))
 
             # Increment revision
             unit._target_updated = True
@@ -267,7 +267,7 @@ class UserPurger(object):
                 # If the suggestion was also created by this user then remove
                 # both review and suggestion.
                 suggestion.delete()
-                logger.debug("Suggestion removed: %s" % (suggestion))
+                logger.debug("Suggestion removed: %s", (suggestion))
             elif suggestion.reviewer == self.user:
                 # If the suggestion is showing as reviewed by the user, then
                 # set the suggestion back to pending and update
@@ -276,7 +276,7 @@ class UserPurger(object):
                 suggestion.reviewer = None
                 suggestion.review_time = None
                 suggestion.save()
-                logger.debug("Suggestion reverted: %s" % (suggestion))
+                logger.debug("Suggestion reverted: %s", (suggestion))
 
             # Remove the review.
             review.delete()
@@ -287,16 +287,14 @@ class UserPurger(object):
                 previous_review = reviews.latest('pk')
                 unit.reviewed_by = previous_review.submitter
                 unit.reviewed_on = previous_review.creation_time
-                logger.debug("Unit reviewed_by reverted: %s"
-                             % (repr(unit)))
+                logger.debug("Unit reviewed_by reverted: %s", repr(unit))
             else:
                 unit.reviewed_by = None
                 unit.reviewed_on = None
 
                 # Increment revision
                 unit._target_updated = True
-                logger.debug("Unit reviewed_by removed: %s"
-                             % (repr(unit)))
+                logger.debug("Unit reviewed_by removed: %s", repr(unit))
             unit.save()
 
     @write_stdout(" * Reverting unit state changes by: %(user)s... ")
@@ -334,8 +332,7 @@ class UserPurger(object):
                 # Increment revision
                 unit._state_updated = True
                 unit.save()
-                logger.debug("Unit state reverted: %s"
-                             % (repr(unit)))
+                logger.debug("Unit state reverted: %s", repr(unit))
 
 
 def verify_user(user):

--- a/pootle/apps/accounts/views.py
+++ b/pootle/apps/accounts/views.py
@@ -33,7 +33,7 @@ class PootleLoginView(LoginView):
         except ImmediateHttpResponse as e:
             return e.response
         except Exception as e:
-            logger.exception("%s %s" % (e.__class__.__name__, e))
+            logger.exception("%s %s", e.__class__.__name__, e)
             raise RuntimeError(_("An error occurred logging you in. Please "
                                  "contact your system administrator"))
 

--- a/pootle/apps/import_export/utils.py
+++ b/pootle/apps/import_export/utils.py
@@ -53,5 +53,5 @@ def import_file(file, user=None):
                      submission_type=SubmissionTypes.UPLOAD)
     except Exception as e:
         # This should not happen!
-        logger.error("Error importing file: %s" % str(e))
+        logger.error("Error importing file: %s", str(e))
         raise FileImportError(_("There was an error uploading your file"))

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -115,7 +115,7 @@ def calculate_checks(check_names=None, translation_project=None):
             Unit.simple_objects.filter(id=unit.id).update(mtime=timezone.now())
 
         if unit_count % 10000 == 0:
-            logging.info("%d units processed" % unit_count)
+            logging.info("%d units processed", unit_count)
 
     if store is not None:
         store.update_dirty_cache()

--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -30,5 +30,5 @@ class Command(PootleCommand):
             translation_project=translation_project
         )
         for store in stores.iterator():
-            logger.info('Add job to update stats for %s' % store.pootle_path)
+            logger.info('Add job to update stats for %s', store.pootle_path)
             store.update_all_cache()

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -56,8 +56,8 @@ class Command(PootleCommand):
         disk_mtime = store.get_file_mtime()
         if not options["force"] and disk_mtime == store.file_mtime:
             # The file on disk wasn't changed since the last sync
-            logging.debug(u"File didn't change since last sync, skipping "
-                          u"%s" % store.pootle_path)
+            logging.debug(u"File didn't change since last sync, "
+                          "skipping %s", store.pootle_path)
             return
 
         store.update_from_disk(overwrite=options["overwrite"])

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1837,9 +1837,9 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
                 )
             self.last_sync_revision = update_revision
             if update_unsynced:
-                logging.info(u"[update] unsynced %d units in %s [revision: %d]"
-                             % (update_unsynced, self.pootle_path,
-                                update_revision))
+                logging.info(u"[update] unsynced %d units in %s "
+                             "[revision: %d]", update_unsynced,
+                             self.pootle_path, update_revision)
         self.save(update_cache=False)
         return changed
 
@@ -1893,8 +1893,8 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         # TODO only_newer -> not force
         if (only_newer and self.file.exists() and
             self.last_sync_revision >= last_revision):
-            logging.info(u"[sync] No updates for %s after [revision: %d]" %
-                         (self.pootle_path, self.last_sync_revision))
+            logging.info(u"[sync] No updates for %s after [revision: %d]",
+                         self.pootle_path, self.last_sync_revision)
             return
 
         if not self.file.exists():
@@ -2000,8 +2000,8 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             log(u"[sync] File saved; %s units in %s [revision: %d]" %
                 (get_change_str(changes), self.pootle_path, last_revision))
         else:
-            logging.info(u"[sync] nothing changed in %s [revision: %d]" %
-                         (self.pootle_path, last_revision))
+            logging.info(u"[sync] nothing changed in %s [revision: %d]",
+                         self.pootle_path, last_revision)
 
         self.last_sync_revision = last_revision
         self.save()

--- a/pootle/core/forms.py
+++ b/pootle/core/forms.py
@@ -125,7 +125,7 @@ class MathCaptchaForm(forms.Form):
                     'expires': float(data['expires']),
                     'sign': sign}
         except Exception as e:
-            logging.info("Captcha error: %r" % e)
+            logging.info("Captcha error: %r", e)
             # l10n for bots? Rather not
             raise forms.ValidationError("Invalid captcha!")
 

--- a/pootle/core/initdb.py
+++ b/pootle/core/initdb.py
@@ -46,13 +46,10 @@ def initdb(create_projects=True):
 def _create_object(model_klass, **criteria):
     instance, created = model_klass.objects.get_or_create(**criteria)
     if created:
-        logger.debug(
-            "Created %s: '%s'"
-            % (instance.__class__.__name__, instance))
+        logger.debug("Created %s: '%s'", instance.__class__.__name__, instance)
     else:
-        logger.debug(
-            "%s already exists - skipping: '%s'"
-            % (instance.__class__.__name__, instance))
+        logger.debug("%s already exists - skipping: '%s'",
+                     instance.__class__.__name__, instance)
     return instance, created
 
 

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -58,10 +58,8 @@ class ElasticSearchBackend(SearchBackend):
             return None
 
     def _log_error(self, e):
-        logger.error("Elasticsearch error for server(%s:%s): %s"
-                     % (self._settings.get("HOST"),
-                        self._settings.get("PORT"),
-                        e))
+        logger.error("Elasticsearch error for server(%s:%s): %s",
+                     self._settings.get("HOST"), self._settings.get("PORT"), e)
 
     def search(self, unit):
         counter = {}
@@ -89,10 +87,9 @@ class ElasticSearchBackend(SearchBackend):
         elif es_res == "":
             # There seems to be an issue with urllib where an empty string is
             # returned
-            logger.error("Elasticsearch search (%s:%s) returned an empty string: %s"
-                         % (self._settings["HOST"],
-                            self._settings["PORT"],
-                            unit))
+            logger.error("Elasticsearch search (%s:%s) returned an empty "
+                         "string: %s", self._settings["HOST"],
+                         self._settings["PORT"], unit)
             return []
 
         for hit in es_res['hits']['hits']:

--- a/pootle/core/search/broker.py
+++ b/pootle/core/search/broker.py
@@ -28,7 +28,7 @@ class SearchBroker(SearchBackend):
                     _search_class = self._settings[server]['ENGINE'].split('.')[-1]
                 except KeyError:
                     logging.warning("Search engine '%s' is missing the required "
-                                    "'ENGINE' setting" % server)
+                                    "'ENGINE' setting", server)
                     break
                 try:
                     module = importlib.import_module(_module)
@@ -36,10 +36,10 @@ class SearchBroker(SearchBackend):
                         self._servers[server] = getattr(module, _search_class)(server)
                     except AttributeError:
                         logging.warning("Search backend '%s'. No search class "
-                                        "'%s' defined." % (server, _search_class))
+                                        "'%s' defined.", server, _search_class)
                 except ImportError:
-                    logging.warning("Search backend '%s'. Cannot import '%s'" %
-                                    (server, _module))
+                    logging.warning("Search backend '%s'. Cannot import '%s'",
+                                    server, _module)
 
     def search(self, unit):
         if not self._servers:


### PR DESCRIPTION
logging can accept variables for interpolation as parameters.  This
means they're only interpolated if something is logged.  Using % means
that the interpolation is always happening (as far as I understand).