### PR TITLE
Simplify user get

### DIFF
--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -75,9 +75,8 @@ def set_permissions(f):
     def method_wrapper(self, request, *args, **kwargs):
         User = get_user_model()
         if request.user.is_anonymous():
-            request.profile = User.get(request.user)
-        else:
-            request.profile = request.user
+            request.user = User.get(request.user)
+        request.profile = request.user
         request.permissions = get_matching_permissions(
             request.user,
             self.permission_context) or []

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -74,11 +74,9 @@ def set_permissions(f):
     @functools.wraps(f)
     def method_wrapper(self, request, *args, **kwargs):
         User = get_user_model()
-        if request.user.is_anonymous():
-            request.user = User.get(request.user)
-        request.profile = request.user
+        request.profile = User.get(self.request.user)
         request.permissions = get_matching_permissions(
-            request.user,
+            request.profile,
             self.permission_context) or []
         return f(self, request, *args, **kwargs)
     return method_wrapper


### PR DESCRIPTION
This PR reverts the changes to retrieve the current user in the `set_permissions()` decorator.

After SQL inspection, I can confirm there's no functional change provided by the reverted commits, and there's no reason to duplicate the logic that is already contained in `User.get()`. Note this method only performs a SQL call to retrieve anonymous users, otherwise returns the passed argument.

In other words, [the body of `User.get`](https://github.com/translate/pootle/blob/052ad6189aaf0795555cf60fe90472276b5c308d/pootle/apps/accounts/models.py#L174-L177):
```python
        if user.is_authenticated():
            return user

        return cls.objects.get_nobody_user()
```
and the extra code which is [now on master](https://github.com/translate/pootle/blob/052ad6189aaf0795555cf60fe90472276b5c308d/pootle/core/views.py#L77-L80):
```python
        if request.user.is_anonymous():
            request.profile = User.get(request.user)
        else:
            request.profile = request.user
```
are equivalent, and hence can be simplified to:
```python
        request.profile = User.get(request.user)
```
This is more evident if `User.get()` was written checking for `is_anonymous()` (note `is_anonymous()` and `is_authenticated()` are converse methods, i.e one returning `False` when the other returns `True` and vice-versa):
```python
        if user.is_anonymous():
            return cls.objects.get_nobody_user()

        return user
```

I see this type of change has been done in 8634190 too, which I'd be keen on reverting once this gets merged.