### PR TITLE
Add parametrised user fixture in view tests

### DIFF
--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -13,6 +13,30 @@ from datetime import datetime, timedelta
 from django.utils.functional import cached_property
 
 
+TEST_USERS = {
+    'nobody': dict(
+        fullname='Nobody',
+        password=''),
+    'system': dict(
+        fullname='System',
+        password=''),
+    'default': dict(
+        fullname='Default',
+        password=''),
+    'admin': dict(
+        fullname='Admin',
+        password='admin',
+        is_superuser=True,
+        email="admin@poot.le"),
+    'member': dict(
+        fullname='Member',
+        password=''),
+    'member2': dict(
+        fullname='Member2',
+        password=''),
+}
+
+
 class PootleTestEnv(object):
 
     methods = (
@@ -227,22 +251,8 @@ class PootleTestEnv(object):
     def setup_system_users(self):
         from .fixtures.models.user import _require_user
 
-        _require_user('nobody', 'Nobody')
-        _require_user('system', 'System')
-        _require_user(
-            'default', 'Default', password='')
-
-        _require_user(
-            'admin', 'Admin',
-            password='admin',
-            is_superuser=True,
-            email="admin@poot.le")
-        _require_user(
-            'member', 'Member',
-            password='')
-        _require_user(
-            'member2', 'Member 2',
-            password='')
+        for username, user_params in TEST_USERS.items():
+            _require_user(username=username, **user_params)
 
     def setup_site_permissions(self):
         from django.contrib.auth import get_user_model

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -41,7 +41,8 @@ from fixtures.site import (
     no_projects, no_permissions, no_permission_sets, no_submissions, no_users,
     post_db_setup)
 from fixtures.views import (
-    bad_views, language_views, project_views, tp_views)
+    bad_views, language_views, project_views, tp_views,
+    tp_view_test_names, tp_view_usernames)
 
 
 __all__ = (
@@ -68,4 +69,5 @@ __all__ = (
     'project_views', 'tp_views', 'language_views',
     'bad_views', 'post_db_setup', 'no_projects', 'no_permission_sets',
     'no_permissions', 'no_submissions', 'no_users', 'no_extra_users',
-    'units_text_searches', 'wordcount_names')
+    'units_text_searches', 'wordcount_names', 'tp_view_test_names',
+    'tp_view_usernames')

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -42,7 +42,7 @@ from fixtures.site import (
     post_db_setup)
 from fixtures.views import (
     bad_views, language_views, project_views, tp_views,
-    tp_view_test_names, tp_view_usernames)
+    tp_view_test_names, tp_view_usernames, tp_uploads)
 
 
 __all__ = (
@@ -70,4 +70,4 @@ __all__ = (
     'bad_views', 'post_db_setup', 'no_projects', 'no_permission_sets',
     'no_permissions', 'no_submissions', 'no_users', 'no_extra_users',
     'units_text_searches', 'wordcount_names', 'tp_view_test_names',
-    'tp_view_usernames')
+    'tp_view_usernames', 'tp_uploads')

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -149,6 +149,10 @@ def _test_browse_view(tp, request, response, kwargs):
             ctx["vfolders"]["items"]
             == vfolders)
 
+    assert (('display_download' in ctx and ctx['display_download']) ==
+            (request.user.is_authenticated()
+             and check_permission('translate', request)))
+
 
 def _test_translate_view(tp, request, response, kwargs, settings):
     ctx = response.context

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -119,7 +119,7 @@ def _test_browse_view(tp, request, response, kwargs):
         translation_project=tp,
         language=tp.language,
         project=tp.project,
-        is_admin=False,
+        is_admin=check_permission('administrate', request),
         is_store=(kwargs.get("filename") and True or False),
         browser_extends="translation_projects/base.html",
         pootle_path=pootle_path,
@@ -144,7 +144,7 @@ def _test_browse_view(tp, request, response, kwargs):
     view_context_test(ctx, **assertions)
     if vfolders:
         for vfolder in ctx["vfolders"]["items"]:
-            assert vfolder["is_grayed"] is False
+            assert (vfolder["is_grayed"] and not ctx["is_admin"]) is False
         assert (
             ctx["vfolders"]["items"]
             == vfolders)
@@ -171,7 +171,7 @@ def _test_translate_view(tp, request, response, kwargs, settings):
         translation_project=tp,
         language=tp.language,
         project=tp.project,
-        is_admin=False,
+        is_admin=check_permission('administrate', request),
         profile=request.profile,
         ctx_path=tp.pootle_path,
         pootle_path=request_path,

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -249,3 +249,9 @@ def test_view_user_choice(client):
     response = client.get("/foo/bar/baz")
     assert response.status_code == 404
     assert "user-choice" not in response
+
+
+@pytest.mark.django_db
+def test_uploads_tp(tp_uploads):
+    tp, request, response, kwargs = tp_uploads
+    assert response.status_code == 200


### PR DESCRIPTION
TP view tests didn't work for different users. 
This PR:
- adds parametrised user fixture;
- adjusts TP view tests to make them working;
- adds tests for #4451.

@phlax I was going to add test authentication backend that can process `client.login()` with username only. I set it as [WIP] atm.