### PR TITLE
Sync optimizations

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1983,8 +1983,12 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         if self.last_sync_revision is not None:
             filter_by.update({'revision__gt': self.last_sync_revision})
 
-        modified_units = set(Unit.objects.filter(**filter_by)
-                                 .values_list('id', flat=True).distinct())
+        if last_revision > self.last_sync_revision:
+            modified_units = set(
+                Unit.objects.filter(**filter_by).values_list(
+                    'id', flat=True).distinct())
+        else:
+            modified_units = set()
 
         common_dbids = set(self.dbid_index.get(uid)
                            for uid in old_ids & new_ids)

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -353,7 +353,7 @@ class TranslationProject(models.Model, CachedTreeItem):
     def sync(self, conservative=True, skip_missing=False, only_newer=True):
         """Sync unsaved work on all stores to disk"""
         stores = self.stores.live().exclude(file='').filter(state__gte=PARSED)
-        for store in stores.iterator():
+        for store in stores.select_related("parent").iterator():
             store.sync(update_structure=not conservative,
                        conservative=conservative,
                        skip_missing=skip_missing, only_newer=only_newer)


### PR DESCRIPTION
Optimizations to speed up sync_stores

This provides db performance boost of ~30%- at least with force/overwrite or a fresh sync

Timings for pootle sync_stores --force --overwrite --project=firefox --language=af:

OLD: 2804 queries run, total 3.281 seconds
NEW: 1862 queries run, total 2.377 seconds

**can i please emphasize that this is for a single TP**