### PR TITLE
Languages admin: prevent from modifying existing language codes

### DIFF
--- a/pootle/static/js/admin/components/Language/LanguageForm.js
+++ b/pootle/static/js/admin/components/Language/LanguageForm.js
@@ -53,6 +53,7 @@ const LanguageForm = React.createClass({
           <FormElement
             autoFocus={true}
             attribute="code"
+            disabled={model.hasOwnProperty('id')}
             label={gettext('Code')}
             handleChange={this.handleChange}
             formData={formData}


### PR DESCRIPTION
This is a workaround until #4213 is properly addressed.