### PR TITLE
[RFC] Cleanup: Use @staticmethod

### DIFF
--- a/pootle/apps/accounts/adapter.py
+++ b/pootle/apps/accounts/adapter.py
@@ -28,7 +28,8 @@ class PootleAccountAdapter(DefaultAccountAdapter):
       - form_errors is renamed to errors
     """
 
-    def ajax_response(self, request, response, redirect_to=None, form=None):
+    @staticmethod
+    def ajax_response(request, response, redirect_to=None, form=None):
         data = {}
         if redirect_to:
             status = 200
@@ -43,7 +44,8 @@ class PootleAccountAdapter(DefaultAccountAdapter):
 
         return JsonResponse(data, status=status)
 
-    def is_open_for_signup(self, request):
+    @staticmethod
+    def is_open_for_signup(request):
         """Controls whether signups are enabled on the site.
 
         This can be changed by setting `POOTLE_SIGNUP_ENABLED = False` in

--- a/pootle/apps/accounts/management/commands/__init__.py
+++ b/pootle/apps/accounts/management/commands/__init__.py
@@ -27,7 +27,8 @@ class UserCommand(BaseCommand):
         self.subcommand = subcommand
         return super(UserCommand, self).create_parser(prog_name, subcommand)
 
-    def get_user(self, username):
+    @staticmethod
+    def get_user(username):
         try:
             return User.objects.get(username=username)
         except User.DoesNotExist:

--- a/pootle/apps/accounts/social_adapter.py
+++ b/pootle/apps/accounts/social_adapter.py
@@ -24,7 +24,8 @@ from .views import SocialVerificationView
 
 class PootleSocialAccountAdapter(DefaultSocialAccountAdapter):
 
-    def is_open_for_signup(self, request, sociallogin):
+    @staticmethod
+    def is_open_for_signup(request, sociallogin):
         """Controls whether signups are enabled on the site when using
         social authentication methods.
         """
@@ -39,7 +40,8 @@ class PootleSocialAccountAdapter(DefaultSocialAccountAdapter):
         # `POOTLE_SIGNUP_ENABLED`.
         return True
 
-    def pre_social_login(self, request, sociallogin):
+    @staticmethod
+    def pre_social_login(request, sociallogin):
         """Hook to be run after receiving the OK from the social provider
         but before completing the social login process. At this time no
         new user accounts have been created and the user is still in the
@@ -69,8 +71,9 @@ class PootleSocialAccountAdapter(DefaultSocialAccountAdapter):
                 response=SocialVerificationView.as_view()(request)
             )
 
-    def authentication_error(self, request, provider_id, error=None,
-                             exception=None, extra_context=None):
+    @staticmethod
+    def authentication_error(request, provider_id, error=None, exception=None,
+                             extra_context=None):
         provider = providers.registry.by_id(provider_id)
         retry_url = provider.get_login_url(request,
                                            **dict(request.GET.iteritems()))

--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -54,7 +54,8 @@ class ContactForm(MathCaptchaForm, OriginalContactForm):
             self.cleaned_data['email']
         )
 
-    def recipient_list(self):
+    @staticmethod
+    def recipient_list():
         return [settings.POOTLE_CONTACT_EMAIL]
 
     def save(self, fail_silently=False):

--- a/pootle/apps/contact/views.py
+++ b/pootle/apps/contact/views.py
@@ -47,7 +47,8 @@ class ContactFormView(AjaxResponseMixin, OriginalContactFormView):
 
         return initial
 
-    def get_success_url(self):
+    @staticmethod
+    def get_success_url():
         # XXX: This is unused. We don't need a `/contact/sent/` URL, but
         # the parent :cls:`ContactView` enforces us to set some value here
         return reverse('pootle-contact')

--- a/pootle/apps/pootle_app/apps.py
+++ b/pootle/apps/pootle_app/apps.py
@@ -23,7 +23,8 @@ class PootleConfig(AppConfig):
     name = "pootle_app"
     verbose_name = "Pootle"
 
-    def ready(self):
+    @staticmethod
+    def ready():
         # FIXME In Django 1.8 this needs to change to
         # register(settings.check_deprecated_settings, "settings")
         checks.register("settings")(deprecation.check_deprecated_settings)

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -176,7 +176,8 @@ class BaseRunCommand(BaseCommand):
     def handle(self, *args, **options):
         return self.serve_forever(*args, **options)
 
-    def get_app(self):
+    @staticmethod
+    def get_app():
         from django.contrib.staticfiles.handlers import StaticFilesHandler
         from django.core.handlers.wsgi import WSGIHandler
 

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -40,7 +40,8 @@ class Command(PootleCommand):
     cached_methods = [CachedMethods.CHECKS]
     process_disabled_projects = True
 
-    def handle_all_stores(self, translation_project, **options):
+    @staticmethod
+    def handle_all_stores(translation_project, **options):
         calculate_checks(check_names=options['check_names'],
                          translation_project=translation_project)
 

--- a/pootle/apps/pootle_app/management/commands/clear_stats.py
+++ b/pootle/apps/pootle_app/management/commands/clear_stats.py
@@ -18,5 +18,6 @@ from pootle_app.management.commands import PootleCommand
 class Command(PootleCommand):
     help = "Flush stats cache."
 
-    def handle_all_stores(self, translation_project, **options):
+    @staticmethod
+    def handle_all_stores(translation_project, **options):
         translation_project.clear_all_cache()

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -159,7 +159,8 @@ class Command(PootleCommand):
                 for child in item.children:
                     self._dump_item(child, level + 1, stop_level=stop_level)
 
-    def dumped(self, item):
+    @staticmethod
+    def dumped(item):
         def get_param(param):
             p = getattr(item, param)
             res = p() if callable(p) else p

--- a/pootle/apps/pootle_app/views/admin/permissions.py
+++ b/pootle/apps/pootle_app/views/admin/permissions.py
@@ -28,7 +28,8 @@ PERMISSIONS = {
 
 class PermissionFormField(forms.ModelMultipleChoiceField):
 
-    def label_from_instance(self, instance):
+    @staticmethod
+    def label_from_instance(instance):
         return _(instance.name)
 
 

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -47,7 +47,8 @@ class ElasticSearchBackend(SearchBackend):
         except ElasticsearchException as e:
             self._log_error(e)
 
-    def _is_valuable_hit(self, unit, hit):
+    @staticmethod
+    def _is_valuable_hit(unit, hit):
         return str(unit.id) != hit['_id']
 
     def _es_call(self, cmd, *args, **kwargs):


### PR DESCRIPTION
Some of these might not be valid, but a few are.  We should mark things as `@staticmethod` if they are indeed that.  I'm not sure how much of a perf boost is involved but it certainly makes it clear.  Some of what I've selected may in fact not be valid thus the RFC.