### PR TITLE
Migrate BaseCommand derived commands to argparse

### DIFF
--- a/pootle/apps/accounts/management/commands/find_duplicate_emails.py
+++ b/pootle/apps/accounts/management/commands/find_duplicate_emails.py
@@ -35,7 +35,8 @@ class Command(BaseCommand):
             for user in users:
                 args = (user.username,
                         " " * (25 - len(user.username)),
-                        user.last_login.strftime('%Y-%m-%d %H:%M'),
+                        user.last_login.strftime('%Y-%m-%d %H:%M')
+                        if user.last_login is not None else "never logged in",
                         (user.is_superuser
                          and "\t\tthis user is a Superuser" or ""))
                 self.stdout.write(" %s%slast login: %s%s\n" % args)

--- a/pootle/apps/accounts/management/commands/find_duplicate_emails.py
+++ b/pootle/apps/accounts/management/commands/find_duplicate_emails.py
@@ -18,7 +18,7 @@ User = get_user_model()
 
 class Command(BaseCommand):
 
-    def handle(self, *args, **kwargs):
+    def handle(self, **options):
         duplicates = get_duplicate_emails()
         if not duplicates:
             self.stdout.write("There are no accounts with duplicate emails\n")

--- a/pootle/apps/import_export/management/commands/import.py
+++ b/pootle/apps/import_export/management/commands/import.py
@@ -44,6 +44,9 @@ class Command(BaseCommand):
                 raise CommandError("Unrecognised user: %s" % options["user"])
 
         for filename in options['file']:
+            if not os.path.isfile(filename):
+                raise CommandError("No such file '%s'" % filename)
+
             if is_zipfile(filename):
                 with ZipFile(filename, "r") as zf:
                     for path in zf.namelist():

--- a/pootle/apps/import_export/management/commands/import.py
+++ b/pootle/apps/import_export/management/commands/import.py
@@ -9,7 +9,6 @@
 
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
-from optparse import make_option
 from zipfile import ZipFile, is_zipfile
 
 from django.contrib.auth import get_user_model
@@ -19,19 +18,23 @@ from import_export.utils import import_file
 
 
 class Command(BaseCommand):
-    args = "<file file ...>"
-    option_list = BaseCommand.option_list + (
-        make_option(
-            "--user",
-            action="store",
-            dest="user",
-            help="Import translation file(s) as USER",
-        ),
-    )
     help = "Import a translation file or a zip of translation files. " \
            "X-Pootle-Path header must be present."
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "file",
+            nargs="+",
+            help="file to import"
+        )
+        parser.add_argument(
+            "--user",
+            action="store",
+            dest="user",
+            help="Import translations as USER",
+        )
+
+    def handle(self, **options):
         user = None
         if options["user"] is not None:
             User = get_user_model()
@@ -40,7 +43,7 @@ class Command(BaseCommand):
             except User.DoesNotExist:
                 raise CommandError("Unrecognised user: %s" % options["user"])
 
-        for filename in args:
+        for filename in options['file']:
             if is_zipfile(filename):
                 with ZipFile(filename, "r") as zf:
                     for path in zf.namelist():

--- a/pootle/apps/pootle_app/management/commands/changed_languages.py
+++ b/pootle/apps/pootle_app/management/commands/changed_languages.py
@@ -12,8 +12,6 @@ import os
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 from django.db.models import Max
 
@@ -24,15 +22,14 @@ from pootle_store.models import Store, Unit
 class Command(BaseCommand):
     help = "List languages that were changed since last synchronization"
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--after-revision',
             action='store',
             dest='after_revision',
             type=int,
             help='Show languages changed after any arbitrary revision',
-        ),
-    )
+        )
 
     def handle(self, **options):
         last_known_revision = Revision.get()

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -8,7 +8,6 @@
 # AUTHORS file for copyright and authorship information.
 
 import os
-from optparse import make_option
 
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
@@ -21,15 +20,15 @@ from pootle.core.initdb import InitDB
 class Command(BaseCommand):
     help = 'Populates the database with initial values: users, projects, ...'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--no-projects',
             action='store_false',
             dest='create_projects',
             default=True,
             help="Do not create the default 'terminology' and 'tutorial' "
                  "projects.",
-        ), )
+        )
 
     def handle(self, **options):
         self.stdout.write('Populating the database.')

--- a/pootle/apps/pootle_app/management/commands/list_languages.py
+++ b/pootle/apps/pootle_app/management/commands/list_languages.py
@@ -10,36 +10,34 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
+    help = "List language codes."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--project',
             action='append',
             dest='projects',
-            help='Limit to PROJECTS'),
-        make_option(
+            help='Limit to PROJECTS',
+        )
+        parser.add_argument(
             "--modified-since",
             action="store",
             dest="modified_since",
             type=int,
             default=0,
             help="Only process translations newer than specified "
-                 "revision"),
-    )
-    help = "List language codes."
+                 "revision",
+        )
 
     def handle(self, **options):
         self.list_languages(**options)
 
     def list_languages(self, **options):
         """List all languages on the server or the given projects."""
-        projects = options.get('projects', [])
-
         from pootle_translationproject.models import TranslationProject
         tps = TranslationProject.objects.distinct()
         tps = tps.exclude(
@@ -49,8 +47,8 @@ class Command(BaseCommand):
             tps = tps.filter(
                 submission__unit__revision__gt=options['modified_since'])
 
-        if projects:
-            tps = tps.filter(project__code__in=projects)
+        if options['projects']:
+            tps = tps.filter(project__code__in=options['projects'])
 
         for lang in tps.values_list('language__code', flat=True):
             self.stdout.write(lang)

--- a/pootle/apps/pootle_app/management/commands/list_projects.py
+++ b/pootle/apps/pootle_app/management/commands/list_projects.py
@@ -10,24 +10,21 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from pootle_project.models import Project
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             "--modified-since",
             action="store",
             dest="revision",
             type=int,
             default=0,
             help="Only process translations newer than specified revision",
-        ),
-    )
+        )
 
     def handle(self, **options):
         self.list_projects(**options)

--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -11,8 +11,6 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
@@ -22,17 +20,14 @@ from pootle_statistics.models import ScoreLog
 class Command(BaseCommand):
     help = "Refresh score"
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--reset',
             action='store_true',
             dest='reset',
             default=False,
             help='Reset all scores to zero',
-        ),
-    )
-
-    option_list = BaseCommand.option_list + shared_option_list
+        )
 
     def handle(self, **options):
 

--- a/pootle/apps/pootle_app/management/commands/revision.py
+++ b/pootle/apps/pootle_app/management/commands/revision.py
@@ -11,25 +11,22 @@
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from pootle.core.models import Revision
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
+    help = "Print Pootle's current revision."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--restore',
             action='store_true',
             default=False,
             dest='restore',
             help='Restore the current revision number from the DB.',
-        ),
-    )
-
-    help = "Print the number of the current revision."
+        )
 
     def handle(self, **options):
         if options['restore']:

--- a/pootle/apps/pootle_app/management/commands/test_checks.py
+++ b/pootle/apps/pootle_app/management/commands/test_checks.py
@@ -11,8 +11,6 @@ import logging
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from translate.filters.checks import FilterFailure, projectcheckers
 
 from django.conf import settings
@@ -26,41 +24,38 @@ from pootle_store.models import Unit
 class Command(BaseCommand):
     help = "Tests quality checks against string pairs."
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--check',
             action='append',
             dest='checks',
             help='Check name to check for',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--source',
             dest='source',
             help='Source string',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--unit',
             dest='unit',
             help='Unit id',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--target',
             dest='target',
             help='Translation string',
-        ),
-    )
-    option_list = BaseCommand.option_list + shared_option_list
+        )
 
     def handle(self, **options):
         # adjust debug level to the verbosity option
-        verbosity = int(options.get('verbosity', 1))
         debug_levels = {
             0: logging.ERROR,
             1: logging.WARNING,
             2: logging.INFO,
             3: logging.DEBUG
         }
-        debug_level = debug_levels.get(verbosity, logging.DEBUG)
+        debug_level = debug_levels.get(options['verbosity'], logging.DEBUG)
         logging.getLogger().setLevel(debug_level)
         self.name = self.__class__.__module__.split('.')[-1]
 
@@ -77,16 +72,15 @@ class Command(BaseCommand):
         checks = options.get('checks', [])
 
         if options['unit'] is not None:
-            unit_id = options.get('unit', '')
             try:
-                unit = Unit.objects.get(id=unit_id)
+                unit = Unit.objects.get(id=options['unit'])
                 source = unit.source
                 target = unit.target
             except Unit.DoesNotExist as e:
                 raise CommandError(e)
         else:
-            source = options.get('source', '').decode('utf-8')
-            target = options.get('target', '').decode('utf-8')
+            source = options['source'].decode('utf-8')
+            target = options['target'].decode('utf-8')
 
         if settings.POOTLE_QUALITY_CHECKER:
             checkers = [import_func(settings.POOTLE_QUALITY_CHECKER)()]

--- a/pootle/apps/pootle_app/management/commands/test_checks.py
+++ b/pootle/apps/pootle_app/management/commands/test_checks.py
@@ -94,6 +94,7 @@ class Command(BaseCommand):
         for checker in checkers:
             for check in checks:
                 filtermessage = ''
+                filterresult = True
                 if check in error_checks:
                     continue
                 try:

--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -11,7 +11,6 @@ import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 import subprocess
 import sys
-from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
@@ -22,17 +21,16 @@ from pootle_misc.baseurl import l
 class Command(BaseCommand):
     help = 'Builds and bundles static assets using webpack'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--dev',
             action='store_true',
             dest='dev',
             default=False,
             help='Enable development builds and watch for changes.',
-        ),
-    )
+        )
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         default_static_dir = os.path.join(settings.WORKING_DIR, 'static')
         custom_static_dirs = filter(lambda x: x != default_static_dir,
                                     settings.STATICFILES_DIRS)
@@ -44,11 +42,11 @@ class Command(BaseCommand):
         if os.name == 'nt':
             webpack_bin = '%s.cmd' % webpack_bin
 
-        args = [webpack_bin, '--config=%s' % webpack_config_file, '--progress',
-                '--colors']
+        webpack_args = [webpack_bin, '--config=%s' % webpack_config_file,
+                        '--progress', '--colors']
 
         if options['dev']:
-            args.extend(['--watch', '--display-error-details'])
+            webpack_args.extend(['--watch', '--display-error-details'])
         else:
             os.environ['NODE_ENV'] = 'production'
 
@@ -65,7 +63,7 @@ class Command(BaseCommand):
             os.environ['WEBPACK_ROOT'] = ':'.join(custom_static_dirs)
 
         try:
-            subprocess.call(args)
+            subprocess.call(webpack_args)
         except OSError:
             raise CommandError(
                 'webpack executable not found.\n'

--- a/pootle/apps/virtualfolder/management/commands/add_vfolders.py
+++ b/pootle/apps/virtualfolder/management/commands/add_vfolders.py
@@ -23,16 +23,19 @@ from virtualfolder.models import VirtualFolder
 class Command(BaseCommand):
     help = "Add virtual folders from file."
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "vfolder",
+            nargs=1,
+            help="JSON vfolder configuration file",
+        )
+
+    def handle(self, **options):
         """Add virtual folders from file."""
 
-        if not args:
-            raise CommandError("You forgot to provide the mandatory filename.")
-
         try:
-            inputfile = open(args[0], "r")
-            vfolders = json.load(inputfile)
-            inputfile.close()
+            with open(options['vfolder'][0], "r") as inputfile:
+                vfolders = json.load(inputfile)
         except IOError as e:
             raise CommandError(e)
         except ValueError as e:

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -106,10 +106,11 @@ def init_command(parser, settings_template, args):
 
     src_dir = os.path.abspath(os.path.dirname(__file__))
     add_help_to_parser(parser)
-    parser.add_argument("--db", default="sqlite",
+    parser.add_argument("--db",
+                        default="sqlite",
+                        choices=['sqlite', 'mysql', 'postgresql'],
                         help=(u"Use the specified database backend (default: "
-                              u"'sqlite'; other options: 'mysql', "
-                              u"'postgresql')."))
+                              u"%(default)s)."))
     parser.add_argument("--db-name", default="",
                         help=(u"Database name (default: 'pootledb') or path "
                               u"to database file if using sqlite (default: "
@@ -137,11 +138,6 @@ def init_command(parser, settings_template, args):
         if resp not in ("y", "yes"):
             print("File already exists, not overwriting.")
             exit(2)
-
-    if args.db not in ["mysql", "postgresql", "sqlite"]:
-        raise management.CommandError("Unrecognised database '%s': should "
-                                      "be one of 'sqlite', 'mysql' or "
-                                      "'postgresql'" % args.db)
 
     try:
         init_settings(config_path, settings_template,

--- a/tests/commands/add_vfolders.py
+++ b/tests/commands/add_vfolders.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+def test_add_vfolders_user_nofile():
+    """Missing vfolder argument."""
+    with pytest.raises(CommandError) as e:
+        call_command('add_vfolders')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+def test_add_vfolders_user_non_existant_file():
+    """No file on filesystem."""
+    with pytest.raises(CommandError) as e:
+        call_command('add_vfolders', 'nofile.json')
+    assert "No such file or directory" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_add_vfolders_emptyfile(capfd, site_matrix_with_vfolders, tmpdir):
+    """Load an empty vfolder.json file"""
+    p = tmpdir.mkdir("sub").join("empty.json")
+    p.write("{}")
+    call_command('add_vfolders', os.path.join(p.dirname, p.basename))
+    out, err = capfd.readouterr()
+    assert "Importing virtual folders" in out

--- a/tests/commands/changed_languages.py
+++ b/tests/commands/changed_languages.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_changed_languages_noargs(capfd, afrikaans_tutorial, french_tutorial,
+                                  revision):
+    """Get changed languages since last sync."""
+    call_command('changed_languages')
+    out, err = capfd.readouterr()
+    assert "(no known changes)" in err
+    assert ("Will show languages changed between revisions 6 (exclusive) and "
+            "6 (inclusive)" in err)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_changed_languages_since_revision(capfd, afrikaans_tutorial,
+                                          french_tutorial, revision):
+    """Changed languages since a given revision"""
+    # Everything
+    call_command('changed_languages', '--after-revision=0')
+    out, err = capfd.readouterr()
+    assert "af,fr" in out
+    # End revisions
+    call_command('changed_languages', '--after-revision=4')
+    out, err = capfd.readouterr()
+    assert "fr" in out

--- a/tests/commands/dump.py
+++ b/tests/commands/dump.py
@@ -41,7 +41,7 @@ def test_dump_stats(capfd, afrikaans_tutorial):
     call_command('dump', '--stats')
     out, err = capfd.readouterr()
     # Ensure it's a --stats
-    assert 'False,None,None' in out
+    assert 'None,None' in out
     assert out.startswith('/')
     # Ensure its got all the files, the data differs due to differing load
     # sequences
@@ -59,7 +59,7 @@ def test_dump_stop_level(capfd, afrikaans_tutorial):
     call_command('dump', '--stats', '--stop-level=1')
     out, err = capfd.readouterr()
     # Ensure it's a --stats
-    assert 'False,None,None' in out
+    assert 'None,None' in out
     assert out.startswith('/')
     # First level
     assert '/af/tutorial/' in out

--- a/tests/commands/find_duplicate_emails.py
+++ b/tests/commands/find_duplicate_emails.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_find_duplicate_emails_nodups(capfd, nobody, system, admin):
+    """No duplicates found.
+
+    Standard users shouldn't flag any error.
+    """
+    call_command('find_duplicate_emails')
+    out, err = capfd.readouterr()
+    assert "There are no accounts with duplicate emails" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_find_duplicate_emails_noemails(capfd, member, member2):
+    """User have no email set."""
+    call_command('find_duplicate_emails')
+    out, err = capfd.readouterr()
+    assert "The following users have no email set" in out
+    assert "member " in out
+    assert "member2" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_find_duplicate_emails_withdups(capfd, member_with_email,
+                                        member2_with_email):
+    """Find duplicate emails for removal where we have dups.
+
+    Standard users shouldn't flag any error.
+    """
+    member2_with_email.email = member_with_email.email
+    member2_with_email.save()
+    call_command('find_duplicate_emails')
+    out, err = capfd.readouterr()
+    assert "The following users have the email: member_with_email@this.test" in out
+    assert "member_with_email" in out
+    assert "member2_with_email" in out

--- a/tests/commands/import.py
+++ b/tests/commands/import.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+def test_import_user_nofile():
+    """Missing 'file' positional argument."""
+    with pytest.raises(CommandError) as e:
+        call_command('import')
+    assert "too few arguments" in str(e)
+
+
+@pytest.mark.cmd
+def test_import_user_non_existant_file():
+    """No file on filesystem."""
+    with pytest.raises(CommandError) as e:
+        call_command('import', 'nofile.po')
+    assert "No such file" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_import_emptyfile(capfd, afrikaans_tutorial, tmpdir):
+    """Load an empty PO file"""
+    p = tmpdir.mkdir("sub").join("empty.po")
+    p.write("")
+    with pytest.raises(CommandError) as e:
+        call_command('import', os.path.join(p.dirname, p.basename))
+    assert "missing X-Pootle-Path header" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_import_onefile(capfd, afrikaans_tutorial, tmpdir):
+    """Load an one unit PO file"""
+    p = tmpdir.mkdir("sub").join("tutorial.po")
+    p.write("""msgid ""
+msgstr ""
+"X-Pootle-Path: /af/tutorial/tutorial.po\\n"
+"X-Pootle-Revision: 12\\n"
+
+msgid "rest"
+msgstr "test"
+           """)
+    call_command('import', os.path.join(p.dirname, p.basename))
+    out, err = capfd.readouterr()
+    assert "[update]" in err
+    assert "obsoleted 3" in err
+    assert "added 1" in err
+    assert "/af/tutorial/tutorial.po" in err
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_import_onefile_with_user(capfd, afrikaans_tutorial, tmpdir, member):
+    """Load an one unit PO file"""
+    p = tmpdir.mkdir("sub").join("tutorial.po")
+    p.write("""msgid ""
+msgstr ""
+"X-Pootle-Path: /af/tutorial/tutorial.po\\n"
+"X-Pootle-Revision: 12\\n"
+
+msgid "rest"
+msgstr "test"
+           """)
+    call_command('import', '--user=member', os.path.join(p.dirname, p.basename))
+    out, err = capfd.readouterr()
+    assert "[update]" in err
+    assert "obsoleted 3" in err
+    assert "added 1" in err
+    assert "/af/tutorial/tutorial.po" in err
+    with pytest.raises(CommandError) as e:
+        call_command('import', '--user=not_a_user',
+                     os.path.join(p.dirname, p.basename))
+    assert "Unrecognised user: not_a_user" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_import_bad_pootlepath(afrikaans_tutorial, tmpdir):
+    """Bad X-Pootle-Path
+
+    / missing before af
+    """
+    p = tmpdir.mkdir("sub").join("tutorial.po")
+    p.write("""msgid ""
+msgstr ""
+"X-Pootle-Path: af/tutorial/tutorial.po\\n"
+"X-Pootle-Revision: 12\\n"
+
+msgid "rest"
+msgstr "test"
+           """)
+    with pytest.raises(CommandError) as e:
+        call_command('import', os.path.join(p.dirname, p.basename))
+    assert "Missing Project/Language?" in str(e)

--- a/tests/commands/initdb.py
+++ b/tests/commands/initdb.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_initdb_noprojects(capfd):
+    """Initialise the database with initdb
+
+    Testing without --no-projects would take too long
+    """
+    call_command('initdb', '--no-projects')
+    out, err = capfd.readouterr()
+    assert "Successfully populated the database." in out
+    assert "pootle createsuperuser" in out
+    # FIXME ideally we want to check for these but it seems that test oders and
+    # such means that these have already been added so we don't get any
+    # reports.
+    # assert "Created User: 'nobody'" in err
+    # assert "Created Directory: '/projects/'" in err
+    # assert "Created Permission:" in err
+    # assert "Created PermissionSet:" in err
+    # assert "Created Language:" in err

--- a/tests/commands/list_languages.py
+++ b/tests/commands/list_languages.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_list_languages_af_es_fr(capfd, afrikaans_tutorial, spanish_tutorial,
+                                 french_tutorial):
+    """Full site list of active languages"""
+    call_command('list_languages')
+    out, err = capfd.readouterr()
+    assert 'af' in out
+    assert 'es' in out
+    assert 'fr' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_list_languages_project(capfd, site_matrix):
+    """Languages on a specific project"""
+    call_command('list_languages', '--project=project0')
+    out, err = capfd.readouterr()
+    assert 'language0' in out
+    assert 'language1' in out
+    assert 'af' not in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_list_languages_modified_since(capfd, afrikaans_tutorial,
+                                       spanish_tutorial, french_tutorial):
+    """Languages modified since a revision
+
+    We expect fr, as its is updated on revision 6 and 7.
+    """
+    call_command('list_languages', '--modified-since=5')
+    out, err = capfd.readouterr()
+    assert 'af' not in out
+    assert 'es' not in out
+    assert 'fr' in out

--- a/tests/commands/list_projects.py
+++ b/tests/commands/list_projects.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_list_projects_tutorial(capfd, afrikaans_tutorial, spanish_tutorial,
+                                french_tutorial):
+    """List site wide projects"""
+    call_command('list_projects')
+    out, err = capfd.readouterr()
+    assert 'tutorial' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_list_projects_modified_since(capfd, afrikaans_tutorial,
+                                      spanish_tutorial, french_tutorial):
+    """Projects modified since a revision"""
+    call_command('list_projects', '--modified-since=5')
+    out, err = capfd.readouterr()
+    assert 'tutorial' in out

--- a/tests/commands/pootle_runner.py
+++ b/tests/commands/pootle_runner.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from subprocess import call
+
+
+@pytest.mark.cmd
+def test_pootle_noargs(capfd):
+    """Pootle no args should give help"""
+    call(['pootle'])
+    out, err = capfd.readouterr()
+    assert "Type 'pootle help <subcommand>'" in out
+
+
+@pytest.mark.cmd
+def test_pootle_version(capfd):
+    """Display Pootle version info"""
+    call(['pootle', '--version'])
+    out, err = capfd.readouterr()
+    assert 'Pootle' in err
+    assert 'Django' in err
+    assert 'Translate Toolkit' in err
+
+
+@pytest.mark.cmd
+def test_pootle_init(capfd):
+    """pootle init --help"""
+    call(['pootle', 'init', '--help'])
+    out, err = capfd.readouterr()
+    assert "--db" in out
+
+
+@pytest.mark.cmd
+def test_pootle_init_db_sqlite(capfd):
+    """pootle init --help"""
+    call(['pootle', 'init', '--db=sqlite'])
+    out, err = capfd.readouterr()
+    assert "Configuration file created" in out

--- a/tests/commands/refresh_scores.py
+++ b/tests/commands/refresh_scores.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_refresh_scores_recalculate(site_matrix):
+    """Recalculate scores."""
+    call_command('refresh_scores')
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_refresh_scores_reset(site_matrix):
+    """Set scores to zero"""
+    call_command('refresh_scores', '--reset')

--- a/tests/commands/revision.py
+++ b/tests/commands/revision.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_revision(capfd):
+    """Get current revision."""
+    call_command('revision')
+    out, err = capfd.readouterr()
+    assert out.rstrip().isnumeric()
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_revision_restore(capfd):
+    """Restore redis revision from DB."""
+    call_command('revision', '--restore')
+    out, err = capfd.readouterr()
+    assert out.rstrip().isnumeric()

--- a/tests/commands/test_checks.py
+++ b/tests/commands/test_checks.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import connection
+
+
+@pytest.mark.cmd
+def test_test_checks_noargs():
+    """No args should fail wanting either --unit or --source."""
+    with pytest.raises(CommandError) as e:
+        call_command('test_checks')
+    assert ("Either --unit or a pair of --source and "
+            "--target must be provided." in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_test_checks_unit_unkown(afrikaans_tutorial):
+    """Check a --unit that we won't have"""
+    with pytest.raises(CommandError) as e:
+        call_command('test_checks', '--unit=100000')
+    assert 'Unit matching query does not exist' in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_test_checks_unit(capfd, site_matrix):
+    """Check a --unit"""
+    # Unit 3/345 is /language0/project0/store0.po Translated Target
+    # unitid varies on different databases
+    if connection.vendor == 'sqlite':
+        unitid = 345
+    else:
+        unitid = 3
+    call_command('test_checks', '--unit=%s' % unitid)
+    out, err = capfd.readouterr()
+    assert 'No errors found' in out
+
+
+@pytest.mark.cmd
+def test_test_checks_srctgt_missing_args():
+    """Check a --source --target with incomplete options."""
+    with pytest.raises(CommandError) as e:
+        call_command('test_checks', '--source="files"')
+    assert 'Use a pair of --source and --target' in str(e)
+    with pytest.raises(CommandError) as e:
+        call_command('test_checks', '--target="leers"')
+    assert 'Use a pair of --source and --target' in str(e)
+
+
+@pytest.mark.cmd
+def test_test_checks_srctgt_pass(capfd):
+    """Passing --source --target check."""
+    call_command('test_checks', '--source="Files"', '--target="Leers"')
+    out, err = capfd.readouterr()
+    assert 'No errors found' in out
+
+
+@pytest.mark.cmd
+def test_test_checks_srctgt_fail(capfd):
+    """Failing --source --target check."""
+    call_command('test_checks', '--source="%s files"', '--target="%s leers"')
+    out, err = capfd.readouterr()
+    assert 'No errors found' in out
+    call_command('test_checks', '--source="%s files"', '--target="%d leers"')
+    out, err = capfd.readouterr()
+    assert 'Failing checks' in out
+
+
+@pytest.mark.cmd
+def test_test_checks_alt_checker(capfd, settings):
+    """Use an alternate checker."""
+    settings.POOTLE_QUALITY_CHECKER = 'pootle_misc.checks.ENChecker'
+    call_command('test_checks', '--source="%s files"', '--target="%s leers"')
+    out, err = capfd.readouterr()
+    assert 'No errors found' in out
+    call_command('test_checks', '--source="%s files"', '--target="%d leers"')
+    out, err = capfd.readouterr()
+    assert 'Failing checks' in out


### PR DESCRIPTION
This focuses on all commands that inherit directly from BaseCommand