### PR TITLE
Create Scorelog object for UPLOAD submissions

### DIFF
--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -49,11 +49,10 @@ class SubmissionTypes(object):
     # Combined types that rely on other types (useful for querying)
     # Please use the `_TYPES` suffix to make it clear they're not core
     # types that are stored in the DB
-    EDIT_TYPES = [NORMAL, SYSTEM]
+    EDIT_TYPES = [NORMAL, SYSTEM, UPLOAD]
     CONTRIBUTION_TYPES = [NORMAL, SYSTEM, SUGG_ADD]
     SUGGESTION_TYPES = [SUGG_ACCEPT, SUGG_ADD, SUGG_REJECT]
     REVIEW_TYPES = [SUGG_ACCEPT, SUGG_REJECT]
-    EDITING_TYPES = [NORMAL, SYSTEM, UNIT_CREATE, UPLOAD]
 
 
 #: Values for the 'field' field of Submission
@@ -142,7 +141,7 @@ class SubmissionManager(BaseSubmissionManager):
         return (
             self.get_queryset().exclude(new_value__isnull=True).filter(
                 field__in=SubmissionFields.TRANSLATION_FIELDS,
-                type__in=SubmissionTypes.EDITING_TYPES,
+                type__in=SubmissionTypes.EDIT_TYPES,
             )
         )
 

--- a/pootle_pytest/factories.py
+++ b/pootle_pytest/factories.py
@@ -16,6 +16,13 @@ from django.utils import timezone
 import pootle_store
 
 
+class ScoreLogFactory(factory.django.DjangoModelFactory):
+    creation_time = timezone.now()
+
+    class Meta(object):
+        model = 'pootle_statistics.ScoreLog'
+
+
 class SubmissionFactory(factory.django.DjangoModelFactory):
     creation_time = timezone.now()
 

--- a/tests/models/scorelog.py
+++ b/tests/models/scorelog.py
@@ -11,9 +11,10 @@ import pytest
 
 from datetime import datetime
 
-from pootle_statistics.models import ScoreLog, SubmissionTypes, SubmissionFields
+from pootle_statistics.models import (ScoreLog, SubmissionTypes, SubmissionFields,
+                                      SIMILARITY_THRESHOLD)
 
-from pootle_pytest.factories import SubmissionFactory
+from pootle_pytest.factories import ScoreLogFactory, SubmissionFactory
 
 
 TEST_EDIT_TYPES = (SubmissionTypes.NORMAL, SubmissionTypes.SYSTEM,
@@ -43,3 +44,23 @@ def test_record_submission(site_matrix, member, submission_type):
 
     sub = SubmissionFactory(**submission_params)
     assert ScoreLog.objects.filter(submission=sub).count() == 1
+
+
+@pytest.mark.parametrize('similarity', (0, 0.1, 0.49, 0.5, 0.51, 0.6, 1))
+def test_get_similarity(similarity):
+    score_log = ScoreLogFactory.build(similarity=similarity)
+    if similarity >= SIMILARITY_THRESHOLD:
+        assert score_log.get_similarity() == similarity
+    else:
+        assert score_log.get_similarity() == 0
+
+
+@pytest.mark.parametrize('similarity, mt_similarity', [(0, 1), (0.5, 0.5), (1, 0)])
+def test_is_similarity_is_taken_from_mt(similarity, mt_similarity):
+    submission = SubmissionFactory.build(similarity=similarity,
+                                         mt_similarity=mt_similarity)
+    score_log = ScoreLogFactory.build(submission=submission)
+    if submission.similarity < submission.mt_similarity:
+        assert score_log.is_similarity_taken_from_mt()
+    else:
+        assert not score_log.is_similarity_taken_from_mt()

--- a/tests/models/scorelog.py
+++ b/tests/models/scorelog.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from datetime import datetime
+
+from pootle_statistics.models import ScoreLog, SubmissionTypes, SubmissionFields
+
+from pootle_pytest.factories import SubmissionFactory
+
+
+TEST_EDIT_TYPES = (SubmissionTypes.NORMAL, SubmissionTypes.SYSTEM,
+                   SubmissionTypes.UPLOAD)
+
+
+@pytest.mark.parametrize('submission_type', TEST_EDIT_TYPES)
+@pytest.mark.django_db
+def test_record_submission(site_matrix, member, submission_type):
+    from pootle_store.models import Store
+    store = Store.objects.first()
+    unit = store.units.first()
+
+    submission_params = {
+        'store': store,
+        'unit': unit,
+        'field': SubmissionFields.TARGET,
+        'type': submission_type,
+        'old_value': unit.target,
+        'new_value': 'New target',
+        'similarity': 0,
+        'mt_similarity': 0,
+        'submitter': member,
+        'translation_project': store.translation_project,
+        'creation_time': datetime.now(),
+    }
+
+    sub = SubmissionFactory(**submission_params)
+    assert ScoreLog.objects.filter(submission=sub).count() == 1


### PR DESCRIPTION
Scorelog object will be created if UPLOAD submission type is added to EDIT_TYPES.
Also it's confusing to have EDITING_TYPES and EDIT_TYPES together. So I'd suggest to get rid of EDITING_TYPES.
Fixes #4296.