### PR TITLE
Redirect case-sensitive lang urls canonical url

### DIFF
--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -124,6 +124,27 @@ class Language(models.Model, TreeItem):
 
     # # # # # # # # # # # # # #  Methods # # # # # # # # # # # # # # # # # # #
 
+    @classmethod
+    def get_canonical(cls, language_code):
+        """Returns the canonical `Language` object matching `language_code`.
+
+        If no language can be matched, `None` will be returned.
+
+        :param language_code: the code of the language to retrieve.
+        """
+        try:
+            return cls.objects.get(code__iexact=language_code)
+        except cls.DoesNotExist:
+            _lang_code = language_code
+            if "-" in language_code:
+                _lang_code = language_code.replace("-", "_")
+            elif "_" in language_code:
+                _lang_code = language_code.replace("_", "-")
+            try:
+                return cls.objects.get(code__iexact=_lang_code)
+            except cls.DoesNotExist:
+                return None
+
     def __unicode__(self):
         return u"%s - %s" % (self.name, self.code)
 

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -55,6 +55,17 @@ class LanguageMixin(object):
                     code__iexact=self.kwargs["language_code"].replace("_", "-"))
             raise Http404
 
+    def get(self, *args, **kwargs):
+        self.object = self.get_object()
+        if self.object.code != kwargs["language_code"]:
+            return redirect(
+                self.url_pattern_name,
+                self.object.code,
+                permanent=True)
+        response = super(LanguageMixin, self).get(*args, **kwargs)
+        response.set_cookie('pootle-language', self.object.code)
+        return response
+
 
 class LanguageBrowseView(LanguageMixin, PootleBrowseView):
     url_pattern_name = "pootle-language-browse"
@@ -80,19 +91,9 @@ class LanguageBrowseView(LanguageMixin, PootleBrowseView):
             'code': self.object.code,
             'name': tr_lang(self.object.fullname)}
 
-    def get(self, *args, **kwargs):
-        self.object = self.get_object()
-        if self.object.code != kwargs["language_code"]:
-            return redirect(
-                self.url_pattern_name,
-                self.object.code,
-                permanent=True)
-        response = super(LanguageBrowseView, self).get(*args, **kwargs)
-        response.set_cookie('pootle-language', self.object.code)
-        return response
-
 
 class LanguageTranslateView(LanguageMixin, PootleTranslateView):
+    url_pattern_name = "pootle-language-translate"
 
     @property
     def display_vfolder_priority(self):
@@ -100,6 +101,7 @@ class LanguageTranslateView(LanguageMixin, PootleTranslateView):
 
 
 class LanguageExportView(LanguageMixin, PootleExportView):
+    url_pattern_name = "pootle-language-export"
     source_language = "en"
 
 

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -54,9 +54,7 @@ class LanguageMixin(object):
                 self.url_pattern_name,
                 self.object.code,
                 permanent=True)
-        response = super(LanguageMixin, self).get(*args, **kwargs)
-        response.set_cookie('pootle-language', self.object.code)
-        return response
+        return super(LanguageMixin, self).get(*args, **kwargs)
 
 
 class LanguageBrowseView(LanguageMixin, PootleBrowseView):
@@ -82,6 +80,11 @@ class LanguageBrowseView(LanguageMixin, PootleBrowseView):
         return {
             'code': self.object.code,
             'name': tr_lang(self.object.fullname)}
+
+    def get(self, *args, **kwargs):
+        response = super(LanguageBrowseView, self).get(*args, **kwargs)
+        response.set_cookie('pootle-language', self.object.code)
+        return response
 
 
 class LanguageTranslateView(LanguageMixin, PootleTranslateView):

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -8,7 +8,7 @@
 # AUTHORS file for copyright and authorship information.
 
 from django.http import Http404
-from django.shortcuts import redirect, render, get_object_or_404
+from django.shortcuts import redirect, render
 from django.utils.functional import cached_property
 
 from pootle.core.browser import make_project_item
@@ -42,18 +42,10 @@ class LanguageMixin(object):
         return {"language_code": self.object.code}
 
     def get_object(self):
-        try:
-            return Language.objects.get(code__iexact=self.kwargs["language_code"])
-        except Language.DoesNotExist:
-            if "-" in self.kwargs["language_code"]:
-                return get_object_or_404(
-                    Language,
-                    code__iexact=self.kwargs["language_code"].replace("-", "_"))
-            elif "-" in self.kwargs["language_code"]:
-                return get_object_or_404(
-                    Language,
-                    code__iexact=self.kwargs["language_code"].replace("_", "-"))
+        lang = Language.get_canonical(self.kwargs["language_code"])
+        if lang is None:
             raise Http404
+        return lang
 
     def get(self, *args, **kwargs):
         self.object = self.get_object()

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -10,6 +10,7 @@
 from django.http import Http404
 from django.shortcuts import redirect, render
 from django.utils.functional import cached_property
+from django.utils.lru_cache import lru_cache
 
 from pootle.core.browser import make_project_item
 from pootle.core.decorators import get_path_obj, permission_required
@@ -41,6 +42,7 @@ class LanguageMixin(object):
     def url_kwargs(self):
         return {"language_code": self.object.code}
 
+    @lru_cache()
     def get_object(self):
         lang = Language.get_canonical(self.kwargs["language_code"])
         if lang is None:

--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -45,7 +45,16 @@ BAD_VIEW_TESTS = OrderedDict(
      ("/language0/PROJECT0/store0.po", {}),
 
      ("/LANGUAGE0/",
-      dict(code=301, location="/language0/"))))
+      dict(code=301, location="/language0/")),
+     ("/LANGUAGE0/foo/",
+      dict(code=301, location="/language0/foo/")),
+     ("/LANGUAGE0/project0/",
+      dict(code=301, location="/language0/project0/")),
+     ("/LANGUAGE0/project0/subdir0/",
+      dict(code=301, location="/language0/project0/subdir0/")),
+     ("/LANGUAGE0/project0/store0.po",
+      dict(code=301, location="/language0/project0/store0.po")),
+     ))
 
 LANGUAGE_VIEW_TESTS = OrderedDict(
     (("browse", {}),

--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -42,8 +42,10 @@ BAD_VIEW_TESTS = OrderedDict(
      ("/projects/PROJECT0/", {}),
      ("/language0/PROJECT0/", {}),
      ("/language0/PROJECT0/subdir0/", {}),
-     ("/language0/PROJECT0/store0.po", {})))
+     ("/language0/PROJECT0/store0.po", {}),
 
+     ("/LANGUAGE0/",
+      dict(code=301, location="/language0/"))))
 
 LANGUAGE_VIEW_TESTS = OrderedDict(
     (("browse", {}),


### PR DESCRIPTION
It fixes #4381 and #4373 if `Language.code` has case insensitive collations.
`__iexact` doesn't work on binary collation fields (see https://code.djangoproject.com/ticket/9682).
It generates a regex for language symbols.