### PR TITLE
VFolder optimizations

### DIFF
--- a/pootle/core/helpers.py
+++ b/pootle/core/helpers.py
@@ -23,7 +23,7 @@ from pootle_misc.stats import get_translation_states
 from pootle_store.models import Unit
 from pootle_store.views import get_step_query
 from pootle_translationproject.models import TranslationProject
-from virtualfolder.models import VirtualFolder
+from virtualfolder.models import VirtualFolderTreeItem
 
 from .url_helpers import get_path_parts, get_previous_url
 
@@ -75,6 +75,18 @@ def get_filter_name(GET):
     return (filter_name, extra)
 
 
+def display_vfolder_priority(request):
+    check_vfolders = (
+        not getattr(request, 'current_vfolder', '')
+        and not request.pootle_path.startswith("/projects")
+        and not request.pootle_path.count("/") < 3)
+    return (
+        check_vfolders
+        and (
+            VirtualFolderTreeItem.objects.filter(
+                pootle_path__startswith=request.pootle_path).exists()))
+
+
 def get_translation_context(request):
     """Returns a common context for translation views.
 
@@ -82,12 +94,6 @@ def get_translation_context(request):
     """
     resource_path = getattr(request, 'resource_path', '')
     vfolder_pk = getattr(request, 'current_vfolder', '')
-    display_priority = False
-
-    if not vfolder_pk:
-        display_priority = VirtualFolder.objects.filter(
-            units__store__pootle_path__startswith=request.pootle_path
-        ).exists()
 
     return {
         'page': 'translate',
@@ -101,7 +107,7 @@ def get_translation_context(request):
         'pootle_path': request.pootle_path,
         'ctx_path': request.ctx_path,
         'current_vfolder_pk': vfolder_pk,
-        'display_priority': display_priority,
+        'display_priority': display_vfolder_priority(request),
         'resource_path': resource_path,
         'resource_path_parts': get_path_parts(resource_path),
 


### PR DESCRIPTION
- Don't check vfolders if not in a TP ui screen
   - this is a very expensive query and has no purpose if the pootle_path starts with /projects
- Use a more efficient search for deciding when to show vfolder priority