### PR TITLE
[RFC] Fix TM missing fullname

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1959,7 +1959,7 @@ PTL.editor = {
       if (results[i].username === 'nobody') {
         results[i].fullname = gettext('some anonymous user');
       } else if (!results[i].fullname) {
-        results[i].fullname = gettext('someone');
+        results[i].fullname = results[i].username;
       }
       results[i].fullname = _.escape(results[i].fullname);
 


### PR DESCRIPTION
Tentative fix for 'someone' always appearing as the TM user who contributed the TM when we don't have the fullname but only the username.

@julen would you be able to verify this?

Not sure if we have a case where both fullname and username are missing?