### PR TITLE
UnitForm: no need to handle id and index

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -204,9 +204,8 @@ def unit_form_factory(language, snplurals=None, request=None):
     class UnitForm(forms.ModelForm):
         class Meta(object):
             model = Unit
-            fields = ('id', 'index', 'target_f', 'state',)
+            fields = ('target_f', 'state',)
 
-        id = forms.IntegerField(required=False)
         target_f = MultiStringFormField(
             nplurals=tnplurals,
             required=False,

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -96,8 +96,6 @@
       </div>
       <div id="target-item-content">
         <form action="" method="post" name="translate" id="translate">
-          {{ form.id.as_hidden }}
-          {{ form.index.as_hidden }}
           <div class="sources">
             <!-- Alternative source language translations -->
             {% for altunit in altsrcs %}


### PR DESCRIPTION
ID is passed around in the URL when making the request, and in no case it needs
to be updated, same as for index. These were needed when the editor wasn't
XHR-based.