### PR TITLE
Optimize vfolder query on directory context

### DIFF
--- a/pootle/apps/virtualfolder/helpers.py
+++ b/pootle/apps/virtualfolder/helpers.py
@@ -7,6 +7,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from pootle_app.models import Directory
+
 from .models import VirtualFolderTreeItem
 
 
@@ -46,3 +48,16 @@ def extract_vfolder_from_path(request_path):
         return None, request_path
     else:
         return vfti.vfolder, vfti.directory.pootle_path
+
+
+def vftis_for_child_dirs(directory):
+    """
+    Returns the vfoldertreeitems for a directory's child directories
+    """
+    child_dir_pks = [
+        child.pk
+        for child
+        in directory.children
+        if isinstance(child, Directory)]
+    return VirtualFolderTreeItem.objects.filter(
+        directory__pk__in=child_dir_pks)

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -92,13 +92,7 @@ def make_generic_item(path_obj, **kwargs):
     }
 
 
-def make_directory_item(directory):
-    filters = {}
-
-    if directory.has_vfolders:
-        # The directory has virtual folders, so append priority sorting to URL.
-        filters['sort'] = 'priority'
-
+def make_directory_item(directory, **filters):
     item = make_generic_item(directory, **filters)
     item.update({
         'icon': 'folder',
@@ -171,19 +165,3 @@ def make_project_list_item(project):
         'title': project.fullname,
     })
     return item
-
-
-def get_children(directory):
-    """Returns a list of children directories and stores for this
-    ``directory``.
-
-    The elements of the list are dictionaries which keys are populated after
-    in the templates.
-    """
-    directories = [make_directory_item(child_dir)
-                   for child_dir in directory.child_dirs.live().iterator()]
-
-    stores = [make_store_item(child_store)
-              for child_store in directory.child_stores.live().iterator()]
-
-    return directories + stores


### PR DESCRIPTION
This finds out which subdirs have vfolders in a single db call.

My db timings for this optimization:

/af/firefox/

OLD: 22 queries run, total 0.022 seconds
NEW: 13 queries run, total 0.013 seconds

/af/firefox/browser/

OLD: 20 queries run, total 0.02 seconds
NEW: 12 queries run, total 0.012 seconds
