### PR TITLE
Tests: revive running without installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pytest]
 python_files=*.py
-addopts=--nomigrations --tb=short tests
+addopts=--nomigrations --tb=short tests -p pytest_pootle.plugin
 norecursedirs=.git _build tmp* requirements commands/*
 usefixtures=po_directory
 markers=

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ class PyTest(TestCommand):
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = ['--tb=short', 'tests/']
+        self.test_args = ['--tb=short', 'tests/', '-p pytest_pootle.plugin']
         self.test_suite = True
 
     def run_tests(self):
@@ -252,7 +252,6 @@ setup(
         'console_scripts': [
             'pootle = pootle.runner:main',
         ],
-        'pytest11': ['pootle = pytest_pootle.plugin'],
     },
     cmdclass={
         'build_checks_templates': BuildChecksTemplatesCommand,


### PR DESCRIPTION
In virtual environments where no package has been installed via setup.py, right
now it's impossible to run tests as it was before, i.e. by simply issuing
`py.test`. This brings back the possibility to do so.

Fixes #4358.