### PR TITLE
Reenable pep257, __all__ should contain strings

### DIFF
--- a/pootle/apps/pootle_app/views/admin/__init__.py
+++ b/pootle/apps/pootle_app/views/admin/__init__.py
@@ -13,5 +13,5 @@ from .users import UserAdminView, UserAPIView
 
 
 __all__ = (
-    LanguageAdminView, LanguageAPIView, ProjectAdminView, ProjectAPIView,
-    UserAdminView, UserAPIView)
+    'LanguageAdminView', 'LanguageAPIView', 'ProjectAdminView',
+    'ProjectAPIView', 'UserAdminView', 'UserAPIView')

--- a/pootle/core/markup/__init__.py
+++ b/pootle/core/markup/__init__.py
@@ -15,6 +15,6 @@ from .widgets import MarkupTextarea
 
 
 __all__ = (
-    Markup, MarkupField,
-    get_markup_filter_name, get_markup_filter_display_name,
-    get_markup_filter, apply_markup_filter, MarkupTextarea)
+    'Markup', 'MarkupField', 'get_markup_filter_name',
+    'get_markup_filter_display_name', 'get_markup_filter',
+    'apply_markup_filter', 'MarkupTextarea')

--- a/pootle/core/mixins/__init__.py
+++ b/pootle/core/mixins/__init__.py
@@ -11,5 +11,4 @@ from .dirtyfields import DirtyFieldsMixin
 from .treeitem import TreeItem, CachedTreeItem, CachedMethods
 
 
-__all__ = (
-    DirtyFieldsMixin, TreeItem, CachedTreeItem, CachedMethods)
+__all__ = ('DirtyFieldsMixin', 'TreeItem', 'CachedTreeItem', 'CachedMethods')

--- a/pootle/core/search/__init__.py
+++ b/pootle/core/search/__init__.py
@@ -12,5 +12,4 @@ from .broker import SearchBroker
 from .backends import ElasticSearchBackend
 
 
-__all__ = (
-    SearchBackend, SearchBroker, ElasticSearchBackend)
+__all__ = ('SearchBackend', 'SearchBroker', 'ElasticSearchBackend')

--- a/pootle/core/search/backends/__init__.py
+++ b/pootle/core/search/backends/__init__.py
@@ -10,4 +10,4 @@
 from .elasticsearch import ElasticSearchBackend
 
 
-__all__ = (ElasticSearchBackend, )
+__all__ = ('ElasticSearchBackend', )


### PR DESCRIPTION
http://docs.pylint.org/features.html#id5

invalid-all-object (E0604): Invalid object %r in `__all__`, must contain only strings Used when an invalid (non-string) object occurs in `__all__`.

Changing this allows us to reenable pep257 checks on Travis.