### PR TITLE
Enable flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - TOXENV=eslint
   - TOXENV=docs
   - TOXENV=mo
-  - TOXENV=pep8
+  - TOXENV=pep8_flake8
   - TOXENV=pep257
 cache:
   directories:

--- a/manage.py
+++ b/manage.py
@@ -12,7 +12,7 @@ import sys
 
 from django.core.management import execute_from_command_line
 
-from pootle import syspath_override
+from pootle import syspath_override  # noqa
 
 
 if __name__ == "__main__":

--- a/pootle/apps/pootle_app/apps.py
+++ b/pootle/apps/pootle_app/apps.py
@@ -15,7 +15,8 @@ See https://docs.djangoproject.com/en/1.7/ref/applications/
 from django.apps import AppConfig
 from django.core import checks
 
-from pootle import checks as pootle_checks
+# imported to force checks to run.  FIXME use AppConfig
+from pootle import checks as pootle_checks  # noqa
 from pootle.core.utils import deprecation
 
 

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -14,7 +14,6 @@ from optparse import make_option
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from pootle.core.mixins.treeitem import CachedMethods
 from pootle.core.checks.checker import QualityCheckUpdater
 
 from . import PootleCommand

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -247,11 +247,11 @@ def check_settings(app_configs=None, **kwargs):
         if markup_filter is not None:
             try:
                 if markup_filter == 'textile':
-                    import textile
+                    import textile  # noqa
                 elif markup_filter == 'markdown':
-                    import markdown
+                    import markdown  # noqa
                 elif markup_filter == 'restructuredtext':
-                    import docutils
+                    import docutils  # noqa
                 else:
                     errors.append(checks.Warning(
                         _("Invalid markup in POOTLE_MARKUP_FILTER."),

--- a/pootle/core/markup/filters.py
+++ b/pootle/core/markup/filters.py
@@ -73,11 +73,11 @@ def get_markup_filter():
         if markup_filter is None:
             return (None, "unset")
         elif markup_filter == 'textile':
-            import textile
+            import textile  # noqa
         elif markup_filter == 'markdown':
-            import markdown
+            import markdown  # noqa
         elif markup_filter == 'restructuredtext':
-            import docutils
+            import docutils  # noqa
         else:
             return (None, '')
     except Exception:

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -14,7 +14,7 @@ from argparse import ArgumentParser, SUPPRESS
 from django.conf import settings
 from django.core import management
 
-import syspath_override
+import syspath_override  # noqa
 
 from .core.utils.redis_rq import rq_workers_are_running
 

--- a/pootle_pytest/fixtures/site.py
+++ b/pootle_pytest/fixtures/site.py
@@ -85,7 +85,7 @@ def site_root(request, system, settings):
 
     for i in range(0, 2):
         # add 2 projects
-        project = ProjectFactory(source_language=languages[0])
+        ProjectFactory(source_language=languages[0])
 
     def _teardown():
         if "root" in Directory.objects.__dict__:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,7 @@
 
 django-debug-toolbar>=1.2
 django-extensions
+flake8
 glue>=0.2.8.1
 ipython
 pep257

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,3 +57,16 @@ exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,migrations,conf.py,_build,.tox,pootle
 # Default ignore list for ref E121,E123,E126,E226,E24,E704
 ignore=E129,E226,E402,W503
 statistics=True
+
+[flake8]
+# See [pep8] above, [pep8] is the reference, please keep in sync.
+# You would think flake8 would have the decency of reading the pep8 configs,
+# but it doesn't so we have to repeat them.
+max-line-length=84
+exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,migrations,conf.py,_build,.tox,pootle/static,pootle/translations,pootle/locale,pootle/assets,templates
+# Additional default excludes:
+# I - import plugin
+# N - naming plugin
+ignore=E129,E226,E402,W503,I,N
+statistics=True
+# /end [pep8] duplication

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ class BuildChecksTemplatesCommand(Command):
         except ImportError:
             from distutils.errors import DistutilsModuleError
             raise DistutilsModuleError("Please install the docutils library.")
-        from pootle import syspath_override
+        from pootle import syspath_override  # noqa
         django.setup()
 
         def get_check_description(name, filterfunc):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{17,18}-{sqlite,mysql,postgres},docs,pep8,pep257,sdist,eslint
+envlist = py27-django{17,18}-{sqlite,mysql,postgres},docs,pep8_flake8,pep257,sdist,eslint
 
 [testenv]
 basepython=python
@@ -65,11 +65,14 @@ whitelist_externals=
 commands=
     make docs
 
-[testenv:pep8]
-deps=pep8==1.5.7
+[testenv:pep8_flake8]
+deps=
+    pep8<1.6
+    flake8
 skipsdist=True
+; flake8 will run pep8 so leaving it out for now
 commands=
-    pep8 --config=setup.cfg
+    flake8 --config=setup.cfg
 
 [testenv:mo]
 basepython=python


### PR DESCRIPTION
This enables flake8 by default.  Seems it is most useful for catching unused imports.

I've used `# noqa` in a few places where we're importing libraries based within `if` statements.

Also note that the build will fail as we have 2 outstanding fixes that I'm hoping someone else can fix:

```
./pootle/apps/virtualfolder/helpers.py:44:35: F812 list comprehension redefines 'dir_path' from line 35
./pootle/core/helpers.py:146:50: F812 list comprehension redefines 'units' from line 140
``