### PR TITLE
[WIP] Search pootle path using regex

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -474,7 +474,7 @@ def get_units(request):
         vfolder, pootle_path = extract_vfolder_from_path(pootle_path)
 
     units_qs = (
-        Unit.objects.get_for_path(pootle_path, request.profile)
+        Unit.objects.get_for_path(request.profile, pootle_path)
                     .order_by("store", "index"))
 
     if vfolder is not None:

--- a/pootle_pytest/fixtures/models/unit.py
+++ b/pootle_pytest/fixtures/models/unit.py
@@ -1,0 +1,90 @@
+
+from collections import OrderedDict
+
+import pytest
+
+
+_UNIT_PATH_RESOLVER_TESTS = (
+    ('pootle-projects-browse', {}),
+    ('pootle-projects-translate', {}),
+    ('pootle-project-browse',
+     {"kwa": {"project_code": "project0",
+              "dir_path": "",
+              "filename": ""},
+      "result": {"project": "project0"}}),
+    ('pootle-project-translate',
+     {"kwa": {"project_code": "project0",
+              "dir_path": "",
+              "filename": ""},
+      "result": {"project": "project0"}}),
+
+    ('pootle-project-translate_subdir',
+     {"kwa": {"project_code": "project0",
+              "dir_path": "subdir0/",
+              "filename": ""},
+      "result": {"project": "project0",
+                 "directory": "subdir0/"}}),
+    ('pootle-project-translate_sub_subdir',
+     {"kwa": {"project_code": "project0",
+              "dir_path": "subdir0/subdir1/",
+              "filename": ""},
+      "result": {"project": "project0",
+                 "directory": "subdir0/subdir1/"}}),
+
+    ('pootle-project-translate_subdir_filename',
+     {"kwa": {"project_code": "project0",
+              "dir_path": "subdir0/",
+              "filename": "store0.po"},
+      "result": {"project": "project0",
+                 "directory": "subdir0/",
+                 "filename": "store0.po"}}),
+    ('pootle-project-translate_sub_subdir_filename',
+     {"kwa": {"project_code": "project0",
+              "dir_path": "subdir0/subdir1/",
+              "filename": "store0.po"},
+      "result": {"project": "project0",
+                 "directory": "subdir0/subdir1/",
+                 "filename": "store0.po"}}),
+
+
+    ('pootle-tp-admin-permissions',
+     {"kwa": {"project_code": "project0",
+              "language_code": "langage0"},
+      "result": {"project": "project0",
+                 "language": "langage0"}}),
+    ('pootle-tp-translate',
+     {"kwa": {"project_code": "project0",
+              "language_code": "langage0",
+              "dir_path": "",
+              "filename": ""},
+      "result": {"project": "project0",
+                 "language": "langage0"}}),
+    ('pootle-tp-browse',
+     {"kwa": {"project_code": "project0",
+              "language_code": "langage0",
+              "dir_path": "",
+              "filename": ""},
+      "result": {"project": "project0",
+                 "language": "langage0"}}),
+    ('pootle-language-browse',
+     {"kwa": {"language_code": "langage0"},
+      "result": {"language": "langage0"}}),
+    ('pootle-language-translate',
+     {"kwa": {"language_code": "langage0"},
+      "result": {"language": "langage0"}}))
+UNIT_PATH_RESOLVER_TESTS = OrderedDict(_UNIT_PATH_RESOLVER_TESTS)
+
+
+@pytest.fixture
+def unit_path_resolver_tests(unit_path_resolver_names,
+                             site_matrix_with_subdirs):
+    from pootle.core.url_helpers import PathResolver
+
+    from django.core.urlresolvers import reverse
+
+    test = UNIT_PATH_RESOLVER_TESTS[unit_path_resolver_names]
+    resolved = PathResolver(
+        reverse(
+            unit_path_resolver_names.split("_")[0],
+            kwargs=test.get("kwa", None)))
+    return resolved, test

--- a/pootle_pytest/plugin.py
+++ b/pootle_pytest/plugin.py
@@ -31,6 +31,8 @@ from fixtures.models.translation_project import (
 from fixtures.models.user import (
     default, system, nobody, trans_nobody, admin, member, trans_member,
     trans_system, member_with_email, member2, evil_member)
+from fixtures.models.unit import (
+    UNIT_PATH_RESOLVER_TESTS, unit_path_resolver_tests)
 
 from fixtures.cache import delete_pattern
 from fixtures.import_export_fixtures import (
@@ -72,7 +74,7 @@ __all__ = (
     'revision', 'admin_client', 'site_matrix', 'site_matrix_with_subdirs',
     'site_root', 'site_matrix_with_vfolders', 'site_matrix_with_announcements',
     'site_permissions', 'project_views', 'tp_views', 'language_views',
-    'bad_views')
+    'bad_views', 'unit_path_resolver_tests')
 
 
 PARAMETERS = (
@@ -82,7 +84,8 @@ PARAMETERS = (
     ("project_view_names", PROJECT_VIEW_TESTS),
     ("language_view_names", LANGUAGE_VIEW_TESTS),
     ("tp_view_names", TP_VIEW_TESTS),
-    ("bad_view_names", BAD_VIEW_TESTS))
+    ("bad_view_names", BAD_VIEW_TESTS),
+    ("unit_path_resolver_names", UNIT_PATH_RESOLVER_TESTS))
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
At the moment when using Unit.objects.get_by_path it uses extra fields. These fields cause a headache with the queryset as store__pootle_path drops out of the scope of the qs.

Also, if pootle_path is not set it currently adds a search of like "/%" which is uncessary.

This PR:
- adds a PathResolver using django's url resolver
- adds regex filtering of qs rather than using extra fields
- removes unnecessary pootle_path filtering 
- adds some tests for above

**just working on some of the code around split_pootle_path**
