### PR TITLE
Exception.message deprecated in Python 2.6

### DIFF
--- a/pootle/apps/accounts/management/commands/update_user_email.py
+++ b/pootle/apps/accounts/management/commands/update_user_email.py
@@ -28,5 +28,5 @@ class Command(UserCommand):
         try:
             accounts.utils.update_user_email(self.get_user(args[0]), args[1])
         except ValidationError as e:
-            raise CommandError(e.message)
+            raise CommandError(e)
         self.stdout.write("Email updated: %s, %s\n" % args)

--- a/pootle/apps/accounts/management/commands/verify_user.py
+++ b/pootle/apps/accounts/management/commands/verify_user.py
@@ -48,10 +48,10 @@ class Command(UserCommand):
                     utils.verify_user(user)
                     print("Verified user '%s'" % user.username)
                 except (ValueError, ValidationError) as e:
-                    print(e.message)
+                    print(e)
         else:
             try:
                 utils.verify_user(self.get_user(args[0]))
                 print("User '%s' has been verified" % args[0])
             except (ValueError, ValidationError) as e:
-                raise CommandError(e.message)
+                raise CommandError(e)

--- a/pootle/apps/import_export/views.py
+++ b/pootle/apps/import_export/views.py
@@ -92,7 +92,7 @@ def handle_upload_form(request, project):
                     django_file.seek(0)
                     import_file(django_file, user=request.user)
             except Exception as e:
-                upload_form.add_error("file", e.message)
+                upload_form.add_error("file", e)
                 return {
                     "upload_form": upload_form,
                 }

--- a/pootle/apps/pootle_app/management/commands/test_checks.py
+++ b/pootle/apps/pootle_app/management/commands/test_checks.py
@@ -83,7 +83,7 @@ class Command(NoArgsCommand):
                 source = unit.source
                 target = unit.target
             except Unit.DoesNotExist, e:
-                raise CommandError(e.message)
+                raise CommandError(e)
         else:
             source = options.get('source', '').decode('utf-8')
             target = options.get('target', '').decode('utf-8')

--- a/pootle/apps/virtualfolder/management/commands/add_vfolders.py
+++ b/pootle/apps/virtualfolder/management/commands/add_vfolders.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                 except ValidationError as e:
                     errored_count += 1
                     self.stdout.write('FAILED')
-                    self.stderr.write(e.message)
+                    self.stderr.write(e)
                 else:
                     self.stdout.write('DONE')
                     added_count += 1
@@ -129,7 +129,7 @@ class Command(BaseCommand):
                     except ValidationError as e:
                         errored_count += 1
                         self.stdout.write('FAILED')
-                        self.stderr.write(e.message)
+                        self.stderr.write(e)
                     else:
                         self.stdout.write('DONE')
                         updated_count += 1


### PR DESCRIPTION
Need someone else to look at this to see that I'm not doing something silly here.