### PR TITLE
Optimization: select_related when extracting vfolder from path

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -39,6 +39,7 @@ from pootle_misc.forms import make_search_form
 from pootle_misc.util import ajax_required, get_date_interval, to_int
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
+from virtualfolder.models import VirtualFolderTreeItem
 
 from .decorators import get_unit_context
 from .fields import to_python
@@ -452,7 +453,10 @@ def get_units(request):
     if 'virtualfolder' in settings.INSTALLED_APPS:
         from virtualfolder.helpers import extract_vfolder_from_path
 
-        vfolder, pootle_path = extract_vfolder_from_path(pootle_path)
+        vfolder, pootle_path = extract_vfolder_from_path(
+            pootle_path,
+            vfti=VirtualFolderTreeItem.objects.select_related(
+                "directory", "vfolder"))
 
     path_keys = [
         "project_code", "language_code", "dir_path", "filename"]

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -353,7 +353,10 @@ class TPTranslateView(TPDirectoryMixin, TPTranslateBaseView):
 
     @cached_property
     def extracted_path(self):
-        return extract_vfolder_from_path(self.request_path)
+        return extract_vfolder_from_path(
+            self.request_path,
+            vfti=VirtualFolderTreeItem.objects.select_related(
+                "directory", "vfolder"))
 
     @property
     def display_vfolder_priority(self):

--- a/pootle/apps/virtualfolder/helpers.py
+++ b/pootle/apps/virtualfolder/helpers.py
@@ -29,21 +29,27 @@ def make_vfolder_treeitem_dict(vfolder_treeitem):
         'icon': 'vfolder'}
 
 
-def extract_vfolder_from_path(request_path):
+def extract_vfolder_from_path(request_path, vfti=None):
     """
     Matches request_path to a VirtualFolderTreeItem pootle_path
 
     If a match is found, the associated VirtualFolder and Directory.pootle_path
     are returned. Otherwise the original request_path is returned.
 
+    A `VirtualFolderTreeItem` queryset can be passed in for checking for
+    Vfolder pootle_paths. This is useful to `select_related` related fields.
+
     :param request_path: a path that may contain a virtual folder
+    :param vfti: optional `VirtualFolderTreeItem` queryset
     :return: (`VirtualFolder`, path)
     """
     if not (request_path.count('/') > 3 and request_path.endswith('/')):
         return None, request_path
 
+    if vfti is None:
+        vfti = VirtualFolderTreeItem.objects.all()
     try:
-        vfti = VirtualFolderTreeItem.objects.get(pootle_path=request_path)
+        vfti = vfti.get(pootle_path=request_path)
     except VirtualFolderTreeItem.DoesNotExist:
         return None, request_path
     else:


### PR DESCRIPTION
This makes a small difference, but nevertheless reduces load on db - which is a good thing.

Timings for /af/firefox/translate/user1/browser/#filter=incomplete:

OLD: 10 queries run, total 0.015 seconds
NEW: 8 queries run, total 0.008 seconds

also small reduction in the db time of get_units if vfolder in effect:

timings for /xhr/units/?path=%2Faf%2Ffirefox%2Fuser1%2Fbrowser%2F&initial=true&filter=incomplete:

OLD: 9 queries run, total 0.021 seconds
NEW: 7 queries run, total 0.018 seconds