### PR TITLE
Fix stats cache updating in calculate_checks command

### DIFF
--- a/pootle/core/checks/checker.py
+++ b/pootle/core/checks/checker.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.lru_cache import lru_cache
 
+from pootle.core.mixins.treeitem import CachedMethods
 from pootle_misc.checks import run_given_filters
 from pootle_misc.util import import_func
 from pootle_store.models import QualityCheck, Store, Unit
@@ -269,6 +270,7 @@ class QualityCheckUpdater(object):
         """After completing QualityCheck updates expire caches for affected Stores.
         """
         for store in Store.objects.filter(pk__in=stores):
+            store.mark_dirty(CachedMethods.CHECKS, CachedMethods.MTIME)
             store.update_dirty_cache()
 
     def update_translated_unit(self, unit, checker=None):


### PR DESCRIPTION
Mark dirty cache methods for a store before we update its cache.
I put `CachedMethods.CHECKS` and `CachedMethods.MTIME` because we update `unit.mtime` [here]( https://github.com/translate/pootle/blob/915db9edb092926679aa554e5657f8774631d1ba/pootle/core/checks/checker.py#L286).
Fix #4482