### PR TITLE
Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@
 sudo: false
 language: python
 env:
-  - TOXENV=py27-django18-sqlite PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
-  - TOXENV=py27-django18-mysql PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
-  - TOXENV=py27-django18-postgres PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
+  - TOXENV=py27-django19-sqlite PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
+  - TOXENV=py27-django19-mysql PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
+  - TOXENV=py27-django19-postgres PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
   # Meta
   - TOXENV=project PYTHONPATH=$HOME/virtualenv/python2.7.9/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
 cache:

--- a/docs/server/mysql_installation.rst
+++ b/docs/server/mysql_installation.rst
@@ -88,20 +88,6 @@ You will most likely want to edit your Pootle configuration (default location:
 Database backend
 ----------------
 
-Please note that Pootle uses `django-transaction-hooks
-<https://pypi.python.org/pypi/django-transaction-hooks/>`_ backends for
-connecting to the database. For MySQL the correct :setting:`ENGINE
-<django:DATABASE-ENGINE>` to set for the backend is:
-
-.. code-block:: python
-
-   DATABASES = {
-       'default': {
-           'ENGINE': 'transaction_hooks.backends.mysql',
-           ...
-       }
-   }
-
 
 .. _mysql_installation#persistent-connections:
 

--- a/docs/server/postgresql_installation.rst
+++ b/docs/server/postgresql_installation.rst
@@ -85,20 +85,6 @@ You will most likely want to edit your Pootle configuration (default location:
 Database backend
 ----------------
 
-Please note that Pootle uses `django-transaction-hooks
-<https://pypi.python.org/pypi/django-transaction-hooks/>`_ backends for
-connecting to the database. For PostgreSQL the correct :setting:`ENGINE
-<DATABASE-ENGINE>` to set for the backend is:
-
-.. code-block:: python
-
-   DATABASES = {
-       'default': {
-           'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
-           ...
-       }
-   }
-
 
 .. _postgresql_installation#persistent-connections:
 

--- a/pootle/apps/pootle_config/managers.py
+++ b/pootle/apps/pootle_config/managers.py
@@ -20,8 +20,8 @@ class ConfigQuerySet(models.QuerySet):
         super(ConfigQuerySet, self).__init__(*args, **kwargs)
         self.query_model = None
 
-    def _clone(self, klass=None, setup=None, **kwargs):
-        clone = super(ConfigQuerySet, self)._clone(klass, setup, **kwargs)
+    def _clone(self, **kwargs):
+        clone = super(ConfigQuerySet, self)._clone(**kwargs)
         clone.query_model = self.query_model
         return clone
 

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -328,7 +328,7 @@ class Submission(models.Model):
             if 'action_code' in score and score['user'] is not None:
                 scorelogs_created.append(ScoreLog(**score))
         if scorelogs_created:
-            self.scorelog_set.add(*scorelogs_created)
+            self.scorelog_set.add(*scorelogs_created, bulk=False)
 
 
 class TranslationActionCodes(object):

--- a/pootle/apps/pootle_store/form_fields.py
+++ b/pootle/apps/pootle_store/form_fields.py
@@ -7,7 +7,7 @@
 # AUTHORS file for copyright and authorship information.
 
 from django import forms
-from django.utils.datastructures import MergeDict, MultiValueDict
+from django.utils.datastructures import MultiValueDict
 
 from pootle.core.dateparse import parse_datetime
 from pootle_misc.checks import CATEGORY_IDS
@@ -19,7 +19,7 @@ class CommaSeparatedCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
         # Accept `sfields` to be a comma-separated string of fields (#46)
         if "," in data.get(name, ""):
             return data.get(name).split(u',')
-        if isinstance(data, (MultiValueDict, MergeDict)):
+        if isinstance(data, MultiValueDict):
             return data.getlist(name)
         return data.get(name, None)
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1002,7 +1002,7 @@ class Unit(models.Model, base.TranslationUnit):
 
             subs_created.append(Submission(**kwargs))
         if subs_created:
-            self.submission_set.add(*subs_created)
+            self.submission_set.add(*subs_created, bulk=False)
 
         # FIXME: remove such a dependency on `ScoreLog`
         # Update current unit instance's attributes
@@ -1411,7 +1411,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
                     old_value=create_subs[field][0],
                     new_value=create_subs[field][1]))
         if subs_created:
-            unit.submission_set.add(*subs_created)
+            unit.submission_set.add(*subs_created, bulk=False)
 
     def update(self, store, user=None, store_revision=None,
                submission_type=None, resolve_conflict=POOTLE_WINS,

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -391,16 +391,15 @@ def check_users(app_configs=None, **kwargs):
 
 
 @checks.register()
-def check_db_transaction_on_commit(app_configs=None, **kwargs):
-    from django.db import connection
+def check_db_transaction_hooks(app_configs=None, **kwargs):
+    from django.conf import settings
+
     errors = []
-    try:
-        connection.on_commit
-    except AttributeError:
+    if settings.DATABASES['default']['ENGINE'].startswith("transaction_hooks"):
         errors.append(checks.Critical(
-            _("Database connection does not implement on_commit."),
-            hint=_("Set the DATABASES['default']['ENGINE'] to use a backend "
-                   "from transaction_hooks.backends."),
+            _("Database connection uses transaction_hooks."),
+            hint=_("Set the DATABASES['default']['ENGINE'] to use a Django "
+                   "backend from django.db.backends."),
             id="pootle.C006",
         ))
     return errors

--- a/pootle/core/utils/templates.py
+++ b/pootle/core/utils/templates.py
@@ -6,7 +6,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.template.base import TemplateDoesNotExist
+from django.template import TemplateDoesNotExist
 from django.template.engine import Engine
 
 

--- a/pootle/core/views/__init__.py
+++ b/pootle/core/views/__init__.py
@@ -23,12 +23,12 @@ __all__ = (
 )
 
 
-def permission_denied(request):
-    return django_403(request, template_name='errors/403.html')
+def permission_denied(request, exception):
+    return django_403(request, exception, template_name='errors/403.html')
 
 
-def page_not_found(request):
-    return django_404(request, template_name='errors/404.html')
+def page_not_found(request, exception):
+    return django_404(request, exception, template_name='errors/404.html')
 
 
 def server_error(request):

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -81,7 +81,7 @@ def init_settings(settings_filepath, template_filename,
     context = {
         "default_key": ("'%s'"
                         % b64encode(os.urandom(KEY_LENGTH)).decode("utf-8")),
-        "db_engine": "'transaction_hooks.backends.%s'" % db_module,
+        "db_engine": "'django.db.backends.%s'" % db_module,
         "db_name": db_name,
         "db_user": db_user,
         "db_password": db_password,

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -6,7 +6,7 @@
 # Database backend settings
 DATABASES = {
     'default': {
-        'ENGINE': 'transaction_hooks.backends.sqlite3',
+        'ENGINE': 'django.db.backends.sqlite3',
         'NAME': working_path('dbs/pootle.db'),
         'USER': '',
         'PASSWORD': '',

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -43,6 +43,9 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'OPTIONS': {
+            'builtins': [
+                'overextends.templatetags.overextends_tags',
+            ],
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -45,7 +45,7 @@ ALLOWED_HOSTS = [
 DATABASES = {
     'default': {
         # Although has issues with locking, SQLite is handy for development
-        'ENGINE': 'transaction_hooks.backends.sqlite3',
+        'ENGINE': 'django.db.backends.sqlite3',
         # Database name or path to database file if using sqlite3.
         'NAME': working_path('dbs/pootle.db'),
         # Not used with sqlite3.

--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -16,7 +16,7 @@ if os.environ.get("TRAVIS"):
     DATABASE_BACKEND = os.environ.get("DATABASE_BACKEND")
     DATABASES = {
         'default': {
-            'ENGINE': 'transaction_hooks.backends.sqlite3',
+            'ENGINE': 'django.db.backends.sqlite3',
             'NAME': working_path('dbs/pootle_travis.db'),
             'USER': '',
             'PASSWORD': '',
@@ -31,11 +31,11 @@ if os.environ.get("TRAVIS"):
 
     if DATABASE_BACKEND == "postgres":
         DATABASES['default']['ENGINE'] = \
-            'transaction_hooks.backends.postgresql_psycopg2'
+            'django.db.backends.postgresql_psycopg2'
         DATABASES['default']['NAME'] = 'pootle'
         DATABASES['default']['USER'] = 'postgres'
     elif DATABASE_BACKEND.startswith("mysql"):
-        DATABASES['default']['ENGINE'] = 'transaction_hooks.backends.mysql'
+        DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
         DATABASES['default']['NAME'] = 'pootle'
         DATABASES['default']['USER'] = 'travis'
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,6 @@ django-redis==4.4.4
 django-rq>=0.8.0,<=0.9.2
 django-sortedm2m==1.3.2
 django-statici18n==1.2.1
-django-transaction-hooks==0.2
 
 # Libraries
 cssmin==0.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Base requirements
 
-Django>=1.8.13,<1.9  # rq.filter: >=1.8,<1.9
+Django>=1.9.9,<1.10  # rq.filter: >=1.9,<1.10
 
 # Django apps
 django-allauth==0.27.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-contact-form==1.2
 django-contrib-comments==1.7.3
 django-overextends==0.4.2
 django-redis==4.4.4
-django-rq>=0.8.0,<=0.9.2
+django-rq>=0.9.0,<=0.9.2
 django-sortedm2m==1.3.2
 django-statici18n==1.2.1
 
@@ -23,7 +23,7 @@ lxml>=3.5,<=3.6.4
 python-dateutil==2.5.3
 python-levenshtein==0.12.0
 pytz==2016.6.1
-rq>=0.5.0,<=0.6.0
+rq>=0.5.5,<=0.6.0
 scandir==1.3
 
 # Translate Toolkit

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,5 +4,4 @@ factory_boy>=2.5.2
 pytest==3.0.2
 pytest-catchlog==1.2.2
 pytest-cov==2.3.1
-# pytest-django==3.0.0
--e git+https://github.com/phlax/pytest-django@transaction_hooks_sqlite#egg=pytest-django
+pytest-django==3.0.0

--- a/tests/views/bad.py
+++ b/tests/views/bad.py
@@ -14,5 +14,4 @@ def test_views_bad(bad_views):
     path_, response, test = bad_views
     assert response.status_code == test["code"]
     if test.get("location"):
-        location = "http://testserver/%s" % test["location"].lstrip("/")
-        assert response.get("location") == location
+        assert response.get("location") == test["location"]

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -262,13 +262,13 @@ def test_view_user_choice(client):
     client.cookies["user-choice"] = "language"
     response = client.get("/foo/bar/baz")
     assert response.status_code == 302
-    assert response.get("location") == "http://testserver/foo/"
+    assert response.get("location") == "/foo/"
     assert "user-choice" not in response
 
     client.cookies["user-choice"] = "project"
     response = client.get("/foo/bar/baz")
     assert response.status_code == 302
-    assert response.get("location") == "http://testserver/projects/bar/"
+    assert response.get("location") == "/projects/bar/"
     assert "user-choice" not in response
 
     client.cookies["user-choice"] = "foo"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django18-{sqlite,mysql,postgres},project
+envlist = py27-django19-{sqlite,mysql,postgres},project
 basepython = python
 usedevelop = True
 skipsdist = True


### PR DESCRIPTION
Upgrading to Django 1.9.  A few of these commits are really Django 1.8 deprecations that get noisy in 1.9.

Some comments
- SessionAuthenticationMiddleware - will become default in 1.10, but has some implications for users.  The recommendation is to run on 1.7 for a while then and then enable. So really impacts migrating users the most.  Opinions on how to handle this welcome.
- Django transaction hooks might need a check, but then we haven't released a version with this
- contact-form - uses unreleased git version
