### PR TITLE
Optimizations for x-language items and project view pages

### DIFF
--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -50,7 +50,8 @@ class ProjectMixin(object):
     @cached_property
     def project(self):
         return get_object_or_404(
-            Project, code=self.kwargs["project_code"])
+            Project.objects.select_related("directory"),
+            code=self.kwargs["project_code"])
 
     @property
     def url_kwargs(self):


### PR DESCRIPTION
- Add `directory` to select_related when querying `ProjectMixin.project` because `directory` is necessary for checking permissions.
- Moving select_related to `ProjectResource` creation allows us to avoid an extra expensive query if `ProjectResource.resources` is equal to `ProjectResource.get_children_for_user`.