### PR TITLE
Improve record submissions 

### DIFF
--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -353,7 +353,7 @@ class Submission(models.Model):
         super(Submission, self).save(*args, **kwargs)
 
         if self.needs_scorelog():
-            ScoreLog.record_submission(submission=self)
+            ScoreLog.record_scorelogs(submission=self)
 
 
 class TranslationActionCodes(object):
@@ -412,7 +412,7 @@ class ScoreLog(models.Model):
         unique_together = ('submission', 'action_code')
 
     @classmethod
-    def record_submission(cls, submission):
+    def record_scorelogs(cls, submission):
         """Records a new log entry for ``submission``."""
         score_dict = {
             'creation_time': submission.creation_time,

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1702,12 +1702,12 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
         # Create Submission after unit saved
         for field in create_subs:
-            sub = Submission(
+            Submission.objects.create(
                 creation_time=current_time,
-                translation_project=self.translation_project,
+                translation_project_id=self.translation_project_id,
                 submitter=user,
                 unit=unit,
-                store=unit.store,
+                store_id=self.id,
                 field=field,
                 type=submission_type,
                 old_value=create_subs[field][0],
@@ -1715,7 +1715,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             )
             # FIXME: we can store these objects in a list and
             # `bulk_create()` them in a single go
-            sub.save()
 
     def update(self, store, user=None, store_revision=None,
                submission_type=None, resolve_conflict=POOTLE_WINS):


### PR DESCRIPTION
- Get rid of queries for translation projects when Submission objects are created.
- Cleanup record_submissions.
