### PR TITLE
Get rid of profile references and use request.user everywhere

### DIFF
--- a/pootle/apps/accounts/managers.py
+++ b/pootle/apps/accounts/managers.py
@@ -9,6 +9,7 @@
 
 from django.contrib.auth.models import BaseUserManager
 from django.utils import timezone
+from django.utils.lru_cache import lru_cache
 
 from . import utils
 
@@ -57,12 +58,15 @@ class UserManager(BaseUserManager):
         return self._create_user(username, email, password, True,
                                  **extra_fields)
 
+    @lru_cache()
     def get_default_user(self):
         return super(UserManager, self).get_queryset().get(username='default')
 
+    @lru_cache()
     def get_nobody_user(self):
         return super(UserManager, self).get_queryset().get(username='nobody')
 
+    @lru_cache()
     def get_system_user(self):
         return super(UserManager, self).get_queryset().get(username='system')
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -161,19 +161,6 @@ class User(AbstractBaseUser):
             return None
 
     @classmethod
-    def get(cls, user):
-        """Return the expected user instance.
-
-        This function is only necessary if `user` could be anonymous,
-        because we want to work with the instance of the special `nobody`
-        user instead of Django's own `AnonymousUser`.
-        """
-        if user.is_authenticated():
-            return user
-
-        return cls.objects.get_nobody_user()
-
-    @classmethod
     def top_scorers(cls, days=30, language=None, project=None, limit=5):
         """Returns users with the top scores.
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -167,9 +167,6 @@ class User(AbstractBaseUser):
         This function is only necessary if `user` could be anonymous,
         because we want to work with the instance of the special `nobody`
         user instead of Django's own `AnonymousUser`.
-
-        If you know for certain that a user is logged in, then use it
-        straight away.
         """
         if user.is_authenticated():
             return user
@@ -266,12 +263,12 @@ class User(AbstractBaseUser):
         return jsonify(model_to_dict(self, exclude=['password']))
 
     def is_anonymous(self):
-        """Returns `True` if this is an anonymous user.
-
-        Since we treat the `nobody` user as special anonymous-like user,
-        we can't rely on `auth.User` model's `is_authenticated()` method.
-        """
+        """Returns `True` if this is an anonymous user."""
         return self.username == 'nobody'
+
+    def is_authenticated(self):
+        """Returns `True` if this is an authenticated user."""
+        return self.username != 'nobody'
 
     def is_system(self):
         """Returns `True` if this is the special `system` user."""

--- a/pootle/apps/pootle_profile/templatetags/profile_tags.py
+++ b/pootle/apps/pootle_profile/templatetags/profile_tags.py
@@ -14,5 +14,5 @@ register = template.Library()
 
 
 @register.filter
-def gravatar(profile, size):
-    return profile.gravatar_url(size)
+def gravatar(user, size):
+    return user.gravatar_url(size)

--- a/pootle/apps/pootle_profile/views.py
+++ b/pootle/apps/pootle_profile/views.py
@@ -32,8 +32,7 @@ class UserDetailView(NoDefaultUserMixin, UserObjectMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(UserDetailView, self).get_context_data(**kwargs)
-        user = User.get(self.request.user)
-        context['user_is_manager'] = user.has_manager_permissions()
+        context['user_is_manager'] = self.request.user.has_manager_permissions()
         return context
 
 

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -52,7 +52,7 @@ class ProjectMixin(object):
         project = get_object_or_404(
             Project.objects.select_related("directory"),
             code=self.kwargs["project_code"])
-        if project.disabled and not self.request.profile.is_superuser:
+        if project.disabled and not self.request.user.is_superuser:
             raise Http404
         return project
 
@@ -144,8 +144,8 @@ class ProjectBrowseView(ProjectMixin, PootleBrowseView):
         items = [
             item_func(item)
             for item
-            in self.object.get_children_for_user(
-                self.request.profile)]
+            in self.object.get_children_for_user(self.request.user)
+        ]
 
         items.sort(
             lambda x, y: locale.strcoll(x['title'], y['title']))

--- a/pootle/apps/pootle_store/decorators.py
+++ b/pootle/apps/pootle_store/decorators.py
@@ -9,7 +9,6 @@
 
 from functools import wraps
 
-from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
@@ -48,11 +47,7 @@ def get_unit_context(permission_code=None):
             tp = unit.store.translation_project
             request.translation_project = tp
 
-            User = get_user_model()
-            current_user = User.get(request.user)
-            request.profile = current_user
-
-            request.permissions = get_matching_permissions(current_user,
+            request.permissions = get_matching_permissions(request.user,
                                                            tp.directory)
 
             if (permission_code is not None and

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -360,7 +360,7 @@ def unit_comment_form_factory(language):
                 sub = Submission(
                     creation_time=creation_time,
                     translation_project=translation_project,
-                    submitter=self.request.profile,
+                    submitter=self.request.user,
                     unit=self.instance,
                     store=self.instance.store,
                     field=SubmissionFields.COMMENT,

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -10,7 +10,6 @@
 import functools
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.core.urlresolvers import resolve, reverse
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
@@ -58,11 +57,9 @@ def redirect_to_tp_on_404(f):
 
     @functools.wraps(f)
     def method_wrapper(self, request, *args, **kwargs):
-        User = get_user_model()
-        request.profile = User.get(self.request.user)
         try:
             request.permissions = get_matching_permissions(
-                request.profile,
+                request.user,
                 self.permission_context) or []
         except Http404 as e:
             # Test if lang code is not canonical but valid
@@ -143,7 +140,7 @@ class TPMixin(object):
 
     @cached_property
     def project(self):
-        if self.tp.project.disabled and not self.request.profile.is_superuser:
+        if self.tp.project.disabled and not self.request.user.is_superuser:
             raise Http404
         return self.tp.project
 

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -9,7 +9,6 @@
 
 from functools import wraps
 
-from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.db import connection
@@ -313,9 +312,7 @@ def permission_required(permission_code):
                                      'path_obj')
             setattr(request, attr_name, path_obj)
 
-            User = get_user_model()
-            request.profile = User.get(request.user)
-            request.permissions = get_matching_permissions(request.profile,
+            request.permissions = get_matching_permissions(request.user,
                                                            directory)
 
             if not permission_code:

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -75,9 +75,8 @@ def set_permissions(f):
     def method_wrapper(self, request, *args, **kwargs):
         User = get_user_model()
         if request.user.is_anonymous():
-            request.profile = User.get(request.user)
-        else:
-            request.profile = request.user
+            request.user = User.get(request.user)
+        request.profile = request.user
         request.permissions = get_matching_permissions(
             request.user,
             self.permission_context) or []

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -74,11 +74,9 @@ def set_permissions(f):
     @functools.wraps(f)
     def method_wrapper(self, request, *args, **kwargs):
         User = get_user_model()
-        if request.user.is_anonymous():
-            request.user = User.get(request.user)
-        request.profile = request.user
+        request.profile = User.get(self.request.user)
         request.permissions = get_matching_permissions(
-            request.user,
+            request.profile,
             self.permission_context) or []
         return f(self, request, *args, **kwargs)
     return method_wrapper

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -73,10 +73,8 @@ def set_permissions(f):
 
     @functools.wraps(f)
     def method_wrapper(self, request, *args, **kwargs):
-        User = get_user_model()
-        request.profile = User.get(self.request.user)
         request.permissions = get_matching_permissions(
-            request.profile,
+            request.user,
             self.permission_context) or []
         return f(self, request, *args, **kwargs)
     return method_wrapper
@@ -613,7 +611,6 @@ class PootleTranslateView(PootleDetailView):
         ctx.update(
             {'page': 'translate',
              'current_vfolder_pk': self.vfolder_pk,
-             'profile': self.request.profile,
              'ctx_path': self.ctx_path,
              'display_priority': self.display_vfolder_priority,
              'check_categories': get_qualitycheck_schema(),
@@ -640,7 +637,7 @@ class PootleExportView(PootleDetailView):
         filter_name, filter_extra = get_filter_name(self.request.GET)
 
         units_qs = Unit.objects.get_translatable(
-            self.request.profile,
+            self.request.user,
             **self.kwargs)
 
         units_qs = get_step_query(self.request, units_qs)

--- a/pootle/middleware/auth.py
+++ b/pootle/middleware/auth.py
@@ -22,8 +22,9 @@ from django.utils.functional import SimpleLazyObject
 
 def get_user(request):
     if not hasattr(request, '_cached_user'):
-        current_user = auth.get_user(request)
-        request._cached_user = auth.get_user_model().get(current_user)
+        user = auth.get_user(request)
+        request._cached_user = (user if user.is_authenticated() else
+                                auth.get_user_model().objects.get_nobody_user())
     return request._cached_user
 
 

--- a/pootle/middleware/auth.py
+++ b/pootle/middleware/auth.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+"""
+Custom Pootle authentication middleware that takes care of returning Pootle's
+special `nobody` user instead of Django's own `AnonymousUser`.
+
+The code has been slightly adapted from django.contrib.auth.middleware.
+
+Note this customization would probably be unnecessary if there was a fix for
+https://code.djangoproject.com/ticket/20313
+"""
+
+from django.contrib import auth
+from django.utils.functional import SimpleLazyObject
+
+
+def get_user(request):
+    if not hasattr(request, '_cached_user'):
+        current_user = auth.get_user(request)
+        request._cached_user = auth.get_user_model().get(current_user)
+    return request._cached_user
+
+
+class AuthenticationMiddleware(object):
+    def process_request(self, request):
+        assert hasattr(request, 'session'), (
+            "The Django authentication middleware requires session middleware "
+            "to be installed. Edit your MIDDLEWARE_CLASSES setting to insert "
+            "'django.contrib.sessions.middleware.SessionMiddleware' before "
+            "'django.contrib.auth.middleware.AuthenticationMiddleware'."
+        )
+        request.user = SimpleLazyObject(lambda: get_user(request))

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -20,7 +20,7 @@ MIDDLEWARE_CLASSES = [
     #: Must be before authentication
     'django.contrib.sessions.middleware.SessionMiddleware',
     #: Must be before anything user-related
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'pootle.middleware.auth.AuthenticationMiddleware',
     #: User-related
     'django.middleware.locale.LocaleMiddleware',
     #: Sets Python's locale based on request's locale for sorting, etc.

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -103,7 +103,6 @@ INSTALLED_APPS = [
 
 
 AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.ModelBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
 

--- a/pootle/templates/editor/_scripts.html
+++ b/pootle/templates/editor/_scripts.html
@@ -22,10 +22,10 @@ $(function() {
     vFolder: '{{ current_vfolder_pk }}',
     ctxPath: '{{ ctx_path }}',
     resourcePath: '{{ resource_path }}',
-    chunkSize: {{ request.profile.get_unit_rows }},
+    chunkSize: {{ request.user.get_unit_rows }},
     isAdmin: {{ is_admin|yesno:"true,false" }},
-    isAnonymous: {{ request.profile.is_anonymous|yesno:"true,false" }},
-    userId: {{ request.profile.id }},
+    isAnonymous: {{ request.user.is_anonymous|yesno:"true,false" }},
+    userId: {{ request.user.id }},
   };
   {% if cansuggest or cantranslate %}
   options.mt = [

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -1,7 +1,7 @@
 {% load i18n baseurl common_tags store_tags cleanhtml cache locale %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs profile.id LANGUAGE_CODE unit.get_terminology %}
+{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.get_terminology %}
 <td colspan="2" rowspan="1" class="translate-full translate-focus{% if unit.isfuzzy %} fuzzy-unit{% endif %}" dir="{% locale_dir %}">
   <div class="translate-container{% if unit.get_active_critical_qualitychecks.exists %} error{% endif %}">
     <div class="unit-path">
@@ -304,7 +304,7 @@
                   <i class="icon-reject" dir="{% locale_dir %}"
                     title="{% trans 'Reject suggestion' %}"></i>
                 </a>
-                {% elif user.is_authenticated and profile == sugg.user %}
+                {% elif user.is_authenticated and user == sugg.user %}
                 <a accesskey="r" class="suggestion-action js-suggestion-reject"
                   data-sugg-id="{{ sugg.id }}">
                   <i class="icon-reject" dir="{% locale_dir %}"

--- a/pootle/templates/editor/units/term_edit.html
+++ b/pootle/templates/editor/units/term_edit.html
@@ -2,7 +2,7 @@
 {% load i18n store_tags cleanhtml cache locale %}
 {% get_current_language as LANGUAGE_CODE %}
 
-{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview report_target altsrcs profile.id LANGUAGE_CODE %}
+{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview report_target altsrcs user.id LANGUAGE_CODE %}
 
 {% block suggestion_comment %}
 {% if sugg.translator_comment %}

--- a/tests/forms/unit.py
+++ b/tests/forms/unit.py
@@ -7,8 +7,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.contrib.auth import get_user_model
-
 import pytest
 
 from pootle_app.models.permissions import get_matching_permissions
@@ -21,13 +19,9 @@ def _create_post_request(rf, directory, user, url='/', data=None):
     if data is None:
         data = {}
 
-    User = get_user_model()
-
     request = rf.post(url, data=data)
     request.user = user
-    request.profile = User.get(user)
-    request.permissions = get_matching_permissions(request.profile,
-                                                   directory)
+    request.permissions = get_matching_permissions(request.user, directory)
     return request
 
 

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -83,7 +83,6 @@ def _test_translate_view(language, request, response, kwargs, settings):
             pootle_path=language.directory.pootle_path,
             resource_path="",
             resource_path_parts=[],
-            profile=request.profile,
             editor_extends="languages/base.html",
             check_categories=get_qualitycheck_schema(),
             previous_url=get_previous_url(request),
@@ -102,8 +101,7 @@ def _test_export_view(language, request, response, kwargs):
     # TODO: export views should be parsed in a form
     ctx = response.context
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_translatable(
-        request.profile, **kwargs)
+    units_qs = Unit.objects.get_translatable(request.user, **kwargs)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -38,7 +38,6 @@ from virtualfolder.models import VirtualFolderTreeItem
 
 def _test_translate_view(project, request, response, kwargs, settings):
     ctx = response.context
-    user = request.profile
     kwargs["project_code"] = project.code
     ctx_path = (
         "/projects/%(project_code)s/" % kwargs)
@@ -52,7 +51,6 @@ def _test_translate_view(project, request, response, kwargs, settings):
             is_admin=False,
             language=None,
             project=project,
-            profile=user,
             pootle_path=pootle_path,
             ctx_path=ctx_path,
             resource_path=resource_path,
@@ -105,7 +103,8 @@ def _test_browse_view(project, request, response, kwargs):
     items = [
         item_func(item)
         for item
-        in ob.get_children_for_user(request.profile)]
+        in ob.get_children_for_user(request.user)
+    ]
     items.sort(lambda x, y: locale.strcoll(x['title'], y['title']))
 
     table_fields = ['name', 'progress', 'total', 'need-translation',
@@ -142,8 +141,7 @@ def _test_export_view(project, request, response, kwargs):
     ctx = response.context
     kwargs["project_code"] = project.code
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_translatable(
-        request.profile, **kwargs)
+    units_qs = Unit.objects.get_translatable(request.user, **kwargs)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [
@@ -224,7 +222,6 @@ def test_view_projects_translate(client, settings):
         is_admin=False,
         language=None,
         project=None,
-        profile=request.profile,
         pootle_path="/projects/",
         ctx_path="/projects/",
         resource_path="",
@@ -249,8 +246,7 @@ def test_view_projects_export(client):
     ctx = response.context
     request = response.wsgi_request
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_translatable(
-        request.profile)
+    units_qs = Unit.objects.get_translatable(request.user)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -176,7 +176,6 @@ def _test_translate_view(tp, request, response, kwargs, settings):
         language=tp.language,
         project=tp.project,
         is_admin=check_permission('administrate', request),
-        profile=request.profile,
         ctx_path=tp.pootle_path,
         pootle_path=request_path,
         resource_path=resource_path,
@@ -198,8 +197,7 @@ def _test_translate_view(tp, request, response, kwargs, settings):
 def _test_export_view(tp, request, response, kwargs):
     ctx = response.context
     filter_name, filter_extra = get_filter_name(request.GET)
-    units_qs = Unit.objects.get_translatable(
-        request.profile, **kwargs)
+    units_qs = Unit.objects.get_translatable(request.user, **kwargs)
     units_qs = get_step_query(request, units_qs)
     units_qs = units_qs.select_related('store')
     unit_groups = [


### PR DESCRIPTION
I had to duplicate a _minimal_ part of `django.contrib.auth.middleware` but I think it's an acceptable trade-off. Now one can simply use `request.user` and forget about `request.profile` altogether.

Fixes #3459.