### PR TITLE
Django 1.8: NoArgsCommand deprecated

### DIFF
--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -12,14 +12,14 @@ import logging
 
 from optparse import make_option
 
-from django.core.management.base import BaseCommand, NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from pootle.runner import set_sync_mode
 from pootle_project.models import Project
 from pootle_translationproject.models import TranslationProject
 
 
-class PootleCommand(NoArgsCommand):
+class PootleCommand(BaseCommand):
     """Base class for handling recursive pootle store management commands."""
 
     shared_option_list = (
@@ -49,7 +49,7 @@ class PootleCommand(NoArgsCommand):
                   "using rq workers"),
         ),
     )
-    option_list = NoArgsCommand.option_list + shared_option_list
+    option_list = BaseCommand.option_list + shared_option_list
     process_disabled_projects = False
 
     def __init__(self, *args, **kwargs):
@@ -90,7 +90,7 @@ class PootleCommand(NoArgsCommand):
                     logging.exception(u"Failed to run %s over %s",
                                       self.name, store.pootle_path)
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         # adjust debug level to the verbosity option
         verbosity = int(options.get('verbosity', 1))
         debug_levels = {

--- a/pootle/apps/pootle_app/management/commands/changed_languages.py
+++ b/pootle/apps/pootle_app/management/commands/changed_languages.py
@@ -14,7 +14,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db.models import Max
 
 from pootle.core.models import Revision
@@ -23,7 +23,7 @@ from pootle_store.models import Store, Unit
 from . import BaseRunCommand
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "List languages that were changed since last synchronization"
 
     option_list = BaseRunCommand.option_list + (
@@ -36,7 +36,7 @@ class Command(NoArgsCommand):
         ),
     )
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         last_known_revision = Revision.get()
 
         if options['after_revision'] is not None:

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -13,15 +13,15 @@ from optparse import make_option
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from pootle.core.initdb import InitDB
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Populates the database with initial values: users, projects, ...'
 
-    option_list = NoArgsCommand.option_list + (
+    option_list = BaseCommand.option_list + (
         make_option(
             '--no-projects',
             action='store_false',
@@ -31,7 +31,7 @@ class Command(NoArgsCommand):
                  "projects.",
         ), )
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         self.stdout.write('Populating the database.')
         InitDB().init_db(options["create_projects"])
         self.stdout.write('Successfully populated the database.')

--- a/pootle/apps/pootle_app/management/commands/list_languages.py
+++ b/pootle/apps/pootle_app/management/commands/list_languages.py
@@ -12,11 +12,11 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
         make_option(
             '--project',
             action='append',
@@ -33,7 +33,7 @@ class Command(NoArgsCommand):
     )
     help = "List language codes."
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         self.list_languages(**options)
 
     def list_languages(self, **options):

--- a/pootle/apps/pootle_app/management/commands/list_projects.py
+++ b/pootle/apps/pootle_app/management/commands/list_projects.py
@@ -12,13 +12,13 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from pootle_project.models import Project
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
         make_option(
             "--modified-since",
             action="store",
@@ -29,7 +29,7 @@ class Command(NoArgsCommand):
         ),
     )
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         self.list_projects(**options)
 
     def list_projects(self, **options):

--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -14,12 +14,12 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from optparse import make_option
 
 from django.contrib.auth import get_user_model
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from pootle_statistics.models import ScoreLog
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Refresh score"
 
     shared_option_list = (
@@ -32,9 +32,9 @@ class Command(NoArgsCommand):
         ),
     )
 
-    option_list = NoArgsCommand.option_list + shared_option_list
+    option_list = BaseCommand.option_list + shared_option_list
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
 
         if options['reset']:
             User = get_user_model()

--- a/pootle/apps/pootle_app/management/commands/retry_failed_jobs.py
+++ b/pootle/apps/pootle_app/management/commands/retry_failed_jobs.py
@@ -13,17 +13,17 @@ import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.core.urlresolvers import set_script_prefix
 from django.utils.encoding import force_unicode
 
 from django_rq.queues import get_failed_queue
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Retry failed RQ jobs."
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         # The script prefix needs to be set here because the generated URLs
         # need to be aware of that and they are cached. Ideally Django should
         # take care of setting this up, but it doesn't yet (fixed in Django

--- a/pootle/apps/pootle_app/management/commands/revision.py
+++ b/pootle/apps/pootle_app/management/commands/revision.py
@@ -13,13 +13,13 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from pootle.core.models import Revision
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
         make_option(
             '--restore',
             action='store_true',
@@ -31,7 +31,7 @@ class Command(NoArgsCommand):
 
     help = "Print the number of the current revision."
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         if options['restore']:
             from pootle_store.models import Unit
             Revision.set(Unit.max_revision())

--- a/pootle/apps/pootle_app/management/commands/test_checks.py
+++ b/pootle/apps/pootle_app/management/commands/test_checks.py
@@ -16,14 +16,14 @@ from optparse import make_option
 from translate.filters.checks import FilterFailure, projectcheckers
 
 from django.conf import settings
-from django.core.management.base import CommandError, NoArgsCommand
+from django.core.management.base import CommandError, BaseCommand
 
 from pootle_misc.checks import get_qualitychecks
 from pootle_misc.util import import_func
 from pootle_store.models import Unit
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Tests quality checks against string pairs."
 
     shared_option_list = (
@@ -49,9 +49,9 @@ class Command(NoArgsCommand):
             help='Translation string',
         ),
     )
-    option_list = NoArgsCommand.option_list + shared_option_list
+    option_list = BaseCommand.option_list + shared_option_list
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         # adjust debug level to the verbosity option
         verbosity = int(options.get('verbosity', 1))
         debug_levels = {


### PR DESCRIPTION
Use BaseCommand and handle()

See
https://docs.djangoproject.com/en/1.9/howto/custom-management-commands/#django.core.management.NoArgsCommand