### PR TITLE
TM: leverage Levenshtein distance on ES hits

### DIFF
--- a/docs/releases/2.7.3b2.rst
+++ b/docs/releases/2.7.3b2.rst
@@ -25,6 +25,9 @@ Details of changes
   scores calculation.
 - :setting:`POOTLE_TM_SERVER` no longer receives the ``MIN_SCORE`` parameter, as
   it was misleading and had questionable effects.
+- :setting:`POOTLE_TM_SERVER` now accepts a ``MIN_SIMILARITY`` parameter, to
+  filter out results which might be irrelevant. To learn more, check the
+  documenation on :setting:`MIN_SIMILARITY <POOTLE_TM_SERVER-MIN_SIMILARITY>`.
 
 
 ...and lots of refactoring, new tests, cleanups, improved documentation and of

--- a/docs/releases/2.7.3b2.rst
+++ b/docs/releases/2.7.3b2.rst
@@ -23,6 +23,8 @@ Details of changes
 
 - :setting:`POOTLE_SCORE_COEFFICIENTS` accepts custom settings for user
   scores calculation.
+- :setting:`POOTLE_TM_SERVER` no longer receives the ``MIN_SCORE`` parameter, as
+  it was misleading and had questionable effects.
 
 
 ...and lots of refactoring, new tests, cleanups, improved documentation and of

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -329,7 +329,6 @@ Translation environment configuration settings.
             'PORT': 9200,
             'INDEX_NAME': 'translations',
             'WEIGHT': 1,
-            'MIN_SCORE': 'AUTO',
         },
         'external': {
             'ENGINE': 'pootle.core.search.backends.ElasticSearchBackend',
@@ -337,7 +336,6 @@ Translation environment configuration settings.
             'PORT': 9200,
             'INDEX_NAME': 'external-translations',
             'WEIGHT': 0.9,
-            'MIN_SCORE': 'AUTO',
         },
     }
 
@@ -345,12 +343,6 @@ Translation environment configuration settings.
   This is configured to access a standard Elasticsearch setup.  Change the
   settings for any non-standard setup.  Change ``HOST`` and ``PORT`` settings
   as required.
-
-  Use ``MIN_SCORE`` to set the Levenshtein Distance score.  Set it to ``AUTO``
-  so that Elasticsearch will adjust the required score depending on the length
-  of the string being translated. Elasticsearch documentation provides further
-  details on `Fuzzy matching
-  <https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness>`_.
 
   The default ``local`` TM is automatically updated every time a new
   translation is submitted. The other TMs are not automatically updated so they

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -312,8 +312,9 @@ Translation environment configuration settings.
 
   .. versionchanged:: 2.7.3
 
-     Added the :setting:`WEIGHT <POOTLE_TM_SERVER-WEIGHT>` option. Also added
-     another default TM used to import external translations from files.
+     Added the :setting:`WEIGHT <POOTLE_TM_SERVER-WEIGHT>` and
+     :setting:`MIN_SIMILARITY <POOTLE_TM_SERVER-MIN_SIMILARITY>` options. Also
+     added another default TM used to import external translations from files.
 
 
   Default: ``{}`` (empty dict)
@@ -357,6 +358,15 @@ Translation environment configuration settings.
   ``WEIGHT`` provides a weighting factor to alter the final score for TM
   results from this TM server. Valid values are between ``0.0`` and ``1.0``,
   both included. Defaults to ``1.0`` if not provided.
+
+  .. setting:: POOTLE_TM_SERVER-MIN_SIMILARITY
+
+  ``MIN_SIMILARITY`` serves as a threshold value to filter out results that are
+  potentially too far from the source text. The Levenshtein distance is
+  considered when measuring how similar the text is from the source text, and
+  this represents a real value in the (0..1) range, 1 being 100% similarity.
+  The default value (0.7) should work fine in most cases, although your mileage
+  might vary.
 
 
 .. setting:: POOTLE_MT_BACKENDS

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -321,14 +321,6 @@ def check_settings(app_configs=None, **kwargs):
                     id="pootle.C012",
                 ))
 
-            if 'MIN_SCORE' not in settings.POOTLE_TM_SERVER[server]:
-                errors.append(checks.Critical(
-                    _("POOTLE_TM_SERVER['%s'] has no MIN_SCORE.", server),
-                    hint=_("Set a MIN_SCORE for POOTLE_TM_SERVER['%s'].",
-                           server),
-                    id="pootle.C013",
-                ))
-
             if ('WEIGHT' in settings.POOTLE_TM_SERVER[server] and
                 not (0.0 <= settings.POOTLE_TM_SERVER[server]['WEIGHT']
                      <= 1.0)):

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import
 
 import logging
 
+import Levenshtein
+
 try:
     from elasticsearch import Elasticsearch
     from elasticsearch.exceptions import ElasticsearchException
@@ -24,6 +26,36 @@ __all__ = ('ElasticSearchBackend',)
 
 
 logger = logging.getLogger(__name__)
+
+
+DEFAULT_MIN_SIMILARITY = 0.7
+
+
+def filter_hits_by_distance(hits, source_text,
+                            min_similarity=DEFAULT_MIN_SIMILARITY):
+    """Returns ES `hits` filtered according to their Levenshtein distance
+    to the `source_text`.
+
+    Any hits with a similarity value (0..1) lower than `min_similarity` will be
+    discarded. It's assumed that `hits` is already sorted from higher to lower
+    score.
+    """
+    if min_similarity <= 0 or min_similarity >= 1:
+        min_similarity = DEFAULT_MIN_SIMILARITY
+
+    filtered_hits = []
+    for hit in hits:
+        hit_source_text = hit['_source']['source']
+        distance = Levenshtein.distance(source_text, hit_source_text)
+        similarity = (
+            1 - distance / float(max(len(source_text), len(hit_source_text)))
+        )
+        if similarity < min_similarity:
+            break
+
+        filtered_hits.append(hit)
+
+    return filtered_hits
 
 
 class ElasticSearchBackend(SearchBackend):
@@ -92,7 +124,13 @@ class ElasticSearchBackend(SearchBackend):
                          self._settings["PORT"], unit)
             return []
 
-        for hit in es_res['hits']['hits']:
+        hits = filter_hits_by_distance(
+            es_res['hits']['hits'],
+            unit.source,
+            min_similarity=self._settings.get('MIN_SIMILARITY',
+                                              DEFAULT_MIN_SIMILARITY)
+        )
+        for hit in hits:
             if self._is_valuable_hit(unit, hit):
                 body = hit['_source']
                 translation_pair = body['source'] + body['target']

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -74,7 +74,7 @@ class ElasticSearchBackend(SearchBackend):
                     "match": {
                         "source": {
                             "query": unit.source,
-                            "fuzziness": self._settings['MIN_SCORE'],
+                            "fuzziness": 'AUTO',
                         }
                     }
                 }

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -50,6 +50,12 @@ def filter_hits_by_distance(hits, source_text,
         similarity = (
             1 - distance / float(max(len(source_text), len(hit_source_text)))
         )
+
+        logger.debug(
+            'Similarity: %.2f (distance: %d)\nOriginal:\t%s\nComparing with:\t%s',
+            similarity, distance, source_text, hit_source_text
+        )
+
         if similarity < min_similarity:
             break
 

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -111,9 +111,6 @@ DATABASES = {
 #        # from this TM server. Valid values are between ``0.0`` and ``1.0``,
 #        # both included. Defaults to ``1.0`` if not provided.
 #        'WEIGHT': 1.0,
-#        # For valid values for MIN_SCORE see
-#        # http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
-#        'MIN_SCORE': 'AUTO',
 #    },
 #    'external': {
 #        'ENGINE': 'pootle.core.search.backends.ElasticSearchBackend',
@@ -121,7 +118,6 @@ DATABASES = {
 #        'PORT': 9200,
 #        'INDEX_NAME': 'external-translations',
 #        'WEIGHT': 0.9,
-#        'MIN_SCORE': 'AUTO',
 #    },
 #}
 

--- a/pootle/templates/editor/units/xhr_tm.html
+++ b/pootle/templates/editor/units/xhr_tm.html
@@ -2,9 +2,7 @@
   <div class="extra-item-title"><%= name %></div>
   <% _.each(suggs, function (sugg, i) { %>
   <div id="tm<%= i %>" class="extra-item-block js-editor-copytext"
-    data-action="overwrite" data-translation-aid="<%- sugg.target %>"
-    <% if (sugg.score) { %> data-score="<%= sugg.score %>"<% } %>
-    >
+    data-action="overwrite" data-translation-aid="<%- sugg.target %>">
     <div class="extra-item-content">
       <div class="extra-item">
         <div class="suggestion-original" lang="<%= store.source_lang %>"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ cssmin
 diff-match-patch>=20121119
 elasticsearch>=1.0.0,<1.7
 lxml>=2.2.0
+python-levenshtein
 rq>=0.5.0,<=0.5.6
 
 # Translate Toolkit


### PR DESCRIPTION
This leverages the Levenshtein distance on top of the hits returned by ES, considering the whole text, not individual terms.

In my testing the irrelevant results are now gone. As mentioned in the issue, we set a threshold to allow changes up to a third of the text contents. YMMV so feel free to propose any adjustments to the threshold.

The PR also removes the `MIN_SCORE` setting because it results irrelevant (check the commit message for further reasoning).

Fixes #3971.