### PR TITLE
Webpack: add --progress and use --no-color

### DIFF
--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -29,6 +29,12 @@ class Command(BaseCommand):
             default=False,
             help='Enable development builds and watch for changes.',
         )
+        parser.add_argument(
+            '--progress',
+            action='store_true',
+            default=False,
+            help='Show progress.',
+        )
 
     def handle(self, **options):
         default_static_dir = os.path.join(settings.WORKING_DIR, 'static')
@@ -42,8 +48,10 @@ class Command(BaseCommand):
         if os.name == 'nt':
             webpack_bin = '%s.cmd' % webpack_bin
 
+        webpack_progress = '--progress' if options['progress'] else ''
+
         webpack_args = [webpack_bin, '--config=%s' % webpack_config_file,
-                        '--progress', '--colors']
+                        webpack_progress, '--colors']
 
         if options['dev']:
             webpack_args.extend(['--watch', '--display-error-details'])

--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -49,9 +49,10 @@ class Command(BaseCommand):
             webpack_bin = '%s.cmd' % webpack_bin
 
         webpack_progress = '--progress' if options['progress'] else ''
+        webpack_colors = '--colors' if not options['no_color'] else ''
 
         webpack_args = [webpack_bin, '--config=%s' % webpack_config_file,
-                        webpack_progress, '--colors']
+                        webpack_progress, webpack_colors]
 
         if options['dev']:
             webpack_args.extend(['--watch', '--display-error-details'])


### PR DESCRIPTION
* Add --progress to allow progress noise to be silenced.  Useful for Travis builds
* Use Django's ``--no-color`` option to control webpack's ``--colors``, though switching off colours doesn't seem to actually work.