### PR TITLE
Pass queue name as origin into Job.create()

### DIFF
--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -650,7 +650,7 @@ class JobWrapper(object):
         args = (self.instance,)
         return Job.create(self.func, args=args, id=self.id,
                           connection=self.connection, depends_on=depends_on,
-                          status=status)
+                          status=status, origin=self.origin)
 
     def save_enqueued(self, pipe):
         """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ cssmin
 diff-match-patch>=20121119
 elasticsearch<1.7
 lxml>=2.2.0
-rq>=0.5.0
+rq>=0.5.0,<=0.5.6
 
 # Translate Toolkit
 translate-toolkit>=1.13.0


### PR DESCRIPTION
This change allows us to use the last version of rq (>=0.5.6).