### PR TITLE
[RFC] Cleanup requirements

### DIFF
--- a/requirements/_docs.txt
+++ b/requirements/_docs.txt
@@ -1,0 +1,3 @@
+# Documentation
+
+sphinx

--- a/requirements/_lint.txt
+++ b/requirements/_lint.txt
@@ -1,0 +1,6 @@
+# Linting tools
+
+flake8!=2.5.3
+pep257
+pep8<1.6
+isort>=3.5.0,!=4.1.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,5 @@
+# Base requirements
+
 Django>=1.8.9,<1.9
 
 # Django apps

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,4 @@
+# Package building
+
 -r base.txt
 -r _docs.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,2 @@
 -r base.txt
-
-sphinx
+-r _docs.txt

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,6 +1,8 @@
+# Pootle deployment
+
 -r base.txt
 
-# Databases
+# Database
 MySQL-python>=1.2.1p2
 # Uncomment for PostgreSQL
 # psycopg2>=2.4.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
--r build.txt
+-r base.txt
 -r tests.txt
+-r _docs.txt
 
 django-debug-toolbar>=1.4
 django-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,12 +1,9 @@
 -r base.txt
 -r tests.txt
 -r _docs.txt
+-r _lint.txt
 
 django-debug-toolbar>=1.4
 django-extensions
-flake8!=2.5.3
 glue>=0.2.8.1
 ipython
-isort>=3.5.0,!=4.1.1
-pep257
-pep8<1.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,5 @@
+# Development
+
 -r base.txt
 -r tests.txt
 -r _docs.txt

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,5 @@
+# Testing
+
 factory_boy>=2.5.2
 pytest
 pytest-catchlog

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,13 +1,10 @@
 -r tests.txt
 -r _docs.txt
+-r _lint.txt
 
 tox>=2.3
 MySQL-python
 psycopg2
 coverage
 coveralls
-pep8<1.6
-pep257
-flake8!=2.5.3
-isort
 codecov

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,11 +1,11 @@
 -r tests.txt
+-r _docs.txt
 
 tox>=2.3
 MySQL-python
 psycopg2
 coverage
 coveralls
-sphinx
 pep8<1.6
 pep257
 flake8!=2.5.3

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,8 +7,8 @@
 tox>=2.3
 
 # Databases
-MySQL-python
-psycopg2
+MySQL-python>=1.2.1p2
+psycopg2>=2.4.5
 
 # Test coverage
 codecov

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,3 +1,5 @@
+# Travis testing https://travis-ci.org/translate/pootle
+
 -r tests.txt
 -r _docs.txt
 -r _lint.txt

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,8 +5,12 @@
 -r _lint.txt
 
 tox>=2.3
+
+# Databases
 MySQL-python
 psycopg2
+
+# Test coverage
+codecov
 coverage
 coveralls
-codecov

--- a/tools/find-dup-requirements.sh
+++ b/tools/find-dup-requirements.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+dups=$(cat requirements/*.txt | egrep -v "^#|^$|^-r" | cut -d">" -f1 | cut -d "<" -f1 | cut -d'!' -f1 | cut -d"=" -f1 | sort | uniq -d)
+
+for dup in $dups
+do
+    egrep $dup requirements/*.txt
+done


### PR DESCRIPTION
Would like some input with these proposed changes.  Summary here:

* Requirement listed in one place - they get out of sync and some of ours where already out of sync between dev and travis.
* Distinguish between private ``_x.txt`` and target ``x.txt`` build requirements.  Target are those you're likely to want, private are those on which various target requirements depend.  i.e. ``_lint.txt`` vs ``dev.txt``