### PR TITLE
Improved CLDR support

### DIFF
--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -29,7 +29,15 @@ class Command(NoArgsCommand):
             default=True,
             help="Do not create the default 'terminology' and 'tutorial'"
                  "projects.",
-        ), )
+        ),
+        make_option(
+            '--cldr',
+            action='store_true',
+            dest='cldr',
+            default=False,
+            help="Initialize the list of language from CLDR database instead of built-in",
+        )
+    )
 
     def handle_noargs(self, **options):
         self.stdout.write('Populating the database.')

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -41,7 +41,8 @@ class Command(NoArgsCommand):
 
     def handle_noargs(self, **options):
         self.stdout.write('Populating the database.')
-        InitDB().init_db(options["create_projects"])
+        InitDB().init_db(create_projects=options["create_projects"],
+                         cldr=options["cldr"])
         self.stdout.write('Successfully populated the database.')
         self.stdout.write("To create an admin user, use the `pootle "
                           "createsuperuser` command.")

--- a/pootle/apps/pootle_language/migrations/0002_extend_pluralequation.py
+++ b/pootle/apps/pootle_language/migrations/0002_extend_pluralequation.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_language', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='language',
+            name='pluralequation',
+            field=models.CharField(help_text='For more information, visit <a href="http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html">our page</a> on plural forms.', max_length=512, verbose_name='Plural Equation', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -102,7 +102,7 @@ class Language(models.Model, TreeItem):
         verbose_name=_("Number of Plurals"), help_text=plurals_help_text
     )
     pluralequation = models.CharField(
-        max_length=255, blank=True, verbose_name=_("Plural Equation"),
+        max_length=512, blank=True, verbose_name=_("Plural Equation"),
         help_text=plurals_help_text)
 
     directory = models.OneToOneField('pootle_app.Directory', db_index=True,


### PR DESCRIPTION
Hey there! 

Just wanted to raise one question. Not sure how to discuss this, maybe we can do that in comments to this pull request.

By default when you initialize Pootle with `initdb`, it generates a bunch of languages with default settings for plural forms. The data for this is taken from the translate toolkit database. The thing is, I feel like the [CLDR database](http://cldr.unicode.org/) becomes the standard de-facto for such kind of information.

It looks like by this point we accumulate a number inconsistencies between CLDR and "classic" translate toolkit. I happen to spot some of them, like:
- Number of languages in Turkish and Hungarian: 2 (TTK) vs 1 (CLDR).
- Number of languages in Russian and Polish: 3 (TTK) vs 4 (CLDR).

It would be great to have at least an option to use CLDR database as a valid source for plural forms, and this PR while doesn't provide a complete solution, tries to solve our own problem in an opportunistic manner. Namely it:
- Adds support for optional import languages and plural definitions from CLDR database (uses babel)
- Allows Pootle admins to convert the language database from TTK to CLDR (well, there's just a function, which isn't exposed in CLI in any way)
- Fixes the `nplurals` check issue: if number of plurals in a database doesn't match the number of plurals, known to TTK, `nplurals` check always fails.
- Extends the `pluralequation` database field (255 symbols isn't enough for some babel-generated plural expressions)

I hope it makes sense and you guys can consider merging this PR in. Thank you!
