### PR TITLE
Move UserCommand to argparse

### DIFF
--- a/docs/releases/2.7.3b2.rst
+++ b/docs/releases/2.7.3b2.rst
@@ -16,6 +16,8 @@ Details of changes
 
 - :djadmin:`run_cherrypy` has been removed.
 - :djadmin:`start` has been removed, use :djadmin:`runserver` instead.
+- :djadmin:`verify_user` and :djadmin:`purge_user` now accept multiple
+  usernames.
 
 
 ...and lots of refactoring, new tests, cleanups, improved documentation and of

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -774,9 +774,12 @@ removing a spam account or other malicious user.
 This command requires a mandatory ``username`` argument, which should be a valid
 username for a user of your site.
 
+.. versionchanged:: 2.7.3 :djadmin:`purge_user` can accept multiple user
+   accounts to purge.
+
 .. code-block:: bash
 
-    $ pootle purge_user username
+    $ pootle purge_user username [username ...]
 
 
 .. django-admin:: update_user_email
@@ -794,9 +797,12 @@ update_user_email
 This command can be used if you wish to update a user's email address. This
 might be useful if you have users with duplicate email addresses.
 
-This command requires a mandatory ``username`` argument, which should be a valid
-username for a user of your site, and a mandatory ``email`` argument which
-should to update a valid email address.
+This command requires a mandatory ``username``, which should be a valid
+username for a user of your site, and a mandatory valid ``email`` address.
+
+.. code-block:: bash
+
+    $ pootle update_user_email username email
 
 
 .. django-admin:: verify_user
@@ -811,13 +817,16 @@ Verify a user without the user having to go through email verification process.
 This is useful if you are migrating users that have already been verified, or
 if you want to create a superuser that can log in immediately.
 
-This command requires either a mandatory ``username`` argument, which should be a
-valid username for a user of your site, or the :option:`--all` flag if you wish to
-verify all users of your site.
+This command requires either mandatory ``username`` arguments, which should be
+valid username(s) for user(s) on your site, or the :option:`--all` flag if you
+wish to verify all users of your site.
+
+.. versionchanged:: 2.7.3 :djadmin:`verify_user` can accept multiple user
+   accounts to verify.
 
 .. code-block:: bash
 
-    $ pootle verify_user username
+    $ pootle verify_user username [username ...]
 
 Available options:
 

--- a/pootle/apps/accounts/management/commands/__init__.py
+++ b/pootle/apps/accounts/management/commands/__init__.py
@@ -24,27 +24,11 @@ class UserCommand(BaseCommand):
             help="Username of account",
         )
 
-    def handle(self, *args, **kwargs):
-        self.check_args(*args)
-
-    def create_parser(self, prog_name, subcommand):
-        self.prog_name = prog_name
-        self.subcommand = subcommand
-        return super(UserCommand, self).create_parser(prog_name, subcommand)
+    def handle(self, **options):
+        raise NotImplementedError
 
     def get_user(self, username):
         try:
             return User.objects.get(username=username)
         except User.DoesNotExist:
             raise CommandError("User %s does not exist" % username)
-
-    def usage_string(self):
-        return self.usage(self.subcommand).replace('%prog', self.prog_name)
-
-    def check_args(self, *args):
-        min_args = len([a for a in self.args.split(" ")
-                        if not a.startswith("[")])
-        max_args = len(self.args.split(" "))
-        if not (min_args <= len(args) <= max_args):
-            raise CommandError("Wrong number of arguments\n\n%s"
-                               % self.usage_string())

--- a/pootle/apps/accounts/management/commands/__init__.py
+++ b/pootle/apps/accounts/management/commands/__init__.py
@@ -17,7 +17,12 @@ User = get_user_model()
 class UserCommand(BaseCommand):
     """Base class for handling user commands."""
 
-    args = "user"
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "user",
+            nargs='+',
+            help="Username of account",
+        )
 
     def handle(self, *args, **kwargs):
         self.check_args(*args)

--- a/pootle/apps/accounts/management/commands/merge_user.py
+++ b/pootle/apps/accounts/management/commands/merge_user.py
@@ -7,32 +7,40 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from optparse import make_option
-
 from . import UserCommand
 from ... import utils
 
 
 class Command(UserCommand):
-    args = "user other_user"
     help = "Merge user to other_user"
-    shared_option_list = (
-        make_option(
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "user",
+            nargs=1,
+            help="Username of account to merge from",
+        )
+        parser.add_argument(
+            "other_user",
+            nargs=1,
+            help="Username of account to merge into",
+        )
+
+        parser.add_argument(
             "--no-delete",
             dest='delete',
             action="store_false",
             default=True,
             help="Don't delete user after merging.",
-        ),
-    )
-    option_list = UserCommand.option_list + shared_option_list
+        )
 
-    def handle(self, *args, **kwargs):
-        super(Command, self).handle(*args, **kwargs)
-        src_user = self.get_user(username=args[0])
-        utils.UserMerger(src_user, self.get_user(username=args[1])).merge()
+    def handle(self, **options):
+        super(Command, self).handle(**options)
+        src_user = self.get_user(username=options['user'][0])
+        utils.UserMerger(src_user,
+                         self.get_user(username=options['other_user'][0])).merge()
 
-        if kwargs.get("delete"):
+        if options["delete"]:
             self.stdout.write("Deleting user: %s...\n" % src_user.username)
             src_user.delete()
             self.stdout.write("User deleted: %s\n" % src_user.username)

--- a/pootle/apps/accounts/management/commands/merge_user.py
+++ b/pootle/apps/accounts/management/commands/merge_user.py
@@ -35,7 +35,6 @@ class Command(UserCommand):
         )
 
     def handle(self, **options):
-        super(Command, self).handle(**options)
         src_user = self.get_user(username=options['user'][0])
         utils.UserMerger(src_user,
                          self.get_user(username=options['other_user'][0])).merge()

--- a/pootle/apps/accounts/management/commands/purge_user.py
+++ b/pootle/apps/accounts/management/commands/purge_user.py
@@ -14,6 +14,5 @@ class Command(UserCommand):
     help = "Delete user and all related objects"
 
     def handle(self, **options):
-        super(Command, self).handle(**options)
         for user in options['user']:
             self.get_user(user).delete(purge=True)

--- a/pootle/apps/accounts/management/commands/purge_user.py
+++ b/pootle/apps/accounts/management/commands/purge_user.py
@@ -11,9 +11,9 @@ from . import UserCommand
 
 
 class Command(UserCommand):
-    args = "user"
     help = "Delete user and all related objects"
 
-    def handle(self, *args, **kwargs):
-        super(Command, self).handle(*args, **kwargs)
-        self.get_user(args[0]).delete(purge=True)
+    def handle(self, **options):
+        super(Command, self).handle(**options)
+        for user in options['user']:
+            self.get_user(user).delete(purge=True)

--- a/pootle/apps/accounts/management/commands/update_user_email.py
+++ b/pootle/apps/accounts/management/commands/update_user_email.py
@@ -20,13 +20,24 @@ User = get_user_model()
 
 
 class Command(UserCommand):
-    args = "user email"
     help = "Update user email address"
 
-    def handle(self, *args, **kwargs):
-        super(Command, self).handle(*args, **kwargs)
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "user",
+            help="Username of account",
+        )
+        parser.add_argument(
+            "email",
+            help="New email address",
+        )
+
+    def handle(self, **options):
+        super(Command, self).handle(**options)
         try:
-            accounts.utils.update_user_email(self.get_user(args[0]), args[1])
+            accounts.utils.update_user_email(self.get_user(options['user']),
+                                             options['email'])
         except ValidationError as e:
             raise CommandError(e)
-        self.stdout.write("Email updated: %s, %s\n" % args)
+        self.stdout.write("Email updated: %s, %s\n" % (options['user'],
+                                                       options['email']))

--- a/pootle/apps/accounts/management/commands/update_user_email.py
+++ b/pootle/apps/accounts/management/commands/update_user_email.py
@@ -33,7 +33,6 @@ class Command(UserCommand):
         )
 
     def handle(self, **options):
-        super(Command, self).handle(**options)
         try:
             accounts.utils.update_user_email(self.get_user(options['user']),
                                              options['email'])

--- a/pootle/apps/accounts/management/commands/verify_user.py
+++ b/pootle/apps/accounts/management/commands/verify_user.py
@@ -33,8 +33,6 @@ class Command(UserCommand):
         )
 
     def handle(self, **options):
-        self.check_args(options['user'])
-
         # Either [user] OR --all should be set
         both_or_neither = ((options['user'] and options['all'])
                            or (not options['user'] and not options['all']))

--- a/pytest_pootle/fixtures/models/user.py
+++ b/pytest_pootle/fixtures/models/user.py
@@ -98,6 +98,15 @@ def member2(db):
 
 
 @pytest.fixture
+def member2_with_email(transactional_db):
+    """Require a member2 user."""
+    user = _require_user('member2_with_email', 'Member2 with email')
+    user.email = "member2_with_email@this.test"
+    user.save()
+    return user
+
+
+@pytest.fixture
 def evil_member(transactional_db):
     """Require a evil_member user."""
     return _require_user('evil_member', 'Evil member')

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -30,7 +30,8 @@ from fixtures.models.translation_project import (
     afrikaans_vfolder_test, templates_tutorial)
 from fixtures.models.user import (
     default, system, nobody, trans_nobody, admin, member, trans_member,
-    trans_system, member_with_email, member2, evil_member, no_perms_user)
+    trans_system, member_with_email, member2, member2_with_email, evil_member,
+    no_perms_user)
 
 from fixtures.cache import delete_pattern
 from fixtures.import_export_fixtures import (
@@ -51,26 +52,27 @@ from fixtures.core.utils.wordcount import WORDCOUNT_TESTS
 
 __all__ = (
     'admin', 'default', 'evil_member', 'member', 'member2', 'no_perms_user',
-    'member_with_email', 'nobody', 'system', 'trans_member', 'trans_nobody',
-    'trans_system', 'projects', 'root', 'afrikaans', 'arabic', 'english',
-    'fish', 'french', 'italian', 'klingon', 'klingon_vpw', 'russian',
-    'spanish', 'templates', 'administrate', 'hide', 'pootle_content_type',
-    'review', 'suggest', 'translate', 'view', 'default_ps', 'nobody_ps',
-    'project_bar', 'project_foo', 'tutorial', 'tutorial_disabled',
-    'vfolder_test', 'af_tutorial_po', 'af_tutorial_subdir_po',
-    'af_vfolder_test_browser_defines_po', 'en_tutorial_po',
-    'en_tutorial_po_member_updated', 'en_tutorial_po_no_file',
-    'es_tutorial_subdir_remove_po', 'fr_tutorial_remove_sync_po',
-    'fr_tutorial_subdir_to_remove_po', 'issue_2401_po', 'it_tutorial_po',
-    'param_update_store_test', 'po_directory', 'ru_tutorial_po',
-    'ru_update_save_changed_units_po', 'ru_update_set_last_sync_revision_po',
-    'store_diff_tests', 'templates_tutorial_pot', 'test_get_units_po',
-    'afrikaans_tutorial', 'afrikaans_vfolder_test', 'arabic_tutorial_obsolete',
-    'english_tutorial', 'french_tutorial', 'italian_tutorial',
-    'russian_tutorial', 'spanish_tutorial', 'templates_tutorial',
-    'delete_pattern', 'en_tutorial_ts', 'file_import_failure', 'ts_directory',
-    'revision', 'admin_client', 'site_matrix', 'site_matrix_with_subdirs',
-    'site_root', 'site_matrix_with_vfolders', 'site_matrix_with_announcements',
+    'member_with_email', 'member2_with_email', 'nobody', 'system',
+    'trans_member', 'trans_nobody', 'trans_system', 'projects', 'root',
+    'afrikaans', 'arabic', 'english', 'fish', 'french', 'italian', 'klingon',
+    'klingon_vpw', 'russian', 'spanish', 'templates', 'administrate', 'hide',
+    'pootle_content_type', 'review', 'suggest', 'translate', 'view',
+    'default_ps', 'nobody_ps', 'project_bar', 'project_foo', 'tutorial',
+    'tutorial_disabled', 'vfolder_test', 'af_tutorial_po',
+    'af_tutorial_subdir_po', 'af_vfolder_test_browser_defines_po',
+    'en_tutorial_po', 'en_tutorial_po_member_updated',
+    'en_tutorial_po_no_file', 'es_tutorial_subdir_remove_po',
+    'fr_tutorial_remove_sync_po', 'fr_tutorial_subdir_to_remove_po',
+    'issue_2401_po', 'it_tutorial_po', 'param_update_store_test',
+    'po_directory', 'ru_tutorial_po', 'ru_update_save_changed_units_po',
+    'ru_update_set_last_sync_revision_po', 'store_diff_tests',
+    'templates_tutorial_pot', 'test_get_units_po', 'afrikaans_tutorial',
+    'afrikaans_vfolder_test', 'arabic_tutorial_obsolete', 'english_tutorial',
+    'french_tutorial', 'italian_tutorial', 'russian_tutorial',
+    'spanish_tutorial', 'templates_tutorial', 'delete_pattern',
+    'en_tutorial_ts', 'file_import_failure', 'ts_directory', 'revision',
+    'admin_client', 'site_matrix', 'site_matrix_with_subdirs', 'site_root',
+    'site_matrix_with_vfolders', 'site_matrix_with_announcements',
     'site_permissions', 'project_views', 'tp_views', 'language_views',
     'bad_views')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ python_files=*.py
 addopts=--nomigrations --tb=short tests
 norecursedirs=.git _build tmp* requirements commands/*
 usefixtures=po_directory
+markers=
+    cmd: Django admin commands.
 
 [pep257]
 inherit=false

--- a/tests/commands/merge_user.py
+++ b/tests/commands/merge_user.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+def test_purge_user_nousers():
+    with pytest.raises(CommandError) as e:
+        call_command('merge_user')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+def test_purge_user_only_one_user(member):
+    with pytest.raises(CommandError) as e:
+        call_command('merge_user', 'member')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_merge_user_nofrom(member2):
+    with pytest.raises(CommandError) as e:
+        call_command('merge_user', 'not_a_user', 'member2')
+    assert "User not_a_user does not exist" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_merge_user_noto(member):
+    with pytest.raises(CommandError) as e:
+        call_command('merge_user', 'member', 'not_a_user2')
+    assert "User not_a_user2 does not exist" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_merge_user_withdelete(capfd, nobody, member, member2):
+    call_command('merge_user', 'member', 'member2')
+    out, err = capfd.readouterr()
+    assert 'User merged: member --> member2' in out
+    assert 'Deleting user: member...' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_merge_user_nodelete(capfd, nobody, member, member2):
+    call_command('merge_user', '--no-delete', 'member', 'member2')
+    out, err = capfd.readouterr()
+    assert 'User merged: member --> member2' in out
+    assert 'Deleting user: member...' not in out

--- a/tests/commands/purge_user.py
+++ b/tests/commands/purge_user.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+def test_purge_user_nouser():
+    with pytest.raises(CommandError) as e:
+        call_command('purge_user')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_purge_user_single_user(capfd, evil_member):
+    call_command('purge_user', 'evil_member')
+    out, err = capfd.readouterr()
+    assert "User purged: evil_member" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_purge_user_multiple_users(capfd, member, member2):
+    call_command('purge_user', 'member', 'member2')
+    out, err = capfd.readouterr()
+    assert "User purged: member " in out
+    assert "User purged: member2 " in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_purge_user_unkownuser():
+    with pytest.raises(CommandError) as e:
+        call_command('purge_user', 'not_a_user')
+    assert "User not_a_user does not exist" in str(e)

--- a/tests/commands/update_user_email.py
+++ b/tests/commands/update_user_email.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_user_email_nouser():
+    with pytest.raises(CommandError) as e:
+        call_command('update_user_email')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_user_email_noemail_supplied(member):
+    with pytest.raises(CommandError) as e:
+        call_command('update_user_email', 'member')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_user_email_unkonwnuser():
+    with pytest.raises(CommandError) as e:
+        call_command('update_user_email', 'not_a_user', 'email@address')
+    assert "User not_a_user does not exist" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_user_email_new_email(capfd, member):
+    call_command('update_user_email', 'member', 'new_email@address.com')
+    out, err = capfd.readouterr()
+    assert "Email updated: member, new_email@address.com" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_user_email_bad_email(member):
+    with pytest.raises(CommandError) as e:
+        call_command('update_user_email', 'member', 'new_email@address')
+    assert "Enter a valid email address." in str(e)

--- a/tests/commands/verify_user.py
+++ b/tests/commands/verify_user.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_nouser(capfd):
+    with pytest.raises(CommandError) as e:
+        call_command('verify_user')
+    assert "You must either provide a [user] to verify or use '--all'" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_user_and_all(capfd):
+    with pytest.raises(CommandError) as e:
+        call_command('verify_user', '--all', 'member_with_email')
+    assert "Either provide a 'user' to verify or use '--all'" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_unknownuser(capfd):
+    with pytest.raises(CommandError) as e:
+        call_command('verify_user', 'not_a_user')
+    assert "User not_a_user does not exist" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_noemail(capfd, member):
+    call_command('verify_user', 'member')
+    out, err = capfd.readouterr()
+    assert "You cannot verify an account with no email set" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_hasemail(capfd, member_with_email):
+    call_command('verify_user', 'member_with_email')
+    out, err = capfd.readouterr()
+    assert "User 'member_with_email' has been verified" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_all(capfd, member_with_email, member2_with_email):
+    call_command('verify_user', '--all')
+    out, err = capfd.readouterr()
+    assert "Verified user 'member_with_email'" in out
+    assert "Verified user 'member2_with_email'" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_verify_user_multiple(capfd, member_with_email, member2_with_email):
+    call_command('verify_user', 'member_with_email', 'member2_with_email')
+    out, err = capfd.readouterr()
+    assert "User 'member_with_email' has been verified" in out
+    assert "User 'member2_with_email' has been verified" in out

--- a/tests/commands/verify_user.py
+++ b/tests/commands/verify_user.py
@@ -17,7 +17,7 @@ from django.core.management.base import CommandError
 def test_verify_user_nouser(capfd):
     with pytest.raises(CommandError) as e:
         call_command('verify_user')
-    assert "You must either provide a [user] to verify or use '--all'" in str(e)
+    assert "Either provide a 'user' to verify or use '--all'" in str(e)
 
 
 @pytest.mark.cmd


### PR DESCRIPTION
Migrate the ``UserCommand`` based management commands to argparse.  Includes tests of the command using ``call_command``.