### PR TITLE
[WIP] Denormalize Unit pootle_path, project and lang and add index

### DIFF
--- a/debug_sql.py
+++ b/debug_sql.py
@@ -1,0 +1,35 @@
+from django.db import connection
+from django.utils.log import getLogger
+
+logger = getLogger(__name__)
+
+class QueryCountDebugMiddleware(object):
+    """
+    This middleware will log the number of queries run
+    and the total time taken for each request (with a
+    status code of 200). It does not currently support
+    multi-db setups.
+    """
+    def process_request(self, request):
+        self.start = len(connection.queries)
+
+    def process_response(self, request, response):
+        if response.status_code == 200:
+            total_time = 0
+            for query in connection.queries:
+                print
+                print query                
+                query_time = query.get('time')
+                if query_time is None:
+                    query_time = query.get('duration', 0) / 1000
+                total_time += float(query_time)
+            logger.debug('%s queries run, total %s seconds' % (len(connection.queries), total_time))
+            print('%s queries run, total %s seconds' % (len(connection.queries), total_time))
+        import json
+        try:
+            content = json.loads(response.content)
+            content["queries"] = connection.queries
+            response.content = json.dumps(content)
+        except:
+            pass
+        return response

--- a/performance_tests.py
+++ b/performance_tests.py
@@ -1,0 +1,90 @@
+import time
+
+import requests
+
+
+BASE_URL = "http://localhost:8000/xhr/units/"
+PATHS_FILE = "paths.txt"
+
+PARAMS = [
+    "filter=all",
+    "filter=all&sort=oldest",
+    "filter=incomplete&sort=oldest",
+    "filter=translated&sort=oldest",
+    "filter=untranslated&sort=oldest"]
+
+
+class MarkdownTableFormatter(object):
+
+    def __init__(self, path_width=80, param_width=40, timing_width=8):
+        self.path_width = path_width
+        self.param_width = param_width
+        self.timing_width = timing_width
+
+    def format(self, performance_test):
+        results = list(
+            reversed(
+                sorted(
+                    performance_test.results,
+                    key=lambda res: res[2])))[:20]
+        print(
+            "|path%s|params%s|timing%s|"
+            % ((" " * (self.path_width - 4)),
+               (" " * (self.param_width - 6)),
+               (" " * (self.timing_width - 6))))
+        
+        print(
+            "|%s|%s|%s|"
+            % ("-" * self.path_width,
+               "-" * self.param_width,
+               "-" * self.timing_width))
+
+        for path, param, timing in results:
+            print (
+                "|%s%s|%s%s|%s%s|"
+                % (path, (" " * (self.path_width - len(path))),
+                   param, (" " * (self.param_width - len(param))),
+                   timing, (" " * (self.timing_width - len(timing)))))
+
+
+
+class GetUnitsPerformance(object):
+
+    def __init__(self, base_url=BASE_URL, paths_file=PATHS_FILE):
+        self.base_url = base_url
+        self.paths_file = paths_file
+
+    def get_paths(self):
+        with open(self.paths_file, "r") as f:
+            for line in f.readlines():
+                yield line.strip()
+
+    def get_params(self):
+        return PARAMS
+
+    @property
+    def results(self):
+        result = []
+
+        for path in self.get_paths():
+            for param in self.get_params():
+                start = time.time()
+                resp = requests.get(
+                    "%s?path=%s&initial=true&%s"
+                    % (self.base_url, path, param))
+                if not path.endswith("/"):
+                    timing = str(
+                        sum(float(t["time"])
+                            for t
+                            in resp.json()["queries"][-2:]))
+                else:
+                    timing = resp.json()["queries"][-1]["time"]
+                result.append(
+                    (path,
+                     param,
+                     timing))
+        return result
+
+
+def run():
+    MarkdownTableFormatter().format(GetUnitsPerformance())

--- a/pootle/__init__.py
+++ b/pootle/__init__.py
@@ -12,3 +12,5 @@ from pootle.core.utils.version import get_version
 VERSION = (2, 7, 3, 'beta', 1)
 
 __version__ = get_version(VERSION)
+
+default_app_config = 'pootle.apps.PootleConfig'

--- a/pootle/apps/__init__.py
+++ b/pootle/apps/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import importlib
+
+from django.apps import AppConfig
+
+
+class PootleConfig(AppConfig):
+
+    name = "pootle"
+    verbose_name = "Pootle"
+
+    def ready(self):
+        importlib.import_module("pootle.core.receivers")

--- a/pootle/apps/contact/views.py
+++ b/pootle/apps/contact/views.py
@@ -88,7 +88,7 @@ class ReportFormView(ContactFormView):
                             {
                                 'unit': unit,
                                 'language':
-                                    unit.store.translation_project.language.code,
+                                    unit.language.code,
                             }),
                         'body': render_to_string(
                             'contact_form/report_form_body.txt',
@@ -97,7 +97,7 @@ class ReportFormView(ContactFormView):
                                 'unit_absolute_url': unit_absolute_url,
                             }),
                         'report_email':
-                            unit.store.translation_project.project.report_email,
+                            unit.project.report_email,
                     })
             except Unit.DoesNotExist:
                 pass

--- a/pootle/apps/pootle_app/management/commands/contributors.py
+++ b/pootle/apps/pootle_app/management/commands/contributors.py
@@ -53,12 +53,12 @@ class Command(PootleCommand):
 
         if self.projects:
             units = units.filter(
-                store__translation_project__project__code__in=self.projects,
+                project__code__in=self.projects,
             )
 
         if self.languages:
             units = units.filter(
-                store__translation_project__language__code__in=self.languages,
+                language__code__in=self.languages,
             )
 
         contribs = Counter()

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -64,15 +64,15 @@ def server_stats_more(request):
 
         result = {}
         unit_query = Unit.objects.filter(state__gte=TRANSLATED).exclude(
-            store__translation_project__project__code__in=(
+            project__code__in=(
                 'pootle', 'tutorial', 'terminology')
         ).exclude(
-            store__translation_project__language__code='templates').order_by()
+            language__code='templates').order_by()
         result['store_count'] = unit_query.values('store').distinct().count()
         result['project_count'] = unit_query.values(
-            'store__translation_project__project').distinct().count()
+            'project').distinct().count()
         result['language_count'] = unit_query.values(
-            'store__translation_project__language').distinct().count()
+            'language').distinct().count()
         sums = sum_column(unit_query, ('source_wordcount',), count=True)
         result['string_count'] = sums['count']
         result['word_count'] = sums['source_wordcount'] or 0

--- a/pootle/apps/pootle_store/apps.py
+++ b/pootle/apps/pootle_store/apps.py
@@ -6,4 +6,15 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-default_app_config = 'pootle_store.apps.PootleStoreConfig'
+import importlib
+
+from django.apps import AppConfig
+
+
+class PootleStoreConfig(AppConfig):
+
+    name = "pootle_store"
+    verbose_name = "Pootle Store"
+
+    def ready(self):
+        importlib.import_module("pootle_store.receivers")

--- a/pootle/apps/pootle_store/migrations/0008_unit_pootle_path.py
+++ b/pootle/apps/pootle_store/migrations/0008_unit_pootle_path.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0007_case_sensitive_schema'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unit',
+            name='pootle_path',
+            field=models.CharField(default='', unique=False, max_length=255, verbose_name='Path', db_index=True),
+            preserve_default=False,
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0009_denormalize_pootle_path.py
+++ b/pootle/apps/pootle_store/migrations/0009_denormalize_pootle_path.py
@@ -1,0 +1,24 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def denormalize_pootle_path(apps, schema_editor):
+
+    Store = apps.get_model("pootle_store", "Store")
+    Unit = apps.get_model("pootle_store", "Unit")
+    paths = Store.objects.values_list("pootle_path", flat=True)
+    for pootle_path in paths.iterator():
+        Unit.objects.filter(
+            store__pootle_path=pootle_path).update(pootle_path=pootle_path)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0008_unit_pootle_path'),
+    ]
+
+    operations = [
+        migrations.RunPython(denormalize_pootle_path),
+    ]

--- a/pootle/apps/pootle_store/migrations/0010_unit_path_schema.py
+++ b/pootle/apps/pootle_store/migrations/0010_unit_path_schema.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from pootle.core.utils.db import set_mysql_collation_for_column
+
+
+def make_unit_paths_cs(apps, schema_editor):
+    cursor = schema_editor.connection.cursor()
+    set_mysql_collation_for_column(
+        apps,
+        cursor,
+        "pootle_store.Unit",
+        "pootle_path",
+        "utf8_bin",
+        "varchar(255)")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0009_denormalize_pootle_path'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_unit_paths_cs),
+        migrations.AlterIndexTogether(
+            name='unit',
+            index_together=set([('pootle_path', 'index')]),
+        ),
+        migrations.AlterModelOptions(
+            name='unit',
+            options={'ordering': ['pootle_path', 'index'], 'get_latest_by': 'mtime'},
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0011_cleanup_orphaned_units.py
+++ b/pootle/apps/pootle_store/migrations/0011_cleanup_orphaned_units.py
@@ -1,0 +1,30 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def cleanup_orphaned_units(apps, schema_editor):
+    Unit = apps.get_model("pootle_store", "Unit")
+    Project = apps.get_model("pootle_project", "Project")
+    Language = apps.get_model("pootle_language", "Language")
+
+    project_ids = Project.objects.values_list("pk", flat=True)
+    language_ids = Language.objects.values_list("pk", flat=True)
+
+    Unit.objects.exclude(store__translation_project__project_id__in=project_ids).delete()
+    Unit.objects.exclude(store__translation_project__language_id__in=language_ids).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_translationproject', '0002_remove_translationproject_disabled'),
+        ('pootle_store', '0010_unit_path_schema')
+    ]
+
+    operations = [
+        migrations.RunPython(cleanup_orphaned_units),
+    ]
+
+
+

--- a/pootle/apps/pootle_store/migrations/0012_unit_language.py
+++ b/pootle/apps/pootle_store/migrations/0012_unit_language.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_language', '0002_case_insensitive_schema'),
+        ('pootle_store', '0011_cleanup_orphaned_units'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unit',
+            name='language',
+            field=models.ForeignKey(related_name='units', blank=True, to='pootle_language.Language', null=True),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0013_denormalize_language.py
+++ b/pootle/apps/pootle_store/migrations/0013_denormalize_language.py
@@ -1,0 +1,28 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+def denormalize_language(apps, schema_editor):
+    Unit = apps.get_model("pootle_store", "Unit")
+    Store = apps.get_model("pootle_store", "Store")
+    stores = Store.objects.values_list(
+        "pk", "translation_project__language_id")
+
+    for store_id, language_id in stores.iterator():
+        if not language_id:
+            continue 
+        units = Unit.objects.filter(
+            store_id=store_id).exclude(language_id=language_id)
+        if units.count() == 0:
+            continue
+        units.update(language_id=language_id)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0012_unit_language')
+    ]
+
+    operations = [
+        migrations.RunPython(denormalize_language),
+    ]

--- a/pootle/apps/pootle_store/migrations/0014_make_unit_language_notnull.py
+++ b/pootle/apps/pootle_store/migrations/0014_make_unit_language_notnull.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0013_denormalize_language'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='unit',
+            name='language',
+            field=models.ForeignKey(related_name='units', to='pootle_language.Language'),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0015_unit_project.py
+++ b/pootle/apps/pootle_store/migrations/0015_unit_project.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_project', '0003_case_sensitive_schema'),
+        ('pootle_store', '0014_make_unit_language_notnull'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='unit',
+            name='project',
+            field=models.ForeignKey(related_name='units', blank=True, to='pootle_project.Project', null=True),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0016_denormalize_project.py
+++ b/pootle/apps/pootle_store/migrations/0016_denormalize_project.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def denormalize_project(apps, schema_editor):
+    Unit = apps.get_model("pootle_store", "Unit")
+    Store = apps.get_model("pootle_store", "Store")
+    stores = Store.objects.values_list(
+        "pk", "translation_project__project_id")
+
+    for store_id, project_id in stores.iterator():
+        if not project_id:
+            continue 
+        units = Unit.objects.filter(
+            store_id=store_id).exclude(project_id=project_id)
+        if units.count() == 0:
+            continue
+        units.update(project_id=project_id)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_translationproject', '0002_remove_translationproject_disabled'),
+        ('pootle_store', '0015_unit_project')
+    ]
+
+    operations = [
+        migrations.RunPython(denormalize_project),
+    ]

--- a/pootle/apps/pootle_store/migrations/0017_make_unit_project_notnull.py
+++ b/pootle/apps/pootle_store/migrations/0017_make_unit_project_notnull.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0016_denormalize_project'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='unit',
+            name='project',
+            field=models.ForeignKey(related_name='units', to='pootle_project.Project'),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0018_index_proj_lang_together.py
+++ b/pootle/apps/pootle_store/migrations/0018_index_proj_lang_together.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0017_make_unit_project_notnull'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='unit',
+            index_together=set([('pootle_path', 'index', 'state', 'project', 'language'), ('priority', 'pootle_path', 'index', 'state', 'project', 'language'), ('submitted_on', 'pootle_path', 'index', 'state', 'project', 'language'), ('mtime', 'pootle_path', 'index', 'state', 'project', 'language')]),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0019_add_store_name_index.py
+++ b/pootle/apps/pootle_store/migrations/0019_add_store_name_index.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0018_index_proj_lang_together'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='store',
+            name='name',
+            field=models.CharField(max_length=128, editable=False, db_index=True),
+        ),
+    ]

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -511,8 +511,8 @@ class Unit(models.Model, base.TranslationUnit):
 
     def delete(self, *args, **kwargs):
         action_log(user='system', action=UNIT_DELETED,
-                   lang=self.store.translation_project.language.code,
-                   unit=self.id, translation='', path=self.store.pootle_path)
+                   lang=self.language.code,
+                   unit=self.id, translation='', path=self.pootle_path)
 
         self.flag_store_before_going_away()
 
@@ -577,9 +577,9 @@ class Unit(models.Model, base.TranslationUnit):
 
         if not created and hasattr(self, '_save_action'):
             action_log(user=self._log_user, action=self._save_action,
-                       lang=self.store.translation_project.language.code,
+                       lang=self.language.code,
                        unit=self.id, translation=self.target_f,
-                       path=self.store.pootle_path)
+                       path=self.pootle_path)
 
         if (self._state_updated and self.state == TRANSLATED and
             self._save_action == TRANSLATION_CHANGED and
@@ -608,9 +608,9 @@ class Unit(models.Model, base.TranslationUnit):
                 self.store.mark_dirty(CachedMethods.WORDCOUNT_STATS)
 
             action_log(user=self._log_user, action=self._save_action,
-                       lang=self.store.translation_project.language.code,
+                       lang=self.language.code,
                        unit=self.id, translation=self.target_f,
-                       path=self.store.pootle_path)
+                       path=self.pootle_path)
 
             self.add_initial_submission(user=user)
 
@@ -642,7 +642,7 @@ class Unit(models.Model, base.TranslationUnit):
                '#unit=%s' % unicode(self.id)))
 
     def get_search_locations_url(self, **kwargs):
-        lang, proj, dir, fn = split_pootle_path(self.store.pootle_path)
+        lang, proj, dir, fn = split_pootle_path(self.pootle_path)
 
         return u''.join([
             reverse('pootle-project-translate', args=[proj, dir, fn]),
@@ -650,8 +650,7 @@ class Unit(models.Model, base.TranslationUnit):
         ])
 
     def get_screenshot_url(self):
-        prefix = self.store.translation_project.\
-            project.screenshot_search_prefix
+        prefix = self.project.screenshot_search_prefix
         if prefix:
             return prefix + urlquote(self.source_f)
 
@@ -665,7 +664,7 @@ class Unit(models.Model, base.TranslationUnit):
 
         from pootle_project.models import Project
         user_projects = Project.accessible_by_user(user)
-        return self.store.translation_project.project.code in user_projects
+        return self.project.code in user_projects
 
     def add_initial_submission(self, user=None):
         if self.istranslated() or self.isfuzzy():
@@ -758,7 +757,7 @@ class Unit(models.Model, base.TranslationUnit):
 
         if unit.target != self.target:
             if unit.hasplural():
-                nplurals = self.store.translation_project.language.nplurals
+                nplurals = self.language.nplurals
                 target_plurals = len(self.target.strings)
                 strings = self.target.strings
                 if target_plurals < nplurals:
@@ -1001,8 +1000,8 @@ class Unit(models.Model, base.TranslationUnit):
             'id': self.id,
             # 'revision' must be an integer for statistical queries to work
             'revision': self.revision,
-            'project': self.store.translation_project.project.fullname,
-            'path': self.store.pootle_path,
+            'project': self.project.fullname,
+            'path': self.pootle_path,
             'source': self.source,
             'target': self.target,
             'username': '',
@@ -1023,7 +1022,7 @@ class Unit(models.Model, base.TranslationUnit):
                 'email_md5': md5(self.submitted_by.email).hexdigest(),
             })
 
-        get_tm_broker().update(self.store.translation_project.language.code,
+        get_tm_broker().update(self.language.code,
                                obj)
 
     def get_tm_suggestions(self):

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -302,6 +302,13 @@ class Unit(models.Model, base.TranslationUnit):
     unitid_hash = models.CharField(max_length=32, db_index=True,
                                    editable=False)
 
+    # Denormalized from Store.pootle_path
+    # any changes to the `pootle_path` field may require updating the schema
+    # see migration 0007_case_sensitive_schema.py
+    pootle_path = models.CharField(
+        max_length=255, null=False, unique=False,
+        db_index=True, verbose_name=_("Path"))
+
     source_f = MultiStringField(null=True)
     source_hash = models.CharField(max_length=32, db_index=True,
                                    editable=False)
@@ -442,6 +449,8 @@ class Unit(models.Model, base.TranslationUnit):
             User = get_user_model()
             self._log_user = User.objects.get_system_user()
         user = kwargs.pop("user", self._log_user)
+
+        self.pootle_path = self.store.pootle_path
 
         if created:
             self._save_action = UNIT_ADDED

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -318,8 +318,7 @@ class Unit(models.Model, base.TranslationUnit):
     # denormalized TP.project
     project = models.ForeignKey(
         "pootle_project.Project",
-        null=True,
-        blank=True,
+        null=False,
         db_index=True,
         related_name='units')
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -262,7 +262,7 @@ class UnitManager(models.Manager):
                 store__translation_project__language__code=language_code)
         else:
             units_qs = units_qs.exclude(
-                store__pootle_path__startswith="/templates/")
+                pootle_path__startswith="/templates/")
 
         if project_code:
             units_qs = units_qs.filter(
@@ -282,17 +282,17 @@ class UnitManager(models.Manager):
         if language_code and project_code:
             if filename:
                 return units_qs.filter(
-                    store__pootle_path=pootle_path)
+                    pootle_path=pootle_path)
             else:
                 return units_qs.filter(
-                    store__pootle_path__startswith=pootle_path)
+                    pootle_path__startswith=pootle_path)
         else:
             # we need to use a regex in this case as lang or proj are not
             # set
             if filename:
                 pootle_path = "%s$" % pootle_path
             return units_qs.filter(
-                store__pootle_path__regex=pootle_path)
+                pootle_path__regex=pootle_path)
 
 
 class Unit(models.Model, base.TranslationUnit):

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -362,7 +362,8 @@ class Unit(models.Model, base.TranslationUnit):
     class Meta(object):
         unique_together = ('store', 'unitid_hash')
         get_latest_by = 'mtime'
-        index_together = [["store", "index"]]
+        index_together = ["pootle_path", "index"]
+        ordering = ["pootle_path", "index"]
 
     # # # # # # # # # # # # # #  Properties # # # # # # # # # # # # # # # # # #
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -218,9 +218,7 @@ class UnitManager(models.Manager):
 
     def live(self):
         """Filters non-obsolete units."""
-        return self.filter(
-            state__in=(
-                UNTRANSLATED, TRANSLATED, FUZZY))
+        return self.filter(state__gt=OBSOLETE)
 
     def get_for_user(self, user, project_code=None):
         """Filters units for a specific user.

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -43,6 +43,7 @@ from pootle.core.url_helpers import (
     get_all_pootle_paths, get_editor_filter, split_pootle_path)
 from pootle.core.utils import dateformat
 from pootle.core.utils.timezone import datetime_min, make_aware
+from pootle_app.models import Directory
 from pootle_misc.aggregate import max_column
 from pootle_misc.checks import check_names, get_checker, run_given_filters
 from pootle_misc.util import import_func
@@ -309,6 +310,12 @@ class UnitManager(models.Manager):
             project_code or PROJECT_REGEX,
             dir_path or "",
             filename or "")
+
+        if dir_path and not filename:
+            relevant_directory = Directory.objects.filter(
+                pootle_path__regex=pootle_path)
+            if not relevant_directory.exists():
+                return units_qs.none()
 
         if language_code and project_code:
             if filename:

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1399,7 +1399,8 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
                                    db_index=True, verbose_name=_("Path"))
     # any changes to the `name` field may require updating the schema
     # see migration 0007_case_sensitive_schema.py
-    name = models.CharField(max_length=128, null=False, editable=False)
+    name = models.CharField(
+        max_length=128, null=False, editable=False, db_index=True)
 
     file_mtime = models.DateTimeField(default=datetime_min)
     state = models.IntegerField(null=False, default=NEW, editable=False,

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -309,6 +309,14 @@ class Unit(models.Model, base.TranslationUnit):
         max_length=255, null=False, unique=False,
         db_index=True, verbose_name=_("Path"))
 
+    # denormalized TP.language
+    language = models.ForeignKey(
+        "pootle_language.Language",
+        null=True,
+        blank=True,
+        db_index=True,
+        related_name='units')
+
     source_f = MultiStringField(null=True)
     source_hash = models.CharField(max_length=32, db_index=True,
                                    editable=False)
@@ -452,6 +460,7 @@ class Unit(models.Model, base.TranslationUnit):
         user = kwargs.pop("user", self._log_user)
 
         self.pootle_path = self.store.pootle_path
+        self.language = self.store.translation_project.language
 
         if created:
             self._save_action = UNIT_ADDED

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -315,6 +315,13 @@ class Unit(models.Model, base.TranslationUnit):
         null=False,
         db_index=True,
         related_name='units')
+    # denormalized TP.project
+    project = models.ForeignKey(
+        "pootle_project.Project",
+        null=True,
+        blank=True,
+        db_index=True,
+        related_name='units')
 
     source_f = MultiStringField(null=True)
     source_hash = models.CharField(max_length=32, db_index=True,
@@ -460,6 +467,7 @@ class Unit(models.Model, base.TranslationUnit):
 
         self.pootle_path = self.store.pootle_path
         self.language = self.store.translation_project.language
+        self.project = self.store.translation_project.project
 
         if created:
             self._save_action = UNIT_ADDED

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -312,8 +312,7 @@ class Unit(models.Model, base.TranslationUnit):
     # denormalized TP.language
     language = models.ForeignKey(
         "pootle_language.Language",
-        null=True,
-        blank=True,
+        null=False,
         db_index=True,
         related_name='units')
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -375,7 +375,16 @@ class Unit(models.Model, base.TranslationUnit):
     class Meta(object):
         unique_together = ('store', 'unitid_hash')
         get_latest_by = 'mtime'
-        index_together = ["pootle_path", "index"]
+        index_together = [
+            ["pootle_path", "index",
+             "state", "project", "language"],
+            ["submitted_on", "pootle_path", "index",
+             "state", "project", "language"],
+            ["mtime", "pootle_path", "index",
+             "state", "project", "language"],
+            ["priority", "pootle_path", "index",
+             "state", "project", "language"]]
+
         ordering = ["pootle_path", "index"]
 
     # # # # # # # # # # # # # #  Properties # # # # # # # # # # # # # # # # # #

--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from pootle_store.models import Store
+
+
+@receiver(pre_save, sender=Store)
+def store_unit_pre_save_handler(sender, instance, **kwargs):
+    """If a Store's pootle_path changes then update the pootle_path on the
+    Store's Units.
+    """
+
+    if instance.pk is None:
+        return
+
+    original = Store.objects.get(pk=instance.pk)
+    if original.pootle_path != instance.pootle_path:
+        original.units.update(pootle_path=instance.pootle_path)

--- a/pootle/apps/pootle_store/templatetags/store_tags.py
+++ b/pootle/apps/pootle_store/templatetags/store_tags.py
@@ -174,7 +174,7 @@ def pluralize_target(unit, nplurals=None):
 
     if nplurals is None:
         try:
-            nplurals = unit.store.translation_project.language.nplurals
+            nplurals = unit.language.nplurals
         except ObjectDoesNotExist:
             pass
     forms = []

--- a/pootle/apps/pootle_store/unit/filters.py
+++ b/pootle/apps/pootle_store/unit/filters.py
@@ -6,11 +6,9 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.db.models import Q
-
 from pootle_statistics.models import SubmissionTypes
 from pootle_store.models import SuggestionStates
-from pootle_store.util import FUZZY, TRANSLATED, UNTRANSLATED
+from pootle_store.util import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 
 
 class FilterNotFound(Exception):
@@ -53,20 +51,19 @@ class UnitStateFilter(BaseUnitFilter):
     """Filter a Unit qs based on unit state"""
 
     def filter_all(self):
-        return self.qs.all()
+        return self.qs
 
     def filter_translated(self):
-        return self.qs.filter(state=TRANSLATED)
+        return self.qs.filter(state__gt=FUZZY)
 
     def filter_untranslated(self):
-        return self.qs.filter(state=UNTRANSLATED)
+        return self.qs.filter(state__gt=OBSOLETE, state__lt=FUZZY)
 
     def filter_fuzzy(self):
-        return self.qs.filter(state=FUZZY)
+        return self.qs.filter(state__gt=UNTRANSLATED, state__lt=TRANSLATED)
 
     def filter_incomplete(self):
-        return self.qs.filter(
-            Q(state=UNTRANSLATED) | Q(state=FUZZY))
+        return self.qs.filter(state__gt=OBSOLETE, state__lt=TRANSLATED)
 
 
 class UnitContributionFilter(BaseUnitFilter):

--- a/pootle/apps/pootle_store/unit/results.py
+++ b/pootle/apps/pootle_store/unit/results.py
@@ -27,10 +27,6 @@ class UnitResult(UnitProxy):
             "store__translation_project__language__nplurals"] or 0
 
     @property
-    def pootle_path(self):
-        return self.unit["store__pootle_path"]
-
-    @property
     def project_code(self):
         return self.unit["store__translation_project__project__code"]
 
@@ -108,7 +104,7 @@ class GroupedResults(object):
         "source_f",
         "target_f",
         "state",
-        "store__pootle_path",
+        "pootle_path",
         "store__translation_project__project__code",
         "store__translation_project__project__source_language__code",
         "store__translation_project__project__checkstyle",
@@ -123,7 +119,7 @@ class GroupedResults(object):
         unit_groups = []
         units_by_path = groupby(
             self.units_qs.values(*self.select_fields),
-            lambda x: x["store__pootle_path"])
+            lambda x: x["pootle_path"])
         for pootle_path, units in units_by_path:
             unit_groups.append({pootle_path: StoreResults(units).data})
         return unit_groups

--- a/pootle/apps/pootle_store/unit/results.py
+++ b/pootle/apps/pootle_store/unit/results.py
@@ -11,8 +11,8 @@ from itertools import groupby
 
 from django.core.urlresolvers import reverse
 
+from pootle.core.site import pootle_site
 from pootle.core.url_helpers import split_pootle_path
-from pootle.i18n.gettext import language_dir
 from pootle_store.models import FUZZY
 from pootle_store.templatetags.store_tags import (
     pluralize_source, pluralize_target)
@@ -22,36 +22,40 @@ from pootle_store.unit.proxy import UnitProxy
 class UnitResult(UnitProxy):
 
     @property
+    def language(self):
+        return pootle_site.get_language(self.unit["language_id"])
+
+    @property
     def nplurals(self):
-        return self.unit[
-            "store__translation_project__language__nplurals"] or 0
+        return self.language["nplurals"] or 0
+
+    @property
+    def project(self):
+        return pootle_site.get_project(self.unit["project_id"])
 
     @property
     def project_code(self):
-        return self.unit["store__translation_project__project__code"]
+        return self.project["code"]
 
     @property
     def project_style(self):
-        return self.unit[
-            "store__translation_project__project__checkstyle"]
+        return self.project["checkstyle"]
 
     @property
     def source_dir(self):
-        return language_dir(self.source_lang)
+        return pootle_site.languages[self.source_lang]["direction"]
 
     @property
     def source_lang(self):
-        return self.unit[
-            "store__translation_project__project__source_language__code"]
+        return pootle_site.get_language(self.project["source_language"])["code"]
 
     @property
     def target_dir(self):
-        return language_dir(self.target_lang)
+        return pootle_site.languages[self.target_lang]["direction"]
 
     @property
     def target_lang(self):
-        return self.unit[
-            "store__translation_project__language__code"]
+        return self.language["code"]
 
     @property
     def translate_url(self):
@@ -105,11 +109,8 @@ class GroupedResults(object):
         "target_f",
         "state",
         "pootle_path",
-        "store__translation_project__project__code",
-        "store__translation_project__project__source_language__code",
-        "store__translation_project__project__checkstyle",
-        "store__translation_project__language__code",
-        "store__translation_project__language__nplurals"]
+        "project_id",
+        "language_id"]
 
     def __init__(self, units_qs):
         self.units_qs = units_qs

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -103,7 +103,7 @@ class DBSearchBackend(object):
                 # use `distinct()` and `order_by()` at the same time
                 qs = qs.annotate(sort_by_field=Max(max_field))
             return qs.order_by(
-                sort_by, "store__pootle_path", "index")
+                sort_by, "pootle_path", "index")
         return qs
 
     def filter_qs(self, qs):

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -149,7 +149,7 @@ class DBSearchBackend(object):
         end = 2 * self.chunk_size
         if self.initial:
             results = self.results
-            uid_list = list(results.values_list('id', flat=True))
+            uid_list = 5 # list(results.values_list('id', flat=True))
             if len(self.uids) == 1:
                 if self.uids[0] not in uid_list:
                     return [], results.none()

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -114,6 +114,9 @@ class DBSearchBackend(object):
         user = kwargs['user']
         vfolder = kwargs["vfolder"]
 
+        if self.sort_by in ["submitted_on", "-submitted_on"]:
+            qs = qs.exclude(submitted_on__isnull=True)
+
         if vfolder is not None:
             qs = qs.filter(vfolders=vfolder)
 

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -18,10 +18,7 @@ from pootle_store.views import SIMPLY_SORTED
 class DBSearchBackend(object):
 
     default_chunk_size = 9
-    default_order = "store", "index"
-    select_related = (
-        'store__translation_project__project',
-        'store__translation_project__language')
+    default_order = "pootle_path", "index"
 
     def __init__(self, request_user, **kwargs):
         self.kwargs = kwargs
@@ -85,8 +82,7 @@ class DBSearchBackend(object):
     def units_qs(self):
         return (
             Unit.objects.get_translatable(**self.qs_kwargs)
-                        .order_by(*self.default_order)
-                        .select_related(*self.select_related))
+                        .order_by(*self.default_order))
 
     def sort_qs(self, qs):
         if self.unit_filter and self.sort_by is not None:

--- a/pootle/apps/pootle_store/util.py
+++ b/pootle/apps/pootle_store/util.py
@@ -71,11 +71,11 @@ def find_altsrcs(unit, alt_src_langs, store=None, project=None):
 
     altsrcs = Unit.objects.filter(
         unitid_hash=unit.unitid_hash,
-        store__translation_project__project=project,
-        store__translation_project__language__in=alt_src_langs,
-        state=TRANSLATED).select_related(
-            'store', 'store__translation_project',
-            'store__translation_project__language')
+        project_id=project.id,
+        language__in=alt_src_langs,
+        state=TRANSLATED).select_related('store',
+                                         'store__translation_project',
+                                         'language')
 
     if project.get_treestyle() == 'nongnu':
         altsrcs = filter(lambda x: x.store.path == store.path, altsrcs)

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -57,8 +57,8 @@ from .util import STATES_MAP, find_altsrcs, get_search_backend
 ALLOWED_SORTS = {
     'units': {
         'priority': '-priority',
-        'oldest': 'submitted_on',
-        'newest': '-submitted_on',
+        'oldest': 'mtime',
+        'newest': '-mtime',
     },
     'suggestions': {
         'oldest': 'suggestion__creation_time',

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -442,7 +442,7 @@ def get_edit_unit(request, unit):
     altsrcs = find_altsrcs(unit, alt_src_langs, store=store, project=project)
     source_language = translation_project.project.source_language
     sources = {
-        unit.store.translation_project.language.code: unit.target_f.strings
+        unit.language.code: unit.target_f.strings
         for unit in altsrcs
     }
     sources[source_language.code] = unit.source_f.strings

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -153,7 +153,7 @@ class VirtualFolder(models.Model):
                     if Directory.objects.filter(pootle_path=vf_file).exists():
                         qs = Unit.objects.filter(
                             state__gt=OBSOLETE,
-                            store__pootle_path__startswith=vf_file
+                            pootle_path__startswith=vf_file
                         )
                         self.units.add(*qs)
                         vfolder_stores_set.update(Store.objects.filter(

--- a/pootle/apps/virtualfolder/receivers.py
+++ b/pootle/apps/virtualfolder/receivers.py
@@ -34,7 +34,7 @@ def update_vfolder_tree(vf, store):
 def add_unit_to_vfolders(unit):
     """For a given Unit check for membership of any VirtualFolders
     """
-    pootle_path = unit.store.pootle_path
+    pootle_path = unit.pootle_path
 
     for vf in VirtualFolder.objects.iterator():
         unit_added = False
@@ -88,8 +88,9 @@ def vfolder_unit_priority_presave_handler(sender, instance, **kwargs):
     for location in removed_locations:
         # reindex these units without this vfolder
         removed_units = (
-            Unit.objects.filter(store__pootle_path__startswith=location,
-                                vfolders=original))
+            Unit.objects.filter(
+                pootle_path__startswith=location,
+                vfolders=original))
         for unit in removed_units.iterator():
             unit.vfolders.remove(original)
             unit.set_priority()

--- a/pootle/core/receivers.py
+++ b/pootle/core/receivers.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from pootle.core.site import pootle_site
+from pootle_language.models import Language
+from pootle_project.models import Project
+
+
+@receiver(pre_save, sender=Language)
+def language_cache_expiry_pre_save_handler(sender, instance, **kwargs):
+    """Expire pootle.core.site.pootle_site Languages
+    """
+    if "languages" in pootle_site.__dict__:
+        del pootle_site.__dict__["languages"]
+
+
+@receiver(pre_save, sender=Project)
+def project_cache_expiry_pre_save_handler(sender, instance, **kwargs):
+    """Expire pootle.core.site.pootle_site Projects
+    """
+    if "projects" in pootle_site.__dict__:
+        del pootle_site.__dict__["projects"]

--- a/pootle/core/search/backends/elasticsearch.py
+++ b/pootle/core/search/backends/elasticsearch.py
@@ -102,7 +102,7 @@ class ElasticSearchBackend(SearchBackend):
     def search(self, unit):
         counter = {}
         res = []
-        language = unit.store.translation_project.language.code
+        language = unit.language.code
         es_res = self._es_call(
             "search",
             index=self._settings['INDEX_NAME'],

--- a/pootle/core/site.py
+++ b/pootle/core/site.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.utils.functional import cached_property
+from django.utils.lru_cache import lru_cache
+
+from pootle.i18n.gettext import language_dir
+from pootle_language.models import Language
+from pootle_project.models import Project
+from pootle_translationproject.models import TranslationProject
+
+
+class PootleSite(object):
+
+    @cached_property
+    def languages(self):
+        languages = {
+            lang["code"]: lang
+            for lang
+            in Language.objects.values("code", "pk", "nplurals")}
+        for code, language in languages.items():
+            language["direction"] = language_dir(code)
+            language["projects"] = self.projects_for_language(language["pk"])
+        return languages
+
+    @cached_property
+    def projects(self):
+        projects = {
+            proj["code"]: proj
+            for proj
+            in Project.objects.values(
+                "code", "pk", "disabled", "source_language", "checkstyle")}
+        for project in projects.values():
+            project["source_direction"] = self.get_language(
+                project["source_language"])["direction"]
+            project["languages"] = self.languages_for_project(project["pk"])
+        return projects
+
+    @cached_property
+    def active_languages(self):
+        return set(
+            TranslationProject.objects.values_list(
+                "language_id", flat=True))
+
+    @cached_property
+    def active_projects(self):
+        return set(
+            Project.objects.values_list("id", flat=True))
+
+    @lru_cache()
+    def languages_for_project(self, project_id):
+        return set(
+            TranslationProject.objects.filter(
+                project_id=project_id).values_list("language_id", flat=True))
+
+    @lru_cache()
+    def projects_for_language(self, language_id):
+        return set(
+            TranslationProject.objects.filter(
+                language_id=language_id).values_list("project_id", flat=True))
+
+    @property
+    def disabled_projects(self):
+        return [
+            proj["pk"]
+            for proj
+            in self.projects.values()
+            if proj["disabled"]]
+
+    def get_language(self, language_id):
+        for code, language in self.languages.items():
+            if language["pk"] == language_id:
+                return language
+
+    def get_project(self, project_id):
+        for code, project in self.projects.items():
+            if project["pk"] == project_id:
+                return project
+
+pootle_site = PootleSite()

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -656,7 +656,7 @@ class PootleExportView(PootleDetailView):
         unit_groups = [
             (path, list(units))
             for path, units
-            in groupby(units_qs, lambda x: x.store.pootle_path)]
+            in groupby(units_qs, lambda x: x.pootle_path)]
 
         ctx.update(
             {'unit_groups': unit_groups,

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -101,10 +101,10 @@
             {% for altunit in altsrcs %}
             <div class="source-language alternative">
               <div class="translation-text-headers" lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
-                <div class="language-name">{{ altunit.store.translation_project.language.name }}</div>
+                <div class="language-name">{{ altunit.language.name }}</div>
                 {% if cansuggest or cantranslate %}
                 <div class="translate-toolbar">
-                  <span class="js-mt-{{ altunit.store.translation_project.language.code }}"></span>
+                  <span class="js-mt-{{ altunit.language.code }}"></span>
                   <a class="icon-copy js-copyoriginal" data-uid="{{ altunit.id }}"
                      title="{% trans 'Copy into translation' %}" accesskey="c"></a>
                 </div>
@@ -113,7 +113,7 @@
               <div id="js-unit-{{ altunit.id }}"
                    class="translate-original{% if unit.hasplural %} translate-plural{% endif %}">
                 {% for i, target, title in altunit|pluralize_target %}
-                <div class="translation-text js-translation-text" lang="{{ altunit.store.translation_project.language.code }}" dir="{{ altunit.store.translation_project.language.direction }}"{% if title %} title="{{ title }}"{% endif %}>{{ target|fancy_highlight }}</div>
+                <div class="translation-text js-translation-text" lang="{{ altunit.language.code }}" dir="{{ altunit.language.direction }}"{% if title %} title="{{ title }}"{% endif %}>{{ target|fancy_highlight }}</div>
                 {% endfor %}
                 <div class="placeholder"></div>
               </div>

--- a/pytest_pootle/search.py
+++ b/pytest_pootle/search.py
@@ -53,7 +53,7 @@ def calculate_search_results(kwargs, user):
                 "directory", "vfolder"))
     qs = (
         Unit.objects.get_translatable(user=user, **resolve(pootle_path).kwargs)
-                    .filter(store__pootle_path__startswith=pootle_path)
+                    .filter(pootle_path__startswith=pootle_path)
                     .order_by("store", "index"))
     if vfolder is not None:
         qs = qs.filter(vfolders=vfolder)
@@ -80,7 +80,7 @@ def calculate_search_results(kwargs, user):
         if sort_by is not None:
             # filtered sort
             if sort_on in SIMPLY_SORTED:
-                qs = qs.order_by(sort_by, "store__pootle_path", "index")
+                qs = qs.order_by(sort_by, "pootle_path", "index")
             else:
                 if sort_by[0] == '-':
                     max_field = sort_by[1:]
@@ -90,7 +90,7 @@ def calculate_search_results(kwargs, user):
                     sort_order = 'sort_by_field'
                 qs = (
                     qs.annotate(sort_by_field=Max(max_field))
-                      .order_by(sort_order, "store__pootle_path", "index"))
+                      .order_by(sort_order, "pootle_path", "index"))
     # text search
     if search and sfields:
         qs = UnitTextSearch(qs).search(
@@ -114,7 +114,7 @@ def calculate_search_results(kwargs, user):
     unit_groups = []
     units_by_path = groupby(
         qs.values(*GroupedResults.select_fields)[begin:end],
-        lambda x: x["store__pootle_path"])
+        lambda x: x["pootle_path"])
     for pootle_path, units in units_by_path:
         unit_groups.append(
             {pootle_path: StoreResults(units).data})


### PR DESCRIPTION
Denormalize project to unit to allow fast filtering and indexing together with language.
BEFORE: [version](https://github.com/translate/pootle/tree/2c525a484c1d81512639641adb784a095ae6f41c) before any get_units refactoring.
AFTER: current PR.
The timings are specifically for the get_units db call - with the uIds call switched off.

### /projects/translate
AFTER: ~~.004s~~ .002s
BEFORE: ∞ 

### /projects/firefox/translate
AFTER: ~~.004s~~ .002s
BEFORE: ~~154s~~, >5s

### /ru/firefox/translate
AFTER: ~~.29s~~ ~~.31s~~ .002s
BEFORE: 0.02s

### /ru/translate/
AFTER: ~~.29s~~ ~~.31s~~ .012s
BEFORE: 0.05s

### /projects/firefox/translate/browser/branding/official/brand.dtd.po
AFTER: ~~.26s~~ ~~.248s~~ .23s
BEFORE: 0.261s

### /ru/firefox/translate/browser/branding/official/brand.dtd.po
AFTER: ~~.001s~~ .001s
BEFORE: .001s

### /projects/firefox/translate/browser/branding/
AFTER: ~~.114s~~ ~~.104s~~ .099s
BEFORE: 0.2s

### /ru/firefox/translate/browser/branding/
AFTER: ~~137s~~ .001s
BEFORE: .001s