### PR TITLE
Use own pootle_path property of TP in get_cachekey() method

### DIFF
--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -355,7 +355,7 @@ class TranslationProject(models.Model, CachedTreeItem):
         return self.directory.children
 
     def get_cachekey(self):
-        return self.directory.pootle_path
+        return self.pootle_path
 
     def get_parents(self):
         return [self.project]


### PR DESCRIPTION
I think we don't need `select_related('directory')` for translation project set with this PR.