### PR TITLE
Allow to use update_stores for disabled projects

### DIFF
--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -43,7 +43,7 @@ class Command(PootleCommand):
         """
         :return: flag if child stores should be updated
         """
-        if translation_project.directory_exists():
+        if translation_project.directory_exists_on_disk():
             logging.info(u"Scanning for new files in %s", translation_project)
             translation_project.scan_files()
             return True

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -37,6 +37,7 @@ class Command(PootleCommand):
                  "appear unchanged)."),
     )
     help = "Update database stores from files."
+    process_disabled_projects = True
 
     def handle_translation_project(self, translation_project, **options):
         """
@@ -47,7 +48,13 @@ class Command(PootleCommand):
             translation_project.scan_files()
             return True
 
-        translation_project.directory.makeobsolete()
+        # Skip if project directory was ceased to exist on disk.
+        if translation_project.project.directory_exists_on_disk():
+            translation_project.directory.makeobsolete()
+        else:
+            logging.warning(u"Missing project directory for %s. Skipping %s.",
+                            translation_project.project, translation_project)
+
         return False
 
     def handle_store(self, store, **options):

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -361,9 +361,8 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
 
     def save(self, *args, **kwargs):
         # Create file system directory if needed
-        project_path = self.get_real_path()
-        if not os.path.exists(project_path) and not self.disabled:
-            os.makedirs(project_path)
+        if not self.directory_exists_on_disk() and not self.disabled:
+            os.makedirs(self.get_real_path())
 
         from pootle_app.models.directory import Directory
         self.directory = Directory.objects.projects \
@@ -395,6 +394,10 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
             raise ValidationError(
                 _('"%s" cannot be used as a project code', self.code)
             )
+
+    def directory_exists_on_disk(self):
+        """Checks if the actual directory for the project exists on disk."""
+        return os.path.exists(self.get_real_path())
 
     # # # TreeItem
 

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -383,9 +383,9 @@ class TranslationProject(models.Model, CachedTreeItem):
 
     # # # /TreeItem
 
-    def directory_exists(self):
+    def directory_exists_on_disk(self):
         """Checks if the actual directory for the translation project
-        exists on-disk.
+        exists on disk.
         """
         return not does_not_exist(self.abs_real_path)
 

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -66,7 +66,7 @@ def create_translation_project(language, project):
 
 
 def scan_translation_projects(languages=None, projects=None):
-    project_query = Project.objects.enabled()
+    project_query = Project.objects.all()
 
     if projects is not None:
         project_query = project_query.filter(code__in=projects)


### PR DESCRIPTION
Besides setting `process_disabled_projects` `PootleCommand` attribute to `True`. We have to skip making obsolete TP if project directory doesn't exist.
Note: that project can be marked as disabled automatically if the entire project directory is ceased to exist.

Fixes #4198 