### PR TITLE
commands: replace print with self.std{out,err}

### DIFF
--- a/pootle/apps/accounts/management/commands/verify_user.py
+++ b/pootle/apps/accounts/management/commands/verify_user.py
@@ -41,14 +41,14 @@ class Command(UserCommand):
             for user in get_user_model().objects.hide_meta():
                 try:
                     utils.verify_user(user)
-                    print("Verified user '%s'" % user.username)
+                    self.stdout.write("Verified user '%s'" % user.username)
                 except (ValueError, ValidationError) as e:
-                    print(e)
+                    self.stderr.write(e.message)
 
         if options['user']:
             for user in options['user']:
                 try:
                     utils.verify_user(self.get_user(user))
-                    print("User '%s' has been verified" % user)
+                    self.stdout.write("User '%s' has been verified" % user)
                 except (ValueError, ValidationError) as e:
-                    print(e)
+                    self.stderr.write(e.message)

--- a/pootle/apps/pootle_app/management/commands/changed_languages.py
+++ b/pootle/apps/pootle_app/management/commands/changed_languages.py
@@ -64,4 +64,4 @@ class Command(BaseCommand):
                                   flat=True)
 
         # list languages separated by comma for easy parsing
-        print ','.join(languages)
+        self.stdout.write(','.join(languages))

--- a/tests/commands/verify_user.py
+++ b/tests/commands/verify_user.py
@@ -41,7 +41,7 @@ def test_verify_user_unknownuser(capfd):
 def test_verify_user_noemail(capfd, member):
     call_command('verify_user', 'member')
     out, err = capfd.readouterr()
-    assert "You cannot verify an account with no email set" in out
+    assert "You cannot verify an account with no email set" in err
 
 
 @pytest.mark.cmd


### PR DESCRIPTION
We shouldn't be using ``print`` in commands, use self.std* instead.