### PR TITLE
Cleanup: if conditions following failed .get()

### DIFF
--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -75,7 +75,7 @@ class ProjectForm(forms.ModelForm):
 
         def clean_localfiletype(self):
             value = self.cleaned_data.get('localfiletype', None)
-            if not value:
+            if value is None:
                 value = self.instance.localfiletype
             filetypes = [x[0] for x in filetype_choices]
             if value not in filetypes:
@@ -86,7 +86,7 @@ class ProjectForm(forms.ModelForm):
 
         def clean_treestyle(self):
             value = self.cleaned_data.get('treestyle', None)
-            if not value:
+            if value is None:
                 value = self.instance.treestyle
             return value
 

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -82,7 +82,7 @@ class DBParser(object):
         iso_submitted_on = unit.get('submitted_on', None)
 
         display_submitted_on = None
-        if iso_submitted_on:
+        if iso_submitted_on is not None:
             display_submitted_on = dateformat.format(
                 dateparse.parse_datetime(str(iso_submitted_on))
             )

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -75,7 +75,7 @@ def get_path_obj(func):
                     # Explicit selection via the UI: redirect either to
                     # ``/language_code/`` or ``/projects/project_code/``
                     user_choice = request.COOKIES.get('user-choice', None)
-                    if user_choice and user_choice in ('language', 'project',):
+                    if user_choice in ('language', 'project',):
                         url = {
                             'language': reverse('pootle-language-browse',
                                                 args=[language_code]),

--- a/pootle/i18n/override.py
+++ b/pootle/i18n/override.py
@@ -65,7 +65,7 @@ def lang_choices():
 def get_lang_from_session(request, supported):
     if hasattr(request, 'session'):
         lang_code = request.session.get('django_language', None)
-        if lang_code and lang_code in supported:
+        if lang_code is not None and lang_code in supported:
             return lang_code
 
     return None


### PR DESCRIPTION
.get() by default will return None if the key is not found in the
dictionary.

Thus if the following does not find the key then x == None.

x = dict.get('something', None)

This requires any conditional to test against None as follows:
if x is not None:

But in place in the code we're doing:
if x:

This correct that and simplifies some conditionals if needed.