### PR TITLE
[WIP] Migrate optparse to argparse

### DIFF
--- a/pootle/apps/accounts/management/commands/find_duplicate_emails.py
+++ b/pootle/apps/accounts/management/commands/find_duplicate_emails.py
@@ -18,7 +18,7 @@ User = get_user_model()
 
 class Command(BaseCommand):
 
-    def handle(self, *args, **kwargs):
+    def handle(self, **options):
         duplicates = get_duplicate_emails()
         if not duplicates:
             self.stdout.write("There are no accounts with duplicate emails\n")

--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -9,7 +9,6 @@
 
 import os
 os.environ["DJANGO_SETTINGS_MODULE"] = "pootle.settings"
-from optparse import make_option
 from zipfile import ZipFile
 
 from django.core.management.base import CommandError
@@ -21,16 +20,17 @@ from pootle_store.models import Store
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Export a Project, Translation Project, or path. " \
+           "Multiple files will be zipped."
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             "--path",
             action="store",
             dest="pootle_path",
             help="Export a single file",
-        ),
-    )
-    help = "Export a Project, Translation Project, or path. " \
-           "Multiple files will be zipped."
+        )
 
     def _create_zip(self, stores, prefix):
         with open("%s.zip" % (prefix), "wb") as f:

--- a/pootle/apps/import_export/management/commands/import.py
+++ b/pootle/apps/import_export/management/commands/import.py
@@ -9,7 +9,6 @@
 
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
-from optparse import make_option
 from zipfile import ZipFile, is_zipfile
 
 from django.contrib.auth import get_user_model
@@ -19,19 +18,23 @@ from import_export.utils import import_file
 
 
 class Command(BaseCommand):
-    args = "<file file ...>"
-    option_list = BaseCommand.option_list + (
-        make_option(
+    help = "Import a translation file or a zip of translation files. " \
+           "X-Pootle-Path header must be present."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "file",
+            dest='files',
+            nargs="+",
+        )
+        parser.add_argument(
             "--user",
             action="store",
             dest="user",
             help="Import translation file(s) as USER",
-        ),
-    )
-    help = "Import a translation file or a zip of translation files. " \
-           "X-Pootle-Path header must be present."
+        )
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         user = None
         if options["user"] is not None:
             User = get_user_model()
@@ -40,7 +43,7 @@ class Command(BaseCommand):
             except User.DoesNotExist:
                 raise CommandError("Unrecognised user: %s" % options["user"])
 
-        for filename in args:
+        for filename in options['files']:
             if is_zipfile(filename):
                 with ZipFile(filename, "r") as zf:
                     for path in zf.namelist():

--- a/pootle/apps/import_export/management/commands/import.py
+++ b/pootle/apps/import_export/management/commands/import.py
@@ -24,8 +24,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "file",
-            dest='files',
             nargs="+",
+            help="file to import"
         )
         parser.add_argument(
             "--user",
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             except User.DoesNotExist:
                 raise CommandError("Unrecognised user: %s" % options["user"])
 
-        for filename in options['files']:
+        for filename in options['file']:
             if is_zipfile(filename):
                 with ZipFile(filename, "r") as zf:
                     for path in zf.namelist():

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -10,8 +10,6 @@
 import datetime
 import logging
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from pootle.runner import set_sync_mode
@@ -22,35 +20,34 @@ from pootle_translationproject.models import TranslationProject
 class PootleCommand(BaseCommand):
     """Base class for handling recursive pootle store management commands."""
 
-    shared_option_list = (
-        make_option(
+    process_disabled_projects = False
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--project',
             action='append',
             dest='projects',
             help='Project to refresh',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--language',
             action='append',
             dest='languages',
             help='Language to refresh',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             "--noinput",
             action="store_true",
             default=False,
             help=u"Never prompt for input",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             "--no-rq",
             action="store_true",
             default=False,
             help=(u"Run all jobs in a single process, without "
                   "using rq workers"),
-        ),
-    )
-    option_list = BaseCommand.option_list + shared_option_list
-    process_disabled_projects = False
+        )
 
     def __init__(self, *args, **kwargs):
         self.languages = []

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -89,15 +89,15 @@ class PootleCommand(BaseCommand):
 
     def handle(self, **options):
         # adjust debug level to the verbosity option
-        verbosity = int(options.get('verbosity', 1))
         debug_levels = {
             0: logging.ERROR,
             1: logging.WARNING,
             2: logging.INFO,
             3: logging.DEBUG
         }
-        debug_level = debug_levels.get(verbosity, logging.DEBUG)
-        logging.getLogger().setLevel(debug_level)
+        logging.getLogger().setLevel(
+            debug_levels.get(options['verbosity'], logging.DEBUG)
+        )
 
         # reduce size of parse pool early on
         self.name = self.__class__.__module__.split('.')[-1]
@@ -121,8 +121,8 @@ class PootleCommand(BaseCommand):
         logging.info('All done for %s in %s', self.name, end - start)
 
     def handle_all(self, **options):
-        if options.get("no_rq", False):
-            set_sync_mode(options.get('noinput', False))
+        if options["no_rq"]:
+            set_sync_mode(options['noinput'])
 
         if self.process_disabled_projects:
             project_query = Project.objects.all()

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -9,7 +9,6 @@
 
 import logging
 import os
-from optparse import make_option
 
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
@@ -21,18 +20,17 @@ from . import PootleCommand
 
 class Command(PootleCommand):
     help = "Allow checks to be recalculated manually."
+    process_disabled_projects = True
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--check',
             action='append',
             dest='check_names',
             default=None,
-            help='Check to recalculate'
-        ),
-    )
-    option_list = PootleCommand.option_list + shared_option_list
-    process_disabled_projects = True
+            help='Check to recalculate',
+        )
 
     def handle_all_stores(self, translation_project, **options):
         logging.info(

--- a/pootle/apps/pootle_app/management/commands/changed_languages.py
+++ b/pootle/apps/pootle_app/management/commands/changed_languages.py
@@ -12,8 +12,6 @@ import os
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 from django.db.models import Max
 
@@ -24,15 +22,14 @@ from pootle_store.models import Store, Unit
 class Command(BaseCommand):
     help = "List languages that were changed since last synchronization"
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--after-revision',
             action='store',
             dest='after_revision',
             type=int,
             help='Show languages changed after any arbitrary revision',
-        ),
-    )
+        )
 
     def handle(self, **options):
         last_known_revision = Revision.get()

--- a/pootle/apps/pootle_app/management/commands/contributors.py
+++ b/pootle/apps/pootle_app/management/commands/contributors.py
@@ -9,7 +9,6 @@
 
 import os
 from collections import Counter
-from optparse import make_option
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "pootle.settings"
 
@@ -24,26 +23,25 @@ User = get_user_model()
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Print a list of contributors."
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             "--from-revision",
             type=int,
             default=0,
             dest="revision",
             help="Only count contributions newer than this revision",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             "--sort-by",
-            type="choice",
             default="name",
             choices=["name", "contributions"],
             dest="sort_by",
             help="Sort by specified item. Accepts name and contributions. "
-                 "Default: %default",
-        ),
-    )
-
-    help = "Print a list of contributors."
+                 "Default: %(default)s",
+        )
 
     def handle_all(self, **options):
         system_user = User.objects.get_system_user()

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -16,8 +16,6 @@ sys.setdefaultencoding('utf-8')
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import CommandError
 
 from pootle_app.management.commands import PootleCommand
@@ -42,30 +40,29 @@ DUMPED = {
 class Command(PootleCommand):
     help = "Dump data."
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--stats',
             action='store_true',
             dest='stats',
             default=False,
             help='Dump stats',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--data',
             action='store_true',
             dest='data',
             default=False,
             help='Data all data',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--stop-level',
             action='store',
             dest='stop_level',
             default=-1,
             type=int,
-        ),
-    )
-    option_list = PootleCommand.option_list + shared_option_list
+        )
 
     def handle_all(self, **options):
         if not self.projects and not self.languages:

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -8,7 +8,6 @@
 # AUTHORS file for copyright and authorship information.
 
 import os
-from optparse import make_option
 
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
@@ -21,15 +20,15 @@ from pootle.core.initdb import InitDB
 class Command(BaseCommand):
     help = 'Populates the database with initial values: users, projects, ...'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--no-projects',
             action='store_false',
             dest='create_projects',
             default=True,
             help="Do not create the default 'terminology' and 'tutorial' "
                  "projects.",
-        ), )
+        )
 
     def handle(self, **options):
         self.stdout.write('Populating the database.')

--- a/pootle/apps/pootle_app/management/commands/list_languages.py
+++ b/pootle/apps/pootle_app/management/commands/list_languages.py
@@ -10,28 +10,28 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
+    help = "List language codes."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--project',
             action='append',
             dest='projects',
-            help='Limit to PROJECTS'),
-        make_option(
+            help='Limit to PROJECTS',
+        )
+        parser.add_argument(
             "--modified-since",
             action="store",
             dest="modified_since",
             type=int,
             default=0,
             help="Only process translations newer than specified "
-                 "revision"),
-    )
-    help = "List language codes."
+                 "revision",
+        )
 
     def handle(self, **options):
         self.list_languages(**options)

--- a/pootle/apps/pootle_app/management/commands/list_projects.py
+++ b/pootle/apps/pootle_app/management/commands/list_projects.py
@@ -10,24 +10,21 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from pootle_project.models import Project
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             "--modified-since",
             action="store",
             dest="revision",
             type=int,
             default=0,
             help="Only process translations newer than specified revision",
-        ),
-    )
+        )
 
     def handle(self, **options):
         self.list_projects(**options)

--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -11,8 +11,6 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
@@ -22,17 +20,14 @@ from pootle_statistics.models import ScoreLog
 class Command(BaseCommand):
     help = "Refresh score"
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--reset',
             action='store_true',
             dest='reset',
             default=False,
             help='Reset all scores to zero',
-        ),
-    )
-
-    option_list = BaseCommand.option_list + shared_option_list
+        )
 
     def handle(self, **options):
 

--- a/pootle/apps/pootle_app/management/commands/revision.py
+++ b/pootle/apps/pootle_app/management/commands/revision.py
@@ -11,25 +11,22 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from pootle.core.models import Revision
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
+    help = "Print Pootle's current revision."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--restore',
             action='store_true',
             default=False,
             dest='restore',
             help='Restore the current revision number from the DB.',
-        ),
-    )
-
-    help = "Print the number of the current revision."
+        )
 
     def handle(self, **options):
         if options['restore']:

--- a/pootle/apps/pootle_app/management/commands/sync_stores.py
+++ b/pootle/apps/pootle_app/management/commands/sync_stores.py
@@ -9,38 +9,38 @@
 
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
-from optparse import make_option
 
 from pootle_app.management.commands import PootleCommand
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Save new translations to disk manually."
+    process_disabled_projects = True
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--overwrite',
             action='store_true',
             dest='overwrite',
             default=False,
             help="Don't just save translations, but "
                  "overwrite files to reflect state in database",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--skip-missing',
             action='store_true',
             dest='skip_missing',
             default=False,
             help="Ignore missing files on disk",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--force',
             action='store_true',
             dest='force',
             default=False,
             help="Don't ignore stores synced after last change",
-        ),
-    )
-    help = "Save new translations to disk manually."
-    process_disabled_projects = True
+        )
 
     def handle_all_stores(self, translation_project, **options):
         if translation_project.directory_exists_on_disk():

--- a/pootle/apps/pootle_app/management/commands/test_checks.py
+++ b/pootle/apps/pootle_app/management/commands/test_checks.py
@@ -11,8 +11,6 @@ import logging
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from translate.filters.checks import FilterFailure, projectcheckers
 
 from django.conf import settings
@@ -26,30 +24,28 @@ from pootle_store.models import Unit
 class Command(BaseCommand):
     help = "Tests quality checks against string pairs."
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--check',
             action='append',
             dest='checks',
             help='Check name to check for',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--source',
             dest='source',
             help='Source string',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--unit',
             dest='unit',
             help='Unit id',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--target',
             dest='target',
             help='Translation string',
-        ),
-    )
-    option_list = BaseCommand.option_list + shared_option_list
+        )
 
     def handle(self, **options):
         # adjust debug level to the verbosity option

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -11,32 +11,33 @@ import logging
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from pootle_app.management.commands import PootleCommand
 from pootle_translationproject.models import scan_translation_projects
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Update database stores from files."
+    process_disabled_projects = True
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--overwrite',
             action='store_true',
             dest='overwrite',
             default=False,
             help="Don't just update untranslated units "
                  "and add new units, but overwrite database "
-                 "translations to reflect state in files."),
-        make_option(
+                 "translations to reflect state in files.",
+        )
+        parser.add_argument(
             '--force',
             action='store_true',
             dest='force',
             default=False,
             help="Unconditionally process all files (even if they "
-                 "appear unchanged)."),
-    )
-    help = "Update database stores from files."
-    process_disabled_projects = True
+                 "appear unchanged).",
+        )
 
     def handle_translation_project(self, translation_project, **options):
         """

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -242,8 +242,8 @@ class Command(BaseCommand):
                  'translations.'
         )
 
-    def _parse_translations(self, *args, **options):
-        units, total = self.parser.get_units(*args)
+    def _parse_translations(self, **options):
+        units, total = self.parser.get_units(options['files'])
 
         if total == 0:
             self.stdout.write("No translations to index")
@@ -267,7 +267,7 @@ class Command(BaseCommand):
         if i != total:
             self.stdout.write("Expected %d, loaded %d." % (total, i))
 
-    def _initialize(self, *args, **options):
+    def _initialize(self, **options):
         if not settings.POOTLE_TM_SERVER:
             raise CommandError('POOTLE_TM_SERVER setting is missing.')
 
@@ -338,8 +338,8 @@ class Command(BaseCommand):
         self.stdout.write("Last indexed revision = %s" %
                           self.last_indexed_revision)
 
-    def handle(self, *args, **options):
-        self._initialize(*args, **options)
+    def handle(self, **options):
+        self._initialize(**options)
 
         if (options['rebuild'] and
             not options['dry_run'] and
@@ -356,4 +356,4 @@ class Command(BaseCommand):
             self._set_latest_indexed_revision(**options)
 
         success, _ = helpers.bulk(self.es,
-                                  self._parse_translations(*args, **options))
+                                  self._parse_translations(**options))

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -250,12 +250,12 @@ class Command(BaseCommand):
             raise CommandError('POOTLE_TM_SERVER setting is missing.')
 
         try:
-            self.tm_settings = settings.POOTLE_TM_SERVER[options.get('tm')]
+            self.tm_settings = settings.POOTLE_TM_SERVER[options['tm']]
         except KeyError:
             raise CommandError("Translation Memory '%s' is not defined in the "
                                "POOTLE_TM_SERVER setting. Please ensure it "
                                "exists and double-check you typed it "
-                               "correctly." % options.get('tm'))
+                               "correctly." % options['tm'])
 
         self.INDEX_NAME = self.tm_settings['INDEX_NAME']
         self.is_local_tm = options.get('tm') == 'local'

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -10,7 +10,6 @@
 import os
 import sys
 from hashlib import md5
-from optparse import make_option
 
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
@@ -173,52 +172,75 @@ class FileParser(object):
 
 class Command(BaseCommand):
     help = "Load Translation Memory with translations"
-    args = "[files]"
-    option_list = BaseCommand.option_list + (
-        make_option('--refresh',
-                    action='store_true',
-                    dest='refresh',
-                    default=False,
-                    help='Process all items, not just the new ones, so '
-                         'existing translations are refreshed'),
-        make_option('--rebuild',
-                    action='store_true',
-                    dest='rebuild',
-                    default=False,
-                    help='Drop the entire TM on start and update everything '
-                         'from scratch'),
-        make_option('--dry-run',
-                    action='store_true',
-                    dest='dry_run',
-                    default=False,
-                    help='Report the number of translations to index and '
-                         'quit'),
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--refresh',
+            action='store_true',
+            dest='refresh',
+            default=False,
+            help='Process all items, not just the new ones, so '
+                 'existing translations are refreshed'
+        )
+        parser.add_argument(
+            '--rebuild',
+            action='store_true',
+            dest='rebuild',
+            default=False,
+            help='Drop the entire TM on start and update everything '
+                 'from scratch'
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            dest='dry_run',
+            default=False,
+            help='Report the number of translations to index and quit'
+        )
+
         # Local TM specific options.
-        make_option('--include-disabled-projects',
-                    action='store_true',
-                    dest='disabled_projects',
-                    default=False,
-                    help='Add translations from disabled projects'),
+        local = parser.add_argument_group('Local TM', 'Pootle Local '
+                                          'Translation Memory')
+        local.add_argument(
+            '--include-disabled-projects',
+            action='store_true',
+            dest='disabled_projects',
+            default=False,
+            help='Add translations from disabled projects'
+        )
+
         # External TM specific options.
-        make_option('--tm',
-                    action='store',
-                    dest='tm',
-                    default='local',
-                    help="TM to use. TM must exist on settings. TM will be "
-                         "created on the server if it doesn't exist"),
-        make_option('--target-language',
-                    action='store',
-                    dest='target_language',
-                    default='',
-                    help="Target language to fallback to use in case it can't "
-                         "be guessed for any of the input files."),
-        make_option('--display-name',
-                    action='store',
-                    dest='project',
-                    default='',
-                    help='Name used when displaying TM matches for these '
-                         'translations.'),
-    )
+        external = parser.add_argument_group('External TM', 'Pootle External '
+                                             'Translation Memory')
+        external.add_argument(
+            nargs='*',
+            dest='files',
+            help='Translation memory files',
+        )
+        external.add_argument(
+            '--tm',
+            action='store',
+            dest='tm',
+            default='local',
+            help="TM to use. TM must exist on settings. TM will be "
+                 "created on the server if it doesn't exist"
+        )
+        external.add_argument(
+            '--target-language',
+            action='store',
+            dest='target_language',
+            default='',
+            help="Target language to fallback to use in case it can't "
+                 "be guessed for any of the input files."
+        )
+        external.add_argument(
+            '--display-name',
+            action='store',
+            dest='project',
+            default='',
+            help='Name used when displaying TM matches for these '
+                 'translations.'
+        )
 
     def _parse_translations(self, *args, **options):
         units, total = self.parser.get_units(*args)
@@ -268,7 +290,7 @@ class Command(BaseCommand):
         )
 
         # If files to import have been provided.
-        if args:
+        if options['files']:
             if self.is_local_tm:
                 raise CommandError('You cannot add translations from files to '
                                    'a local TM.')

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -35,7 +35,7 @@ class DBParser(object):
         self.INDEX_NAME = kwargs.pop('index', None)
         self.exclude_disabled_projects = not kwargs.pop('disabled_projects')
 
-    def get_units(self, *filenames):
+    def get_units(self, filenames):
         """Gets the units to import and its total count."""
         units_qs = Unit.simple_objects \
             .exclude(target_f__isnull=True) \
@@ -111,7 +111,7 @@ class FileParser(object):
         self.target_language = kwargs.pop('language', None)
         self.project = kwargs.pop('project', None)
 
-    def get_units(self, *filenames):
+    def get_units(self, filenames):
         """Gets the units to import and its total count."""
         units = []
         all_filenames = set()

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -280,7 +280,7 @@ class Command(BaseCommand):
                                "correctly." % options['tm'])
 
         self.INDEX_NAME = self.tm_settings['INDEX_NAME']
-        self.is_local_tm = options.get('tm') == 'local'
+        self.is_local_tm = options['tm'] == 'local'
 
         self.es = Elasticsearch([
             {
@@ -295,22 +295,19 @@ class Command(BaseCommand):
                 raise CommandError('You cannot add translations from files to '
                                    'a local TM.')
 
-            self.target_language = options.pop('target_language')
-            self.project = options.pop('project')
-
-            if not self.project:
+            if not options['project']:
                 raise CommandError('You must specify a project name with '
                                    '--display-name.')
             self.parser = FileParser(stdout=self.stdout, index=self.INDEX_NAME,
-                                     language=self.target_language,
-                                     project=self.project)
+                                     language=options['target_language'],
+                                     project=options['project'])
         elif not self.is_local_tm:
             raise CommandError('You cannot add translations from database to '
                                'an external TM.')
         else:
             self.parser = DBParser(
                 stdout=self.stdout, index=self.INDEX_NAME,
-                disabled_projects=options.pop('disabled_projects'))
+                disabled_projects=options['disabled_projects'])
 
     def _set_latest_indexed_revision(self, **options):
         self.last_indexed_revision = -1

--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -11,7 +11,6 @@ import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 import subprocess
 import sys
-from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
@@ -22,15 +21,14 @@ from pootle_misc.baseurl import l
 class Command(BaseCommand):
     help = 'Builds and bundles static assets using webpack'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--dev',
             action='store_true',
             dest='dev',
             default=False,
             help='Enable development builds and watch for changes.',
-        ),
-    )
+        )
 
     def handle(self, *args, **options):
         default_static_dir = os.path.join(settings.WORKING_DIR, 'static')

--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -20,6 +20,7 @@ from pootle_misc.baseurl import l
 
 class Command(BaseCommand):
     help = 'Builds and bundles static assets using webpack'
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             help='Enable development builds and watch for changes.',
         )
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         default_static_dir = os.path.join(settings.WORKING_DIR, 'static')
         custom_static_dirs = filter(lambda x: x != default_static_dir,
                                     settings.STATICFILES_DIRS)
@@ -43,11 +43,11 @@ class Command(BaseCommand):
         if os.name == 'nt':
             webpack_bin = '%s.cmd' % webpack_bin
 
-        args = [webpack_bin, '--config=%s' % webpack_config_file, '--progress',
-                '--colors']
+        webpack_args = [webpack_bin, '--config=%s' % webpack_config_file,
+                        '--progress', '--colors']
 
         if options['dev']:
-            args.extend(['--watch', '--display-error-details'])
+            webpack_args.extend(['--watch', '--display-error-details'])
         else:
             os.environ['NODE_ENV'] = 'production'
 
@@ -64,7 +64,7 @@ class Command(BaseCommand):
             os.environ['WEBPACK_ROOT'] = ':'.join(custom_static_dirs)
 
         try:
-            subprocess.call(args)
+            subprocess.call(webpack_args)
         except OSError:
             raise CommandError(
                 'webpack executable not found.\n'

--- a/pootle/apps/virtualfolder/management/commands/add_vfolders.py
+++ b/pootle/apps/virtualfolder/management/commands/add_vfolders.py
@@ -23,14 +23,18 @@ from virtualfolder.models import VirtualFolder
 class Command(BaseCommand):
     help = "Add virtual folders from file."
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "vfolder",
+            nargs=1,
+            help="JSON vfolder configuration file",
+        )
+
+    def handle(self, **options):
         """Add virtual folders from file."""
 
-        if not args:
-            raise CommandError("You forgot to provide the mandatory filename.")
-
         try:
-            inputfile = open(args[0], "r")
+            inputfile = open(options['vfolder'], "r")
             vfolders = json.load(inputfile)
             inputfile.close()
         except IOError as e:

--- a/tests/commands/help.py
+++ b/tests/commands/help.py
@@ -1,0 +1,19 @@
+from django.core.management import get_commands
+from django.core.management import call_command
+
+import pytest
+
+
+@pytest.mark.cmd
+@pytest.mark.parametrize("command,app", [
+    (command, app)
+    for command, app in get_commands().iteritems()
+    if not app.startswith("django.") and not app.startswith("django_")
+])
+def test_initdb_help(capfd, command, app):
+    """Catch any simple command issues"""
+    print "Command: %s, App: %s" % (command, app)
+    with pytest.raises(SystemExit):
+        call_command(command, '--help')
+    out, err = capfd.readouterr()
+    assert '--help' in out

--- a/tests/commands/initdb.py
+++ b/tests/commands/initdb.py
@@ -1,0 +1,22 @@
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_initdb_noprojects(capfd):
+    """Initialise the database with initdb
+
+    Testing without --no-projects would take too long
+    """
+    call_command('initdb', '--no-projects')
+    out, err = capfd.readouterr()
+    assert "Successfully populated the database." in out
+    assert "Successfully populated the database." in out
+    assert "pootle createsuperuser" in out
+    assert "Created User: 'nobody'" in err
+    assert "Created Directory: '/projects/'" in err
+    assert "Created Permission:" in err
+    assert "Created PermissionSet:" in err
+    assert "Created Language:" in err

--- a/tests/commands/revision.py
+++ b/tests/commands/revision.py
@@ -1,0 +1,21 @@
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_revision(capfd):
+    """Get current revision."""
+    call_command('revision')
+    out, err = capfd.readouterr()
+    assert out.rstrip().isnumeric()
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_revision_restore(capfd):
+    """Restore redis revision from DB."""
+    call_command('revision', '--restore')
+    out, err = capfd.readouterr()
+    assert out.rstrip().isnumeric()


### PR DESCRIPTION
optparse is deprecated in Django and replaces with argparse.

The change is quite invasive.
* We need to move all make_options to add_argument
* ``*args`` is no longer
* opton['opt'] is the correct way to get option settings
* Various argparse related fixes can now happen