### PR TITLE
Tests: skip pootle runner tests if not installed via setup.py

### DIFF
--- a/tests/commands/pootle_runner.py
+++ b/tests/commands/pootle_runner.py
@@ -11,6 +11,10 @@ from subprocess import call
 import pytest
 
 
+pytestmark = pytest.mark.skipif(call(['which', 'pootle']) != 0,
+                                reason='not installed via setup.py')
+
+
 @pytest.mark.cmd
 def test_pootle_noargs(capfd):
     """Pootle no args should give help"""


### PR DESCRIPTION
Allows to omit some tests when developing directly in a virtualenv, where `setup.py` extras are not available (the `pootle` command is an entry point provided by `setup.py`).