### PR TITLE
Simplify vfolder extract algorithm

### DIFF
--- a/pootle/apps/virtualfolder/helpers.py
+++ b/pootle/apps/virtualfolder/helpers.py
@@ -7,8 +7,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from pootle.core.url_helpers import get_all_pootle_paths
-
 from .models import VirtualFolderTreeItem
 
 
@@ -39,14 +37,12 @@ def extract_vfolder_from_path(request_path):
     :param request_path: a path that may contain a virtual folder
     :return: (`VirtualFolder`, path)
     """
-    all_dir_paths = [
-        dir_path for dir_path in get_all_pootle_paths(request_path)
-        if dir_path.count('/') > 3 and dir_path.endswith('/')]
-    vftis = VirtualFolderTreeItem.objects.filter(pootle_path__in=all_dir_paths)
-    if vftis.exists():
-        # There may be more than one vfti with matching pootle_path, so we get
-        # the one with the shortest path or highest priority.
-        vfti = (vftis.select_related("vfolder", "directory")
-                     .order_by("pootle_path").first())
+    if not (request_path.count('/') > 3 and request_path.endswith('/')):
+        return None, request_path
+
+    try:
+        vfti = VirtualFolderTreeItem.objects.get(pootle_path=request_path)
+    except VirtualFolderTreeItem.DoesNotExist:
+        return None, request_path
+    else:
         return vfti.vfolder, vfti.directory.pootle_path
-    return None, request_path

--- a/pootle/apps/virtualfolder/helpers.py
+++ b/pootle/apps/virtualfolder/helpers.py
@@ -46,10 +46,7 @@ def extract_vfolder_from_path(request_path):
     if vftis.exists():
         # There may be more than one vfti with matching pootle_path, so we get
         # the one with the shortest path or highest priority.
-        vfti = sorted(
-            vftis.select_related("vfolder", "directory"),
-            key=lambda obj: (
-                -obj.pootle_path.count("/"),
-                obj.vfolder.priority))[0]
+        vfti = (vftis.select_related("vfolder", "directory")
+                     .order_by("pootle_path").first())
         return vfti.vfolder, vfti.directory.pootle_path
     return None, request_path


### PR DESCRIPTION
Lets suppose a 'whatever' vfolder is created in `/af/firefox/` and it includes
a `/af/firefox/browser/chrome/browser/translation.dtd.po` file, so the
following VirtualFolderTreeItems are created for the vfolder:

`/af/firefox/whatever/`
`/af/firefox/whatever/browser/`
`/af/firefox/whatever/browser/chrome/`
`/af/firefox/whatever/browser/chrome/browser/`

Note that for any of these VirtualFolderTreeItems, the vfolder name is always
placed in the same place in the path.

So if a path like `/af/firefox/whatever/browser/chrome/` is provided for
extraction the matched VirtualFolderTreeItems are:

`/af/firefox/whatever/`
`/af/firefox/whatever/browser/`
`/af/firefox/whatever/browser/chrome/`

which all them belong to the same vfolder, and therefore it is unnecessary
for them to be sorted by vfolder priority.

There can be vfolders with the same name and different location, but
their VirtualFolderTreeItems will have the vfolder name in a different place
in their paths, so only VirtualFolderTreeItems for a single vfolder will be
matched.

If there are vfolders with different name in the same location only
VirtualFolderTreeItems for the same vfolder will be matched as well.