### PR TITLE
Travis: fix `node_modules` cache location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: TOXENV=isort
 cache:
   directories:
-    - pootle/assets/js/node_modules
+    - pootle/static/js/node_modules
     - $HOME/.cache/pip
     - docs/_build
 before_install:


### PR DESCRIPTION
While there was a `cache` entry for it, it was surprising that every single `npm install` run was downloading all the dependencies. It turns out the configuration wasn't pointing to the source directory where npm is invoked.