### PR TITLE
Skip adding/obsoleting units for UPLOAD submission type

### DIFF
--- a/pootle/apps/import_export/management/commands/import.py
+++ b/pootle/apps/import_export/management/commands/import.py
@@ -7,6 +7,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import datetime
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from zipfile import ZipFile, is_zipfile
@@ -40,10 +41,16 @@ class Command(BaseCommand):
             User = get_user_model()
             try:
                 user = User.objects.get(username=options["user"])
+                self.stdout.write(
+                    'User %s will be set as author of the import.'
+                    % user.username)
             except User.DoesNotExist:
                 raise CommandError("Unrecognised user: %s" % options["user"])
 
+        start = datetime.datetime.now()
         for filename in options['file']:
+            self.stdout.write('Importing %s...' % filename)
+
             if not os.path.isfile(filename):
                 raise CommandError("No such file '%s'" % filename)
 
@@ -64,3 +71,6 @@ class Command(BaseCommand):
                         import_file(f, user=user)
                     except Exception as e:
                         raise CommandError(e)
+
+        end = datetime.datetime.now()
+        self.stdout.write('All done in %s.' % (end - start))

--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -39,7 +39,7 @@ class PootleTestEnv(object):
         "redis", "case_sensitive_schema", "content_type", "site_root",
         "languages", "site_matrix", "system_users", "permissions",
         "site_permissions", "tps", "vfolders", "subdirs", "submissions",
-        "announcements")
+        "announcements", "terminology")
 
     def __init__(self, request):
         self.request = request
@@ -286,6 +286,19 @@ class PootleTestEnv(object):
         for i in range(0, 2):
             # add 2 projects
             ProjectFactory(source_language=source_language)
+
+    def setup_terminology(self):
+        from pytest_pootle.factories import (ProjectFactory,
+                                             TranslationProjectFactory)
+        from pootle_language.models import Language
+
+        source_language = Language.objects.get(code="en")
+        terminology = ProjectFactory(code="terminology",
+                                     checkstyle="terminology",
+                                     fullname="Terminology",
+                                     source_language=source_language)
+        for language in Language.objects.all():
+            TranslationProjectFactory(project=terminology, language=language)
 
     def setup_subdirs(self):
         from pytest_pootle.factories import DirectoryFactory

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -159,10 +159,7 @@ class UnitFactory(factory.django.DjangoModelFactory):
 
     @factory.lazy_attribute
     def unitid(self):
-        return (
-            "%s_unit%s"
-            % (pootle_store.util.get_state_name(self),
-               self.index))
+        return self.source_f
 
     @factory.lazy_attribute
     def unitid_hash(self):

--- a/pytest_pootle/fixtures/import_export_fixtures.py
+++ b/pytest_pootle/fixtures/import_export_fixtures.py
@@ -73,3 +73,18 @@ def en_tutorial_ts(settings, english_tutorial, ts_directory):
     return store._require_store(english_tutorial,
                                 ts_directory,
                                 'tutorial.ts')
+
+
+@pytest.fixture(
+    params=[
+        "language0_project0", "templates_project0", "en_terminology"])
+def import_tps(request):
+    """List of required translation projects for import tests."""
+    from pootle_translationproject.models import TranslationProject
+
+    language_code, project_code = request.param.split('_')
+    try:
+        return TranslationProject.objects.get(language__code=language_code,
+                                              project__code=project_code)
+    except TranslationProject.DoesNotExist:
+        return request.getfuncargvalue(request.param)

--- a/pytest_pootle/fixtures/models/translation_project.py
+++ b/pytest_pootle/fixtures/models/translation_project.py
@@ -98,3 +98,20 @@ def tp_checker_tests(request, english, checkers):
     request.addfinalizer(_remove_project_directory)
 
     return (checker_name, project)
+
+
+@pytest.fixture
+def templates_project0(request, templates):
+    """Require the templates/project0/ translation project."""
+    from pootle_project.models import Project
+    from pytest_pootle.factories import TranslationProjectFactory
+
+    project0 = Project.objects.get(code="project0")
+    tp = TranslationProjectFactory(language=templates, project=project0)
+
+    def _cleanup():
+        shutil.rmtree(tp.abs_real_path)
+
+    request.addfinalizer(_cleanup)
+
+    return tp

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -107,3 +107,19 @@ def update_store(store, units=None, store_revision=None, add_headers=False,
                  store_revision=store_revision,
                  user=user, submission_type=submission_type,
                  resolve_conflict=resolve_conflict)
+
+
+def get_translated_storefile(store, pootle_path=None):
+    """Returns file store with added translations for untranslated units."""
+    storeclass = store.get_file_class()
+    filestore = store.convert(storeclass)
+    for i, unit in enumerate(filestore.units):
+        if not unit.istranslated():
+            unit.target = "Translation of %s" % unit.source
+
+    path = pootle_path if pootle_path is not None else store.pootle_path
+    filestore.updateheader(add=True, X_Pootle_Path=path)
+    filestore.updateheader(add=True,
+                           X_Pootle_Revision=store.get_max_unit_revision())
+
+    return filestore

--- a/tests/import_export/import.py
+++ b/tests/import_export/import.py
@@ -24,31 +24,33 @@ IMPORT_UNSUPP_FILE = "tutorial.ts"
 
 
 def _import_file(file_name, file_dir=TEST_PO_DIR,
-                 content_type="text/x-gettext-translation"):
+                 content_type="text/x-gettext-translation",
+                 user=None):
     with open(os.path.join(file_dir, file_name), "r") as f:
-        import_file(SimpleUploadedFile(file_name,
-                                       f.read(),
-                                       content_type))
+        import_file(
+            SimpleUploadedFile(file_name, f.read(), content_type),
+            user=user)
 
 
 @pytest.mark.django_db
-def test_import_success(en_tutorial_po_no_file):
+def test_import_success(en_tutorial_po_no_file, admin):
     assert en_tutorial_po_no_file.state == NEW
-    _import_file(IMPORT_SUCCESS)
+    _import_file(IMPORT_SUCCESS, user=admin)
     store = Store.objects.get(pk=en_tutorial_po_no_file.pk)
     assert store.state == PARSED
 
 
 @pytest.mark.django_db
-def test_import_failure(file_import_failure, en_tutorial_po):
+def test_import_failure(file_import_failure, en_tutorial_po, member):
     filename, exception = file_import_failure
     with pytest.raises(exception):
-        _import_file(filename)
+        _import_file(filename, user=member)
 
 
 @pytest.mark.django_db
-def test_import_unsupported(en_tutorial_ts, ts_directory):
+def test_import_unsupported(en_tutorial_ts, ts_directory, member):
     with pytest.raises(UnsupportedFiletypeError):
         _import_file(IMPORT_UNSUPP_FILE,
                      file_dir=os.path.join(ts_directory, "tutorial/en"),
-                     content_type="text/vnd.trolltech.linguist")
+                     content_type="text/vnd.trolltech.linguist",
+                     user=member)


### PR DESCRIPTION
- Add `allow_add_obsolete` parameter in `Store.update()`
- Allow add/obsolete for terminology project or templates translation project for users who has administrate permission.

Fixes #4302