### PR TITLE
Check stats of created translation projects

### DIFF
--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -287,6 +287,9 @@ class TranslationProject(models.Model, CachedTreeItem):
                     init_store_from_template(self, template_store)
 
             self.scan_files()
+            # If this TP has no stores cache should be updated forcibly.
+            if self.stores.live().count() == 0:
+                self.update_all_cache()
 
             # Create units from disk store
             for store in self.stores.live().iterator():

--- a/pootle_pytest/fixtures/site.py
+++ b/pootle_pytest/fixtures/site.py
@@ -44,11 +44,11 @@ def site_matrix_with_subdirs(site_matrix):
 
 
 @pytest.fixture
-def site_matrix(request, system, settings):
+def site_root(request, system, settings):
 
     from pootle_pytest.factories import (
-        ProjectFactory, DirectoryFactory, LanguageFactory,
-        TranslationProjectFactory)
+        ProjectFactory, DirectoryFactory, LanguageFactory
+    )
 
     from pootle_app.models import Directory
 
@@ -68,11 +68,6 @@ def site_matrix(request, system, settings):
         # add 2 projects
         project = ProjectFactory(source_language=languages[0])
 
-        for language in languages:
-            # add a TP to the project for each language
-            tp = TranslationProjectFactory(project=project, language=language)
-            _add_stores(tp)
-
     def _teardown():
         if "root" in Directory.objects.__dict__:
             del Directory.objects.__dict__['root']
@@ -86,3 +81,16 @@ def site_matrix(request, system, settings):
                         settings.POOTLE_TRANSLATION_DIRECTORY, trans_dir))
 
     request.addfinalizer(_teardown)
+
+
+@pytest.fixture
+def site_matrix(site_root):
+    from pootle_project.models import Project
+    from pootle_language.models import Language
+    from pootle_pytest.factories import TranslationProjectFactory
+
+    for project in Project.objects.all():
+        for language in Language.objects.all():
+            # add a TP to the project for each language
+            tp = TranslationProjectFactory(project=project, language=language)
+            _add_stores(tp)

--- a/pootle_pytest/plugin.py
+++ b/pootle_pytest/plugin.py
@@ -37,7 +37,7 @@ from fixtures.import_export_fixtures import (
     FILE_IMPORT_FAIL_TESTS,
     file_import_failure, ts_directory, en_tutorial_ts)
 from fixtures.revision import revision
-from fixtures.site import site_matrix, site_matrix_with_subdirs
+from fixtures.site import site_matrix, site_matrix_with_subdirs, site_root
 from fixtures.views import admin_client
 
 from fixtures.core.utils.wordcount import WORDCOUNT_TESTS
@@ -74,4 +74,5 @@ __all__ = (
     'english_tutorial', 'french_tutorial', 'italian_tutorial',
     'russian_tutorial', 'spanish_tutorial', 'templates_tutorial',
     'delete_pattern', 'en_tutorial_ts', 'file_import_failure', 'ts_directory',
-    'revision', 'admin_client', 'site_matrix', 'site_matrix_with_subdirs')
+    'revision', 'admin_client', 'site_matrix', 'site_matrix_with_subdirs',
+    'site_root',)

--- a/tests/models/translationproject.py
+++ b/tests/models/translationproject.py
@@ -96,3 +96,15 @@ def test_tp_empty_stats(site_root):
     assert stats['fuzzy'] == 0
     assert stats['suggestions'] == 0
     assert stats['critical'] == 0
+
+
+@pytest.mark.django_db
+def test_tp_stats_created_from_template(tutorial, fish, templates):
+    tp = TranslationProject.objects.create(project=tutorial, language=fish)
+    assert tp.stores.all().count() == 1
+    stats = tp.get_stats()
+    assert stats['total'] == 2  # there are 2 words in test template
+    assert stats['translated'] == 0
+    assert stats['fuzzy'] == 0
+    assert stats['suggestions'] == 0
+    assert stats['critical'] == 0


### PR DESCRIPTION
Calculate stats forcibly for empty TP.
Added tests for:
- empty created TP;
- non-empty TP created from template;

Fixes #3235