### PR TITLE
Add flush_cache command which works via redis client directly

### DIFF
--- a/docs/releases/2.7.3b2.rst
+++ b/docs/releases/2.7.3b2.rst
@@ -23,6 +23,9 @@ Details of changes
 - :djadmin:`contributors` has two new options
   :option:`--since <contributors --since>` and
   :option:`--only-emails <contributors --only-emails>`.
+- :djadmin:`flush_cache` flushes `default`, `redis`, `stats` caches,
+  accepts :option:`--rqdata`, :option:`--stats`, :option:`--django-cache`
+  options.
 
 - :setting:`POOTLE_SCORE_COEFFICIENTS` accepts custom settings for user
   scores calculation.

--- a/docs/releases/2.7.3b2.rst
+++ b/docs/releases/2.7.3b2.rst
@@ -18,7 +18,7 @@ Details of changes
 - :djadmin:`start` has been removed, use :djadmin:`runserver` instead.
 - :djadmin:`verify_user` and :djadmin:`purge_user` now accept multiple
   usernames.
-- :djadmin:`refresh_scores` now recalculates user scores and accept
+- :djadmin:`refresh_scores` now recalculates user scores and accepts
   multiple usernames.
 - :djadmin:`contributors` has two new options
   :option:`--since <contributors --since>` and

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -167,7 +167,7 @@ clear_stats
 Clear stats cache data.
 
 Make use of :djadmin:`clear_stats` in cases where you want to remove all stats
-data.  Such a case may be where you want to recalculate stats after a change
+data. Such a case may be where you want to recalculate stats after a change
 to checks or wordcount calculations.  While it should be fine to run
 :djadmin:`refresh_stats` or :djadmin:`calculate_checks`, by first running
 :djadmin:`clear_stats` you can be sure that the stats are calculated from

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -174,6 +174,39 @@ to checks or wordcount calculations.  While it should be fine to run
 scratch.
 
 
+.. django-admin:: flush_cache
+
+flush_cache
+^^^^^^^^^^^
+
+.. versionadded:: 2.8.0
+
+Flush cache.
+
+.. warning:: You must first **stop the workers** if you flush `stats`
+   or `redis` cache.
+
+.. django-admin-option:: --django-cache
+
+Use the :option:`--django-cache` to flush `default` cache which keeps Django
+templates, project permissions etc.).
+
+.. django-admin-option:: --rqdata
+
+Use the :option:`--rqdata` to flush all data contained in `redis` cache:
+pending jobs, dirty flags, revision (which will be automatically restored),
+all data from queues.
+
+.. django-admin-option:: --stats
+
+Use the :option:`--stats` to flush all stats data only (it works faster than
+:djadmin:`clear_stats` but it requires stopping the worker).
+
+.. django-admin-option:: --all
+
+Use the :option:`--all` to flush all caches (`default`, `redis`, `stats`) data.
+
+
 .. django-admin:: refresh_scores
 
 refresh_scores

--- a/pootle/apps/pootle_app/management/commands/clear_stats.py
+++ b/pootle/apps/pootle_app/management/commands/clear_stats.py
@@ -16,7 +16,7 @@ from pootle_app.management.commands import PootleCommand
 
 
 class Command(PootleCommand):
-    help = "Flush stats cache."
+    help = "Clear stats cache."
 
     def handle_all_stores(self, translation_project, **options):
         translation_project.clear_all_cache()

--- a/pootle/apps/pootle_app/management/commands/flush_cache.py
+++ b/pootle/apps/pootle_app/management/commands/flush_cache.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+
+# This must be run before importing Django.
+os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
+
+from django.core.management.base import BaseCommand, CommandError
+
+from django_redis import get_redis_connection
+
+from pootle.core.models import Revision
+from pootle_store.models import Unit
+
+
+class Command(BaseCommand):
+    help = """Flush cache."""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--django-cache',
+            action='store_true',
+            dest='flush_django_cache',
+            default=False,
+            help='Flush Django default cache.',
+        )
+        parser.add_argument(
+            '--rqdata',
+            action='store_true',
+            dest='flush_rqdata',
+            default=False,
+            help=("Flush revision counter and all RQ data (queues, pending or "
+                  "failed jobs, refresh_stats optimisation data). "
+                  "Revision counter is restores automatically. "),
+        )
+        parser.add_argument(
+            '--stats',
+            action='store_true',
+            dest='flush_stats',
+            default=False,
+            help='Flush stats cache data.',
+        )
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            dest='flush_all',
+            default=False,
+            help='Flush all caches data.',
+        )
+
+    def handle(self, **options):
+        if (options['flush_stats'] or options['flush_rqdata']
+            or options['flush_django_cache'] or options['flush_all']):
+            self.stdout.write('Flushing cache...')
+        else:
+            raise CommandError("No options were provided. Use one of "
+                               "--django-cache, --rqdata, --stats or --all.")
+
+        if options['flush_stats'] or options['flush_all']:
+            # Delete all stats cache data.
+            r_con = get_redis_connection('stats')
+            r_con.flushdb()
+            self.stdout.write('All stats data removed.')
+
+        if options['flush_rqdata'] or options['flush_all']:
+            # Flush all rq data, dirty counter and restore Pootle revision
+            # value.
+            r_con = get_redis_connection('redis')
+            r_con.flushdb()
+            self.stdout.write('RQ data removed.')
+            Revision.set(Unit.max_revision())
+            self.stdout.write('Max unit revision restored.')
+
+        if options['flush_django_cache'] or options['flush_all']:
+            r_con = get_redis_connection('default')
+            r_con.flushdb()
+            self.stdout.write('All default Django cache data removed.')

--- a/tests/commands/clear_stats.py
+++ b/tests/commands/clear_stats.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_clear_stats(capfd):
+    call_command('clear_stats', '--project=project0', '--language=language0',
+                 '--verbosity=2')
+    out, err = capfd.readouterr()
+    assert "clear_stats over /language0/project0/" in err

--- a/tests/commands/flush_cache.py
+++ b/tests/commands/flush_cache.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_flush_cache(capfd):
+    call_command('flush_cache', '--rqdata')
+    out, err = capfd.readouterr()
+    assert "Flushing cache..." in out
+    assert "RQ data removed." in out
+    assert "Max unit revision restored." in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_flush_cache_no_options():
+    with pytest.raises(CommandError) as e:
+        call_command('flush_cache')
+    assert "No options were provided." in str(e)


### PR DESCRIPTION
~~This allows to clear all stats cache data and dirty items using redis API directly.
Also all rq data (jobs, last jobs) can be removed with option `--clear-rq`.~~

This adds `flush_cache` command which work via redis directly. So it allows to flush all default cache, redis data (RQ, refresh_stats RQ keys), stats instantly.
`clear_stats` command left as it is to allow to clear stats using `--project`, `--language` options.

Refs #4219