### PR TITLE
Another followup for Fix: remove coalesce from get_units search

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -55,7 +55,7 @@ from .util import FUZZY, STATES_MAP, TRANSLATED, UNTRANSLATED, find_altsrcs
 #: will be used against the DB.
 ALLOWED_SORTS = {
     'units': {
-        'priority': 'priority',
+        'priority': '-priority',
         'oldest': 'submitted_on',
         'newest': '-submitted_on',
     },


### PR DESCRIPTION
We do want to display units with higher priority first.

Fixes #4391.