### PR TITLE
Convert get_for_path to get_translatable

### DIFF
--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -629,8 +629,11 @@ class PootleExportView(PootleDetailView):
     def get_context_data(self, *args, **kwargs):
         ctx = {}
         filter_name, filter_extra = get_filter_name(self.request.GET)
-        units_qs = Unit.objects.get_for_path(self.object.pootle_path,
-                                             self.request.profile)
+
+        units_qs = Unit.objects.get_translatable(
+            self.request.profile,
+            **self.kwargs)
+
         units_qs = get_step_query(self.request, units_qs)
         unit_total_count = units_qs.count()
         units_qs = units_qs.select_related('store')

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -102,8 +102,8 @@ def _test_export_view(language, request, response, kwargs):
     # TODO: export views should be parsed in a form
     ctx = response.context
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_for_path(
-        language.pootle_path, request.profile)
+    units_qs = Unit.objects.get_translatable(
+        request.profile, **kwargs)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -141,28 +141,9 @@ def _test_browse_view(project, request, response, kwargs):
 def _test_export_view(project, request, response, kwargs):
     ctx = response.context
     kwargs["project_code"] = project.code
-
-    resource_path = (
-        "%(dir_path)s%(filename)s" % kwargs)
-    project_path = (
-        "%s/%s"
-        % (kwargs["project_code"], resource_path))
-    if not (kwargs["dir_path"] or kwargs["filename"]):
-        ob = project
-    elif not kwargs["filename"]:
-        ob = ProjectResource(
-            Directory.objects.live().filter(
-                pootle_path__regex="^/.*/%s$" % project_path),
-            pootle_path="/projects/%s" % project_path)
-    else:
-        ob = ProjectResource(
-            Store.objects.live().filter(
-                pootle_path__regex="^/.*/%s$" % project_path),
-            pootle_path="/projects/%s" % project_path)
-
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_for_path(
-        ob.pootle_path, request.profile)
+    units_qs = Unit.objects.get_translatable(
+        request.profile, **kwargs)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [
@@ -272,8 +253,8 @@ def test_view_projects_export(site_permissions, site_matrix_with_vfolders,
     ctx = response.context
     request = response.wsgi_request
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_for_path(
-        "/projects/", request.profile)
+    units_qs = Unit.objects.get_translatable(
+        request.profile)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -176,19 +176,9 @@ def _test_translate_view(tp, request, response, kwargs, settings):
 
 def _test_export_view(tp, request, response, kwargs):
     ctx = response.context
-    resource_path = "%(dir_path)s%(filename)s" % kwargs
-    pootle_path = "%s%s" % (tp.pootle_path, resource_path)
-    if not (kwargs["dir_path"] or kwargs.get("filename")):
-        ob = tp.directory
-    elif not kwargs.get("filename"):
-        ob = Directory.objects.get(
-            pootle_path=pootle_path)
-    else:
-        ob = Store.objects.get(
-            pootle_path=pootle_path)
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_for_path(
-        ob.pootle_path, request.profile)
+    units_qs = Unit.objects.get_translatable(
+        request.profile, **kwargs)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/unit.py
+++ b/tests/views/unit.py
@@ -9,7 +9,7 @@
 
 import pytest
 
-from pootle.core.exceptions import Http400
+from django.http import Http404
 
 from pootle_store.views import get_units
 
@@ -23,13 +23,13 @@ def test_get_units(rf, default):
 
     # `path` query parameter missing
     request = create_api_request(rf, user=default)
-    with pytest.raises(Http400):
+    with pytest.raises(Http404):
         view(request)
 
     # `path` query parameter present
     request = create_api_request(rf, url='/?path=foo', user=default)
-    response = view(request)
-    assert response.status_code == 200
+    with pytest.raises(Http404):
+        view(request)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- replaces Unit.get_for_path with Unit.get_translatable
- avoids use of path or regex wherever possible
