### PR TITLE
Add site_matrix test fixture with lots of units

### DIFF
--- a/pootle/apps/pootle_store/util.py
+++ b/pootle/apps/pootle_store/util.py
@@ -32,6 +32,12 @@ STATES_MAP = {
     TRANSLATED: _("Translated"),
 }
 
+STATES_NAMES = {
+    OBSOLETE: "obsolete",
+    UNTRANSLATED: "untranslated",
+    FUZZY: "fuzzy",
+    TRANSLATED: "translated"}
+
 
 def add_trailing_slash(path):
     """If path does not end with /, add it and return."""
@@ -128,3 +134,7 @@ def parse_pootle_revision(store):
         if pootle_revision is not None:
             return int(pootle_revision)
     return None
+
+
+def get_state_name(code, default="untranslated"):
+    return STATES_NAMES.get(code, default)

--- a/pootle_pytest/fixtures/site.py
+++ b/pootle_pytest/fixtures/site.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def site_matrix(request, system, settings):
+
+    from pootle_pytest.factories import (
+        ProjectFactory, DirectoryFactory, LanguageFactory,
+        TranslationProjectFactory, StoreFactory, UnitFactory)
+
+    from pootle_store.models import UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE
+
+    # create root and projects directories
+    DirectoryFactory(name="projects", parent=DirectoryFactory(parent=None))
+
+    # add 2 languages
+    languages = [LanguageFactory() for i in range(0, 2)]
+
+    for i in range(0, 2):
+        # add 2 projects
+        project = ProjectFactory(source_language=languages[0])
+
+        for language in languages:
+            # add a TP to the project for each language
+            tp = TranslationProjectFactory(project=project, language=language)
+
+            for i in range(0, 3):
+                # add 3 stores
+                store = StoreFactory(translation_project=tp)
+
+                # add 8 units to each store
+                for state in [UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE]:
+                    for i in range(0, 2):
+                        UnitFactory(store=store, state=state)
+
+    def _teardown():
+        # required to get clean slate 8/
+        for trans_dir in os.listdir(settings.POOTLE_TRANSLATION_DIRECTORY):
+            if trans_dir.startswith("project"):
+                shutil.rmtree(
+                    os.path.join(
+                        settings.POOTLE_TRANSLATION_DIRECTORY, trans_dir))
+
+    request.addfinalizer(_teardown)

--- a/pootle_pytest/plugin.py
+++ b/pootle_pytest/plugin.py
@@ -37,6 +37,7 @@ from fixtures.import_export_fixtures import (
     FILE_IMPORT_FAIL_TESTS,
     file_import_failure, ts_directory, en_tutorial_ts)
 from fixtures.revision import revision
+from fixtures.site import site_matrix
 from fixtures.views import admin_client
 
 
@@ -70,4 +71,4 @@ __all__ = (
     'english_tutorial', 'french_tutorial', 'italian_tutorial',
     'russian_tutorial', 'spanish_tutorial', 'templates_tutorial',
     'delete_pattern', 'en_tutorial_ts', 'file_import_failure', 'ts_directory',
-    'revision', 'admin_client')
+    'revision', 'admin_client', 'site_matrix')


### PR DESCRIPTION
This commit adds a fixture for factory generating:
- 2 langs
- 2 projects
- a tp for each proj/lang
- 3 stores for each tp
- 8 units for each store (2 each of translated, untranslated, fuzzy, obsolete)

The units mtimes are spread out to allow sort/filter testing of unit lists based on mtime
