### PR TITLE
Convert PootleCommand derived commands to argparse

### DIFF
--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -9,7 +9,6 @@
 
 import os
 os.environ["DJANGO_SETTINGS_MODULE"] = "pootle.settings"
-from optparse import make_option
 from zipfile import ZipFile
 
 from django.core.management.base import CommandError
@@ -21,16 +20,17 @@ from pootle_store.models import Store
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Export a Project, Translation Project, or path. " \
+           "Multiple files will be zipped."
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             "--path",
             action="store",
             dest="pootle_path",
             help="Export a single file",
-        ),
-    )
-    help = "Export a Project, Translation Project, or path. " \
-           "Multiple files will be zipped."
+        )
 
     def _create_zip(self, stores, prefix):
         with open("%s.zip" % (prefix), "wb") as f:

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -7,7 +7,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import logging
 import os
 
 # This must be run before importing Django.
@@ -33,16 +32,15 @@ class Command(PootleCommand):
         )
 
     def handle_all_stores(self, translation_project, **options):
-        logging.info(
-            u"Running %s for %s",
-            self.name, translation_project)
+        self.stdout.write(u"Running %s for %s" %
+                          (self.name, translation_project))
         QualityCheckUpdater(
             options['check_names'],
             translation_project).update()
 
     def handle_all(self, **options):
         if not self.projects and not self.languages:
-            logging.info(u"Running %s (noargs)", self.name)
+            self.stdout.write(u"Running %s (noargs)" % self.name)
             QualityCheckUpdater(options['check_names']).update()
         else:
             super(Command, self).handle_all(**options)

--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -9,7 +9,6 @@
 
 import logging
 import os
-from optparse import make_option
 
 # This must be run before importing Django.
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
@@ -21,18 +20,17 @@ from . import PootleCommand
 
 class Command(PootleCommand):
     help = "Allow checks to be recalculated manually."
+    process_disabled_projects = True
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--check',
             action='append',
             dest='check_names',
             default=None,
-            help='Check to recalculate'
-        ),
-    )
-    option_list = PootleCommand.option_list + shared_option_list
-    process_disabled_projects = True
+            help='Check to recalculate',
+        )
 
     def handle_all_stores(self, translation_project, **options):
         logging.info(

--- a/pootle/apps/pootle_app/management/commands/contributors.py
+++ b/pootle/apps/pootle_app/management/commands/contributors.py
@@ -9,7 +9,6 @@
 
 import os
 from collections import Counter
-from optparse import make_option
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "pootle.settings"
 
@@ -24,26 +23,25 @@ User = get_user_model()
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Print a list of contributors."
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             "--from-revision",
             type=int,
             default=0,
             dest="revision",
             help="Only count contributions newer than this revision",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             "--sort-by",
-            type="choice",
             default="name",
             choices=["name", "contributions"],
             dest="sort_by",
             help="Sort by specified item. Accepts name and contributions. "
-                 "Default: %default",
-        ),
-    )
-
-    help = "Print a list of contributors."
+                 "Default: %(default)s",
+        )
 
     def handle_all(self, **options):
         system_user = User.objects.get_system_user()

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -9,7 +9,6 @@
 
 
 import os
-
 import sys
 reload(sys)
 sys.setdefaultencoding('utf-8')
@@ -20,7 +19,10 @@ from django.core.management.base import CommandError
 
 from pootle_app.management.commands import PootleCommand
 from pootle_app.models import Directory
+from pootle_language.models import Language
 from pootle_project.models import Project
+from pootle_translationproject.models import TranslationProject
+
 
 DUMPED = {
     'TranslationProject': ('pootle_path', 'real_path', 'disabled'),
@@ -140,17 +142,18 @@ class Command(PootleCommand):
 
     def _dump_item(self, item, level, stop_level):
         self.stdout.write(self.dumped(item))
-        if item.is_dir:
-            # item is a Directory
-            if item.is_project():
-                self.stdout.write(self.dumped(item.project))
-            elif item.is_language():
-                self.stdout.write(self.dumped(item.language))
-            elif item.is_translationproject():
-                try:
-                    self.stdout.write(self.dumped(item.translationproject))
-                except:
-                    pass
+        if isinstance(item, Directory):
+            pass
+        elif isinstance(item, Language):
+            self.stdout.write(self.dumped(item.language))
+        elif isinstance(item, TranslationProject):
+            try:
+                self.stdout.write(self.dumped(item.translationproject))
+            except:
+                pass
+        elif isinstance(item, Project):
+            pass
+            # self.stdout.write(self.dumped(item))
         else:
             # item should be a Store
             for unit in item.units:

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -111,12 +111,18 @@ class Command(PootleCommand):
         res[key] = (item.get_stats(include_children=False))
 
         if res[key]['lastaction']:
-            last_action_id = res[key]['lastaction']['id']
+            if 'id' in res[key]['lastaction']:
+                last_action_id = res[key]['lastaction']['id']
+            else:
+                last_action_id = None
         else:
             last_action_id = None
 
         if res[key]['lastupdated']:
-            last_updated_id = res[key]['lastupdated']['id']
+            if 'id' in res[key]['lastupdated']:
+                last_updated_id = res[key]['lastupdated']['id']
+            else:
+                last_updated_id = None
         else:
             last_updated_id = None
 

--- a/pootle/apps/pootle_app/management/commands/dump.py
+++ b/pootle/apps/pootle_app/management/commands/dump.py
@@ -16,8 +16,6 @@ sys.setdefaultencoding('utf-8')
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from django.core.management.base import CommandError
 
 from pootle_app.management.commands import PootleCommand
@@ -42,30 +40,30 @@ DUMPED = {
 class Command(PootleCommand):
     help = "Dump data."
 
-    shared_option_list = (
-        make_option(
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--stats',
             action='store_true',
             dest='stats',
             default=False,
             help='Dump stats',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--data',
             action='store_true',
             dest='data',
             default=False,
             help='Data all data',
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--stop-level',
             action='store',
             dest='stop_level',
             default=-1,
             type=int,
-        ),
-    )
-    option_list = PootleCommand.option_list + shared_option_list
+            help="Depth of data to retreive",
+        )
 
     def handle_all(self, **options):
         if not self.projects and not self.languages:

--- a/pootle/apps/pootle_app/management/commands/sync_stores.py
+++ b/pootle/apps/pootle_app/management/commands/sync_stores.py
@@ -9,38 +9,38 @@
 
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
-from optparse import make_option
 
 from pootle_app.management.commands import PootleCommand
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Save new translations to disk manually."
+    process_disabled_projects = True
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--overwrite',
             action='store_true',
             dest='overwrite',
             default=False,
             help="Don't just save translations, but "
                  "overwrite files to reflect state in database",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--skip-missing',
             action='store_true',
             dest='skip_missing',
             default=False,
             help="Ignore missing files on disk",
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--force',
             action='store_true',
             dest='force',
             default=False,
             help="Don't ignore stores synced after last change",
-        ),
-    )
-    help = "Save new translations to disk manually."
-    process_disabled_projects = True
+        )
 
     def handle_all_stores(self, translation_project, **options):
         if translation_project.directory_exists_on_disk():

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -11,32 +11,33 @@ import logging
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 
-from optparse import make_option
-
 from pootle_app.management.commands import PootleCommand
 from pootle_translationproject.models import scan_translation_projects
 
 
 class Command(PootleCommand):
-    option_list = PootleCommand.option_list + (
-        make_option(
+    help = "Update database stores from files."
+    process_disabled_projects = True
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
             '--overwrite',
             action='store_true',
             dest='overwrite',
             default=False,
             help="Don't just update untranslated units "
                  "and add new units, but overwrite database "
-                 "translations to reflect state in files."),
-        make_option(
+                 "translations to reflect state in files.",
+        )
+        parser.add_argument(
             '--force',
             action='store_true',
             dest='force',
             default=False,
             help="Unconditionally process all files (even if they "
-                 "appear unchanged)."),
-    )
-    help = "Update database stores from files."
-    process_disabled_projects = True
+                 "appear unchanged).",
+        )
 
     def handle_translation_project(self, translation_project, **options):
         """

--- a/tests/commands/calculate_checks.py
+++ b/tests/commands/calculate_checks.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_calculate_checks_noargs(capfd, afrikaans_tutorial):
+    call_command('calculate_checks')
+    out, err = capfd.readouterr()
+    assert 'Running calculate_checks (noargs)' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_calculate_checks_printf(capfd, afrikaans_tutorial):
+    call_command('calculate_checks', '--check=printf')
+    out, err = capfd.readouterr()
+    assert 'Running calculate_checks (noargs)' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_calculate_checks_afrikaans(capfd, afrikaans_tutorial):
+    call_command('calculate_checks', '--language=af')
+    out, err = capfd.readouterr()
+    assert 'Running calculate_checks for /af/tutorial/' in out

--- a/tests/commands/contributors.py
+++ b/tests/commands/contributors.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_contributors_noargs(capfd, en_tutorial_po_member_updated):
+    """Contributors across the site."""
+    call_command('contributors')
+    out, err = capfd.readouterr()
+    assert "Member (1 contributions)" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_contributors_revision(capfd, en_tutorial_po_member_updated):
+    """Contributors since a given revision."""
+    call_command('contributors', '--from-revision=1')
+    out, err = capfd.readouterr()
+    assert "Member (1 contributions)" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_contributors_project(capfd, en_tutorial_po_member_updated):
+    """Contributors in a given project."""
+    call_command('contributors', '--project=tutorial')
+    out, err = capfd.readouterr()
+    assert "Member (1 contributions)" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_contributors_language(capfd, en_tutorial_po_member_updated):
+    """Contributors in a given language."""
+    call_command('contributors', '--language=en')
+    out, err = capfd.readouterr()
+    assert "Member (1 contributions)" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_contributors_sort(capfd, en_tutorial_po_member_updated, member):
+    """Contributors in contribution order."""
+    member.email = "member@test.email"
+    member.save()
+    call_command('contributors', '--sort-by=contributions')
+    out, err = capfd.readouterr()
+    assert "Member <member@test.email> (1 contributions)" in out

--- a/tests/commands/dump.py
+++ b/tests/commands/dump.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.cmd
+def test_dump_noargs():
+    """Dump requires an output option."""
+    with pytest.raises(CommandError) as e:
+        call_command('dump')
+    assert "Set --data or --stats option" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_dump_data(capfd, afrikaans_tutorial):
+    """--data output."""
+    call_command('dump', '--data')
+    out, err = capfd.readouterr()
+    assert "Directory" in out
+    assert "Project" in out
+    assert "TranslationProject" in out
+    assert "Store" in out
+    # FIXME unsure why this one does not appear
+    # assert "Language" in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_dump_stats(capfd, afrikaans_tutorial):
+    """--stats output."""
+    call_command('dump', '--stats')
+    out, err = capfd.readouterr()
+    # Ensure it's a --stats
+    assert 'False,None,None' in out
+    assert out.startswith('/')
+    # Ensure its got all the files, the data differs due to differing load
+    # sequences
+    assert '/af/tutorial/issue_2401.po' in out
+    assert '/af/tutorial/test_get_units.po' in out
+    assert '/af/tutorial/' in out
+    assert '/af/tutorial/subdir/' in out
+    assert '/projects/tutorial/' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_dump_stop_level(capfd, afrikaans_tutorial):
+    """Set the depth for data."""
+    call_command('dump', '--stats', '--stop-level=1')
+    out, err = capfd.readouterr()
+    # Ensure it's a --stats
+    assert 'False,None,None' in out
+    assert out.startswith('/')
+    # First level
+    assert '/af/tutorial/' in out
+    assert '/projects/tutorial/' in out
+    # Deaper levels not output
+    assert '/af/tutorial/issue_2401.po' not in out
+    assert '/af/tutorial/test_get_units.po' not in out
+    assert '/af/tutorial/subdir/' not in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_dump_data_tp(capfd, afrikaans_tutorial):
+    """--data output with TP selection."""
+    call_command('dump', '--data', '--project=tutorial', '--language=af')
+    out, err = capfd.readouterr()
+    assert "Directory" in out
+    assert "Store" in out
+    # FIXME check if these really should be missing
+    assert "Language" not in out
+    assert "Project" not in out
+    assert "TranslationProject" not in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_dump_stats_tp(capfd, afrikaans_tutorial):
+    """--stats output with TP selection"""
+    call_command('dump', '--stats', '--project=tutorial', '--language=af')
+    out, err = capfd.readouterr()
+    # Ensure it's a --stats
+    assert 'False,None,None' in out
+    assert out.startswith('/')
+    # Ensure its got all the files (the data differs due to differing load
+    # sequences)
+    assert '/af/tutorial/issue_2401.po' in out
+    assert '/af/tutorial/test_get_units.po' in out
+    assert '/af/tutorial/' in out
+    assert '/af/tutorial/subdir/' in out
+    # As this is a TP, these shouldn't be here
+    assert '/projects/tutorial/' not in out

--- a/tests/commands/export.py
+++ b/tests/commands/export.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_export_noargs(capfd, en_tutorial_po_member_updated):
+    """Export whole site"""
+    call_command('export')
+    out, err = capfd.readouterr()
+    assert 'Created tutorial-en.zip' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_export_project(capfd, afrikaans_tutorial, french_tutorial):
+    """Export a project"""
+    call_command('export', '--project=tutorial')
+    out, err = capfd.readouterr()
+    assert 'tutorial.zip' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_export_language(capfd, afrikaans_tutorial, french_tutorial):
+    """Export a language"""
+    call_command('export', '--language=af')
+    out, err = capfd.readouterr()
+    assert 'af.zip' in out
+    assert 'fr.zip' not in out

--- a/tests/commands/sync_stores.py
+++ b/tests/commands/sync_stores.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_sync_stores_noargs(capfd, en_tutorial_po_member_updated):
+    """Site wide sync_stores"""
+    call_command('sync_stores')
+    out, err = capfd.readouterr()
+    # FIXME we should work out how to get something here
+    assert out == ''
+    assert err == ''

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_stores_noargs(capfd, en_tutorial_po_member_updated):
+    """Site wide update_stores"""
+    call_command('update_stores')
+    out, err = capfd.readouterr()
+    # Store and Unit are deleted as there are no files on disk
+    # SO - Store Obsolete
+    assert 'system\tSO\t/en/tutorial/tutorial.po' in err
+    # UO - Unit Obsolete
+    assert 'system\tUO\ten' in err
+
+    # Repeat and we should have zero output
+    call_command('update_stores')
+    out, err = capfd.readouterr()
+    assert 'system\tSO' not in err
+    assert 'system\tUO' not in err

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -37,6 +37,11 @@ CACHES = {
         'LOCATION': 'redis://127.0.0.1:6379/15',
         'TIMEOUT': None,
     },
+    'exports': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': os.path.join(ROOT_DIR, 'tests', 'exports'),
+        'TIMEOUT': 259200,  # 3 days.
+    },
 }
 
 # Using synchronous mode for testing


### PR DESCRIPTION
Next batch for conversions and tests.  This focuses on PootleCommand which drive commands that process Stores and have options like ``--language`` and ``--project``.