### PR TITLE
Remove unit ordering

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -84,7 +84,7 @@ class StoreDiff(object):
         unit_fields = ("unitid", "state", "id", "index", "revision",
                        "source_f", "target_f", "developer_comment",
                        "translator_comment", "locations", "context")
-        for unit in self.db_store.unit_set.values(*unit_fields):
+        for unit in self.db_store.unit_set.values(*unit_fields).order_by("index"):
             db_units[unit["unitid"]] = unit
         return db_units
 

--- a/pootle/apps/pootle_store/migrations/0003_remove_unit_ordering.py
+++ b/pootle/apps/pootle_store/migrations/0003_remove_unit_ordering.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0002_make_suggestion_user_not_null'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='unit',
+            options={'get_latest_by': 'mtime'},
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0004_index_store_index_together.py
+++ b/pootle/apps/pootle_store/migrations/0004_index_store_index_together.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0003_remove_unit_ordering'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='unit',
+            index_together=set([('store', 'index')]),
+        ),
+    ]

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -362,6 +362,7 @@ class Unit(models.Model, base.TranslationUnit):
     class Meta(object):
         unique_together = ('store', 'unitid_hash')
         get_latest_by = 'mtime'
+        index_together = [["store", "index"]]
 
     # # # # # # # # # # # # # #  Properties # # # # # # # # # # # # # # # # # #
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -360,7 +360,6 @@ class Unit(models.Model, base.TranslationUnit):
     simple_objects = models.Manager()
 
     class Meta(object):
-        ordering = ['store', 'index']
         unique_together = ('store', 'unitid_hash')
         get_latest_by = 'mtime'
 

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -474,7 +474,9 @@ def get_units(request):
 
         vfolder, pootle_path = extract_vfolder_from_path(pootle_path)
 
-    units_qs = Unit.objects.get_for_path(pootle_path, request.profile)
+    units_qs = (
+        Unit.objects.get_for_path(pootle_path, request.profile)
+                    .order_by("store", "index"))
 
     if vfolder is not None:
         units_qs = units_qs.filter(vfolders=vfolder)

--- a/pootle_pytest/fixtures/models/store.py
+++ b/pootle_pytest/fixtures/models/store.py
@@ -132,7 +132,8 @@ def _setup_store_test(store, member, member2, test):
 
     store_revision, units_update = test["update_store"]
     revision_min = store.get_max_unit_revision()
-    units_before = [unit for unit in store.unit_set.all()]
+    units_before = [
+        unit for unit in store.unit_set.all().order_by("index")]
 
     fs_wins = test.get("fs_wins", True)
     if fs_wins:


### PR DESCRIPTION
On sites with a large number of Units - doing any db operation with
Unit.objects is pretty much unusable due to a v expensive sort

In general sorting on anything non-unique is expensive, even more so if there are multiple sort params - so best not
to make it the default.

This commit removes that ordering