### PR TITLE
Add support for POST requests in TP views

### DIFF
--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -246,6 +246,9 @@ class TPBrowseBaseView(PootleBrowseView):
                  'has_sidebar': True})
         return ctx
 
+    def post(self, *args, **kwargs):
+        return self.get(*args, **kwargs)
+
 
 class TPBrowseStoreView(TPStoreMixin, TPBrowseBaseView):
     pass


### PR DESCRIPTION
POST requests (used for uploading) are not allowed after we converted TP views to DjangoDetailsViews in 02a24f71. This PR just uses `get()` handler in `post()`. I think this is not right solution but this is the fastest one and it matches pre 02a24f71 behaviour.