### PR TITLE
Add Pootle FS app to manage syncing with filesystems

### DIFF
--- a/pootle/apps/pootle_fs/apps.py
+++ b/pootle/apps/pootle_fs/apps.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import importlib
+
 from django.apps import AppConfig
 
 
@@ -13,3 +15,8 @@ class PootleFSConfig(AppConfig):
 
     name = "pootle_fs"
     verbose_name = "Pootle Filesystem synchronisation"
+
+    def ready(self):
+        importlib.import_module("pootle_fs.models")
+        importlib.import_module("pootle_fs.getters")
+        importlib.import_module("pootle_fs.providers")

--- a/pootle/apps/pootle_fs/getters.py
+++ b/pootle/apps/pootle_fs/getters.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.delegate import response, state
+from pootle.core.plugin import getter
+
+from .delegate import fs_file, fs_finder, fs_matcher, fs_resources
+from .files import FSFile
+from .finder import TranslationFileFinder
+from .localfs import LocalFSPlugin
+from .matcher import FSPathMatcher
+from .resources import FSProjectResources
+from .response import ProjectFSResponse
+from .state import ProjectFSState
+
+
+@getter(state, sender=LocalFSPlugin)
+def fs_plugin_state_getter(**kwargs):
+    return ProjectFSState
+
+
+@getter(response, sender=ProjectFSState)
+def fs_plugin_response_getter(**kwargs):
+    return ProjectFSResponse
+
+
+@getter(fs_file, sender=LocalFSPlugin)
+def fs_file_getter(**kwargs):
+    return FSFile
+
+
+@getter(fs_resources, sender=LocalFSPlugin)
+def fs_resources_getter(**kwargs):
+    return FSProjectResources
+
+
+@getter(fs_finder, sender=LocalFSPlugin)
+def fs_finder_getter(**kwargs):
+    return TranslationFileFinder
+
+
+@getter(fs_matcher, sender=LocalFSPlugin)
+def fs_matcher_getter(**kwargs):
+    return FSPathMatcher

--- a/pootle/apps/pootle_fs/localfs.py
+++ b/pootle/apps/pootle_fs/localfs.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import logging
+
+import dirsync
+
+from .plugin import Plugin
+
+
+class LocalFSPlugin(Plugin):
+
+    fs_type = "localfs"
+    _pulled = False
+
+    def push(self, response):
+        dirsync.sync(
+            self.project.local_fs_path,
+            self.fs_url,
+            "sync",
+            purge=True,
+            logger=logging.getLogger(dirsync.__name__))
+        return response
+
+    def pull(self):
+        dirsync.sync(
+            self.fs_url,
+            self.project.local_fs_path,
+            "sync",
+            create=True,
+            purge=True,
+            logger=logging.getLogger(dirsync.__name__))

--- a/pootle/apps/pootle_fs/plugin.py
+++ b/pootle/apps/pootle_fs/plugin.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import logging
+import os
+import shutil
+
+from django.contrib.auth import get_user_model
+from django.utils.functional import cached_property
+from django.utils.lru_cache import lru_cache
+
+from pootle.core.delegate import (
+    config, response as pootle_response, state as pootle_state)
+from pootle_store.models import Store
+from pootle_project.models import Project
+
+from .decorators import emits_state, responds_to_state
+from .delegate import fs_finder, fs_matcher, fs_resources
+from .signals import fs_pre_push, fs_post_push, fs_pre_pull, fs_post_pull
+
+
+logger = logging.getLogger(__name__)
+
+
+class Plugin(object):
+    """Base Plugin implementation"""
+
+    name = None
+
+    def __init__(self, project):
+        if not isinstance(project, Project):
+            raise TypeError(
+                "pootle_fs.Plugin expects a Project")
+        self.project = project
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and self.project == other.project
+            and self.name == other.name)
+
+    def __str__(self):
+        return "<%s(%s)>" % (self.__class__.__name__, self.project)
+
+    @property
+    def is_cloned(self):
+        return os.path.exists(self.project.local_fs_path)
+
+    @property
+    def finder_class(self):
+        return fs_finder.get(self.__class__)
+
+    @property
+    def fs_url(self):
+        return self.project.config["pootle_fs.fs_url"]
+
+    @property
+    def response_class(self):
+        return pootle_response.get(self.state_class)
+
+    @cached_property
+    def matcher_class(self):
+        return fs_matcher.get(self.__class__)
+
+    @property
+    def store_fs_class(self):
+        from .models import StoreFS
+
+        return StoreFS
+
+    @cached_property
+    def matcher(self):
+        return self.matcher_class(self)
+
+    @cached_property
+    def pootle_user(self):
+        User = get_user_model()
+        username = config.get(
+            self.project.__class__,
+            instance=self.project,
+            key="pootle_fs.pootle_user")
+        if username:
+            try:
+                return User.objects.get(username=username)
+            except User.DoesNotExist:
+                logger.warning(
+                    "Misconfigured pootle_fs user: %s"
+                    % username)
+
+    @cached_property
+    def resources(self):
+        return fs_resources.get(self.__class__)(self.project)
+
+    @cached_property
+    def state_class(self):
+        return pootle_state.get(self.__class__)
+
+    @lru_cache(maxsize=None)
+    def get_fs_path(self, pootle_path):
+        """
+        Reverse match an FS filepath from a ``Store.pootle_path``.
+
+        :param pootle_path: A ``Store.pootle_path``
+        :returns: An filepath relative to the FS root.
+        """
+        return self.matcher.reverse_match(pootle_path)
+
+    def clear_repo(self):
+        if self.is_cloned:
+            shutil.rmtree(self.project.local_fs_path)
+
+    def create_store_fs(self, fs_path=None, pootle_path=None, store=None):
+        return self.store_fs_class.objects.create(
+            project=self.project,
+            pootle_path=pootle_path,
+            path=fs_path,
+            store=store)
+
+    def find_translations(self, fs_path=None, pootle_path=None):
+        """
+        Find translation files from the file system
+
+        :param fs_path: Path glob to filter translations matching FS path
+        :param pootle_path: Path glob to filter translations to add matching
+          ``pootle_path``
+        :yields pootle_path, fs_path: Where `pootle_path` and `fs_path` are
+          matched paths.
+        """
+        return self.matcher.matches(fs_path, pootle_path)
+
+    def pull(self):
+        """
+        Pull the FS from external source if required.
+        """
+        raise NotImplementedError
+
+    def push(self, paths=None, message=None, response=None):
+        """
+        Push the FS to an external source if required.
+        """
+        raise NotImplementedError
+
+    def reload(self):
+        self.project.config.reload()
+        if "matcher" in self.__dict__:
+            del self.__dict__["matcher"]
+        if "pootle_user" in self.__dict__:
+            del self.__dict__["pootle_user"]
+
+    def response(self, state):
+        return self.response_class(state)
+
+    def state(self, fs_path=None, pootle_path=None):
+        """
+        Get a state object for showing current state of FS/Pootle
+
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+          ``pootle_path``
+        :returns state: Where ``state`` is an instance of self.state_class
+        """
+        self.pull()
+        return self.state_class(
+            self, fs_path=fs_path, pootle_path=pootle_path)
+
+    @responds_to_state
+    def add(self, state, response,
+            fs_path=None, pootle_path=None, force=False):
+        """
+        Stage translations from Pootle into the FS
+
+        If ``force``=``True`` is present it will also:
+        - stage untracked conflicting files from Pootle
+        - stage tracked conflicting files to update from Pootle
+
+        :param force: Add conflicting translations.
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        to_add = state["pootle_untracked"]
+        if force:
+            to_add = (
+                to_add
+                + state["conflict_untracked"]
+                + state["fs_removed"]
+                + state["conflict"])
+        for fs_state in to_add:
+            if fs_state.state_type in ["pootle_untracked", "conflict_untracked"]:
+                fs_state.kwargs["store_fs"] = self.create_store_fs(
+                    pootle_path=fs_state.pootle_path,
+                    fs_path=fs_state.fs_path)
+            fs_state.store_fs.file.add()
+            response.add("added_from_pootle", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    def fetch(self, state, response,
+              fs_path=None, pootle_path=None, force=False):
+        """
+        Stage translations from FS into Pootle
+
+        If ``force``=``True`` is present it will also:
+        - stage untracked conflicting files from FS
+        - stage tracked conflicting files to update from FS
+
+        :param force: Fetch conflicting translations.
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        to_fetch = state["fs_untracked"]
+        if force:
+            to_fetch = (
+                to_fetch
+                + state["conflict_untracked"]
+                + state["pootle_removed"]
+                + state["conflict"])
+        for fs_state in to_fetch:
+            if fs_state.state_type in ["fs_untracked", "conflict_untracked"]:
+                fs_state.kwargs["store_fs"] = self.create_store_fs(
+                    pootle_path=fs_state.pootle_path,
+                    fs_path=fs_state.fs_path)
+            fs_state.store_fs.file.fetch()
+            response.add("fetched_from_fs", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    def merge(self, state, response,
+              fs_path=None, pootle_path=None, pootle_wins=False):
+        """
+        Stage translations for merge.
+
+        :param pootle_wins: Prefer Pootle where there are conflicting units
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        for fs_state in state["conflict"] + state["conflict_untracked"]:
+            if fs_state.state_type == "conflict_untracked":
+                fs_state.kwargs["store_fs"] = self.create_store_fs(
+                    store=Store.objects.get(pootle_path=fs_state.pootle_path),
+                    fs_path=fs_state.fs_path)
+            fs_state.store_fs.file.merge(pootle_wins)
+            if pootle_wins:
+                response.add("staged_for_merge_pootle", fs_state=fs_state)
+            else:
+                response.add("staged_for_merge_fs", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    def rm(self, state, response, fs_path=None, pootle_path=None, force=False):
+        """
+        Stage translations for removal.
+
+        If ``force``=``True`` is present it will also:
+        - stage untracked files from FS
+        - stage untracked Stores
+
+        :param force: Fetch conflicting translations.
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        removed = (
+            state["pootle_removed"]
+            + state["fs_removed"]
+            + state["both_removed"])
+        if force:
+            removed = (
+                removed
+                + state["fs_untracked"]
+                + state["pootle_untracked"])
+        for fs_state in removed:
+            if fs_state.state_type in ["fs_untracked", "pootle_untracked"]:
+                fs_state.kwargs["store_fs"] = self.create_store_fs(
+                    pootle_path=fs_state.pootle_path,
+                    fs_path=fs_state.fs_path)
+            fs_state.store_fs.file.rm()
+            response.add("staged_for_removal", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    def sync_merge(self, state, response, fs_path=None, pootle_path=None):
+        """
+        Perform merge between Pootle and working directory
+
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        for fs_state in (state["merge_pootle_wins"] + state["merge_fs_wins"]):
+            pootle_wins = (fs_state.state_type == "merge_pootle_wins")
+            store_fs = fs_state.store_fs
+            store_fs.file.pull(
+                merge=True,
+                pootle_wins=pootle_wins,
+                user=self.pootle_user)
+            store_fs.file.push()
+            if pootle_wins:
+                response.add("merged_from_pootle", fs_state=fs_state)
+            else:
+                response.add("merged_from_fs", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    @emits_state(pre=fs_pre_pull, post=fs_post_pull)
+    def sync_pull(self, state, response, fs_path=None, pootle_path=None):
+        """
+        Pull translations from working directory to Pootle
+
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        for fs_state in (state['fs_staged'] + state['fs_ahead']):
+            fs_state.store_fs.file.pull(user=self.pootle_user)
+            response.add("pulled_to_pootle", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    @emits_state(pre=fs_pre_push, post=fs_post_push)
+    def sync_push(self, state, response, fs_path=None, pootle_path=None):
+        """
+        Push translations from Pootle to working directory.
+
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        pushable = state['pootle_staged'] + state['pootle_ahead']
+        for fs_state in pushable:
+            fs_state.store_fs.file.push()
+            response.add('pushed_to_fs', fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    def sync_rm(self, state, response, fs_path=None, pootle_path=None):
+        """
+        Remove Store and files from working directory that are staged for
+        removal.
+
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        for fs_state in state['remove']:
+            fs_state.store_fs.file.delete()
+            response.add("removed", fs_state=fs_state)
+        return response
+
+    @responds_to_state
+    def sync(self, state, response, fs_path=None, pootle_path=None):
+        """
+        Synchronize all staged and non-conflicting files and Stores, and push
+        changes upstream if required.
+
+        :param fs_path: FS path glob to filter translations
+        :param pootle_path: Pootle path glob to filter translations
+        :returns response: Where ``response`` is an instance of self.respose_class
+        """
+        self.sync_rm(
+            state, response, fs_path=fs_path, pootle_path=pootle_path)
+        self.sync_merge(
+            state, response, fs_path=fs_path, pootle_path=pootle_path)
+        self.sync_pull(
+            state, response, fs_path=fs_path, pootle_path=pootle_path)
+        self.sync_push(
+            state, response, fs_path=fs_path, pootle_path=pootle_path)
+        self.push(response)
+        sync_types = [
+            "pushed_to_fs", "pulled_to_pootle",
+            "merge_from_pootle", "merge_from_fs"]
+        for sync_type in sync_types:
+            if sync_type in response:
+                for response_item in response.completed(sync_type):
+                    response_item.store_fs.file.on_sync()
+        return response

--- a/pootle/apps/pootle_fs/providers.py
+++ b/pootle/apps/pootle_fs/providers.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.plugin import provider
+
+from .delegate import fs_plugins
+from .localfs import LocalFSPlugin
+
+
+@provider(fs_plugins)
+def localfs_plugin_provider(**kwargs):
+    return dict(localfs=LocalFSPlugin)

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -125,6 +125,7 @@ class StoreDBFactory(factory.django.DjangoModelFactory):
 
     parent = factory.LazyAttribute(
         lambda s: s.translation_project.directory)
+    obsolete = False
 
     @factory.lazy_attribute
     def pootle_path(self):

--- a/pytest_pootle/fixtures/pootle_fs/base.py
+++ b/pytest_pootle/fixtures/pootle_fs/base.py
@@ -6,7 +6,51 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import os
+
 import pytest
+
+
+@pytest.fixture
+def project_fs(tmpdir, settings):
+    from pootle_project.models import Project
+    from pootle_fs.utils import FSPlugin
+
+    project = Project.objects.get(code="project0")
+    new_url = os.path.join(str(tmpdir), "__src__")
+    project.config["pootle_fs.fs_url"] = new_url
+    project.config["pootle_fs.fs_type"] = "localfs"
+    project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    plugin = FSPlugin(project)
+    os.makedirs(new_url)
+    settings.POOTLE_FS_PATH = str(tmpdir)
+    return plugin
+
+
+@pytest.fixture
+def project_fs_empty(english, tmpdir, settings):
+    from pytest_pootle.factories import ProjectDBFactory
+
+    from pootle.core.delegate import config
+    from pootle_fs.utils import FSPlugin
+    from pootle_project.models import Project
+
+    project = ProjectDBFactory(
+        source_language=english,
+        code="project_fs_empty",
+        treestyle="none")
+    settings.POOTLE_FS_PATH = str(tmpdir)
+    repo_path = os.path.join(str(tmpdir), "__src__")
+    if not os.path.exists(repo_path):
+        os.mkdir(repo_path)
+    conf = config.get(Project, instance=project)
+    conf.set_config("pootle_fs.fs_type", "localfs")
+    conf.set_config("pootle_fs.fs_url", repo_path)
+    conf.set_config(
+        "pootle_fs.translation_paths",
+        {"default": "/<language_code>/<dir_path>/<filename>.<ext>"})
+    return FSPlugin(project)
 
 
 @pytest.fixture

--- a/pytest_pootle/fixtures/pootle_fs/plugin.py
+++ b/pytest_pootle/fixtures/pootle_fs/plugin.py
@@ -1,0 +1,487 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+import shutil
+from fnmatch import fnmatch
+from uuid import uuid4
+
+import pytest
+
+
+_plugin_fetch_base = {
+    'conflict': 1,
+    'conflict_untracked': 1,
+    'fs_ahead': 1,
+    'fs_removed': 1,
+    'fs_untracked': 2,
+    'pootle_ahead': 1,
+    'pootle_removed': 1,
+    'pootle_untracked': 1}
+
+
+@pytest.fixture
+def localfs(settings, request, tmpdir, project_fs):
+    plugin = project_fs
+    project = project_fs.project
+    project.treestyle = "none"
+    project.save()
+    project_src = os.path.join(
+        settings.POOTLE_TRANSLATION_DIRECTORY, project.code)
+    shutil.rmtree(plugin.fs_url)
+    shutil.copytree(project_src, plugin.fs_url)
+    plugin.project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    return plugin
+
+
+@pytest.fixture
+def project0_dummy_finder(no_fs_finder, localfs):
+    from pootle.core.plugin import getter
+    from pootle.core.url_helpers import split_pootle_path
+    from pootle_fs.delegate import fs_finder
+    from pootle_fs.finder import TranslationFileFinder
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+    pootle_paths = list(stores.values_list("pootle_path", flat=True))
+
+    class DummyFSFinder(TranslationFileFinder):
+
+        def find(self):
+            for pootle_path in pootle_paths:
+                fs_path = plugin.get_fs_path(pootle_path)
+                if self.path_filters:
+                    if not fnmatch(fs_path, self.path_filters[0]):
+                        continue
+                matched = dict()
+                (matched['language_code'],
+                 project_code,
+                 matched['dir_path'],
+                 matched['filename']) = split_pootle_path(pootle_path)
+                matched["ext"] = "po"
+                matched['filename'] = os.path.splitext(matched["filename"])[0]
+                yield plugin.get_fs_path(pootle_path), matched
+
+    @getter(fs_finder, sender=plugin.__class__, weak=False)
+    def get_fs_finder(**kwargs):
+        return DummyFSFinder
+
+
+@pytest.fixture
+def project_empty_dummy_finder(no_fs_finder, localfs, project_fs_empty):
+    from pootle.core.plugin import getter
+    from pootle.core.url_helpers import split_pootle_path
+    from pootle_fs.delegate import fs_finder
+    from pootle_fs.finder import TranslationFileFinder
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+    pootle_paths = list(stores.values_list("pootle_path", flat=True))
+
+    class DummyEmptyFSFinder(TranslationFileFinder):
+
+        def find(self):
+            for pootle_path in pootle_paths:
+                pootle_path = pootle_path.replace(
+                    plugin.project.code, project_fs_empty.project.code)
+                fs_path = plugin.get_fs_path(pootle_path)
+                if self.path_filters:
+                    if not fnmatch(fs_path, self.path_filters[0]):
+                        continue
+                matched = dict()
+                (matched['language_code'],
+                 project_code,
+                 matched['dir_path'],
+                 matched['filename']) = split_pootle_path(pootle_path)
+                matched["ext"] = "po"
+                matched['filename'] = os.path.splitext(matched["filename"])[0]
+                yield plugin.get_fs_path(pootle_path), matched
+
+    @getter(fs_finder, sender=plugin.__class__, weak=False)
+    def get_fs_finder(**kwargs):
+        return DummyEmptyFSFinder
+
+
+@pytest.fixture
+def project0_dummy_finder_empty(no_fs_finder, localfs):
+    from pootle.core.plugin import getter
+    from pootle_fs.delegate import fs_finder
+    from pootle_fs.finder import TranslationFileFinder
+
+    plugin = localfs
+
+    class DummyEmptyFSFinder(TranslationFileFinder):
+
+        def find(self):
+            return []
+
+    @getter(fs_finder, sender=plugin.__class__, weak=False)
+    def get_fs_finder(**kwargs):
+        return DummyEmptyFSFinder
+
+
+@pytest.fixture
+def project0_dummy_storefs_file(no_fs_files, localfs):
+    from pootle.core.plugin import getter
+    from pootle_fs.delegate import fs_file
+    from pootle_fs.files import FSFile
+
+    plugin = localfs
+
+    class DummyFSFile(FSFile):
+
+        _added = False
+        _deleted = False
+        _fetched = False
+        _merged = False
+        _pulled = False
+        _pushed = False
+        _removed = False
+        _synced = False
+
+        on_sync = lambda self: setattr(self, "_synced", True)
+
+        @property
+        def latest_hash(self):
+            return str(hash(self.pootle_path))
+
+        def add(self):
+            self._added = True
+
+        def delete(self):
+            self._deleted = True
+
+        def fetch(self):
+            self._fetched = True
+
+        def merge(self, pootle_wins):
+            self._merged = True
+            if pootle_wins:
+                self._merge_pootle = True
+            else:
+                self._merge_fs = True
+
+        def pull(self, **kwargs):
+            self._pulled = True
+            self._pull_data = sorted(kwargs.items())
+
+        def push(self):
+            self._pushed = True
+
+        def rm(self):
+            self._removed = True
+
+    @getter(fs_file, sender=plugin.__class__, weak=False)
+    def get_fs_file(**kwargs):
+        return DummyFSFile
+
+
+@pytest.fixture
+def localfs_pootle_untracked(settings, request, tmpdir,
+                             project0_dummy_storefs_file):
+    from pootle_fs.utils import FSPlugin
+    from pootle_project.models import Project
+
+    project = Project.objects.get(code="project0")
+    project.config["pootle_fs.fs_type"] = "localfs"
+    new_url = os.path.join(str(tmpdir), "__src__")
+    project.config["pootle_fs.fs_url"] = new_url
+    plugin = FSPlugin(project)
+    plugin.project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    settings.POOTLE_FS_PATH = str(tmpdir)
+    return plugin
+
+
+@pytest.fixture
+def localfs_fs_removed(settings, request, tmpdir,
+                       project0_dummy_storefs_file):
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_fs.utils import FSPlugin
+    from pootle_project.models import Project
+    from pootle_store.models import Store
+
+    project = Project.objects.get(code="project0")
+    project.config["pootle_fs.fs_type"] = "localfs"
+    new_url = os.path.join(str(tmpdir), "__src__")
+    project.config["pootle_fs.fs_url"] = new_url
+    plugin = FSPlugin(project)
+    plugin.project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    settings.POOTLE_FS_PATH = str(tmpdir)
+    stores = Store.objects.filter(
+        translation_project__project=plugin.project)
+    for store in stores:
+        add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path),
+            synced=True)
+    return plugin
+
+
+@pytest.fixture
+def localfs_conflict(localfs, request,
+                     project0_dummy_finder,
+                     project0_dummy_storefs_file):
+
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        store_fs = add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path))
+        store_fs.last_sync_revision = store.get_max_unit_revision() - 1
+        store_fs.last_sync_hash = uuid4().hex
+        store_fs.save()
+    assert len(plugin.state()["conflict"]) == stores.count()
+    return plugin
+
+
+@pytest.fixture
+def project0_fs_conflict_untracked(localfs, request,
+                                   project0_dummy_finder,
+                                   project0_dummy_storefs_file):
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+    pootle_paths = list(stores.values_list("pootle_path", flat=True))
+    assert len(plugin.state()["conflict_untracked"]) == len(pootle_paths)
+    return plugin
+
+
+@pytest.fixture
+def localfs_pootle_removed(project_fs, request,
+                           project_fs_empty,
+                           project_empty_dummy_finder,
+                           project0_dummy_storefs_file):
+    from pootle.core.models import Revision
+    from pootle_fs.models import StoreFS
+    from pootle_store.models import Store
+
+    plugin = project_fs_empty
+    plugin.project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    stores = Store.objects.filter(translation_project__project=project_fs.project)
+    max_revision = Revision.get()
+    for store in stores:
+        pootle_path = store.pootle_path.replace(
+            project_fs.project.code, plugin.project.code)
+        fs_path = plugin.get_fs_path(pootle_path)
+        store_fs = StoreFS.objects.create(
+            project=plugin.project,
+            path=fs_path,
+            pootle_path=pootle_path,
+            last_sync_revision=max_revision)
+        store_fs.last_sync_hash = store_fs.file.latest_hash
+        store_fs.save()
+    assert plugin.state()["pootle_removed"]
+    assert len(plugin.state()["pootle_removed"]) == stores.count()
+    return plugin
+
+
+@pytest.fixture
+def localfs_fs_untracked(project0_dummy_finder,
+                         project0_dummy_storefs_file,
+                         project_fs_empty):
+    plugin = project_fs_empty
+    plugin.project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    assert plugin.state()["fs_untracked"]
+    assert (
+        len(plugin.state()["fs_untracked"])
+        == len(list(plugin.find_translations())))
+    return plugin
+
+
+@pytest.fixture
+def localfs_merge_pootle_wins(localfs, request,
+                              project0_dummy_finder,
+                              project0_dummy_storefs_file):
+
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import POOTLE_WINS, Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        store_fs = add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path),
+            synced=True)
+        store_fs.resolve_conflict = POOTLE_WINS
+        store_fs.staged_for_merge = True
+        store_fs.save()
+    assert plugin.state()["merge_pootle_wins"]
+    assert len(plugin.state()["merge_pootle_wins"]) == stores.count()
+    return plugin
+
+
+@pytest.fixture
+def localfs_merge_fs_wins(localfs, request,
+                          project0_dummy_finder,
+                          project0_dummy_storefs_file):
+
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import FILE_WINS, Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        store_fs = add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path),
+            synced=True)
+        store_fs.resolve_conflict = FILE_WINS
+        store_fs.staged_for_merge = True
+        store_fs.save()
+    assert plugin.state()["merge_fs_wins"]
+    assert len(plugin.state()["merge_fs_wins"]) == stores.count()
+    return plugin
+
+
+@pytest.fixture
+def localfs_fs_ahead(localfs, request,
+                     project0_dummy_finder,
+                     project0_dummy_storefs_file):
+
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        store_fs = add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path))
+        store_fs.last_sync_revision = store.get_max_unit_revision()
+        store_fs.last_sync_hash = uuid4().hex
+        store_fs.save()
+    assert plugin.state()["fs_ahead"]
+    assert len(plugin.state()["fs_ahead"]) == stores.count()
+    return plugin
+
+
+@pytest.fixture
+def localfs_fs_staged(project0_dummy_finder,
+                      project0_dummy_storefs_file,
+                      project_fs_empty):
+    from pootle_fs.models import StoreFS
+
+    plugin = project_fs_empty
+    plugin.project.config["pootle_fs.translation_paths"] = {
+        "default": "/<language_code>/<dir_path>/<filename>.<ext>"}
+    matches = list(plugin.find_translations())
+    for pootle_path, fs_path in matches:
+        StoreFS.objects.create(path=fs_path, pootle_path=pootle_path)
+    assert plugin.state()["fs_staged"]
+    assert len(plugin.state()["fs_staged"]) == len(matches)
+    return plugin
+
+
+@pytest.fixture
+def localfs_pootle_ahead(localfs,
+                         project0_dummy_finder,
+                         project0_dummy_storefs_file):
+
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        store_fs = add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path))
+        store_fs.last_sync_hash = store_fs.file.latest_hash
+        store_fs.last_sync_revision = store.get_max_unit_revision()
+        store_fs.save()
+        unit = store.units.first()
+        unit.target = "%sFOO" % store.name
+        unit.save()
+    assert plugin.state()["pootle_ahead"]
+    assert len(plugin.state()["pootle_ahead"]) == stores.count()
+    return plugin
+
+
+@pytest.fixture
+def localfs_pootle_staged(project0_dummy_finder_empty,
+                          project0_dummy_storefs_file,
+                          localfs):
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path))
+
+    assert plugin.state()["pootle_staged"]
+    assert len(plugin.state()["pootle_staged"]) == len(stores)
+    return plugin
+
+
+@pytest.fixture
+def localfs_remove(project0_dummy_finder_empty,
+                   project0_dummy_storefs_file,
+                   localfs):
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+    for store in stores:
+        store_fs = add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path))
+        store_fs.staged_for_removal = True
+        store_fs.save()
+    assert plugin.state()["remove"]
+    assert len(plugin.state()["remove"]) == len(stores)
+    return plugin
+
+
+@pytest.fixture
+def localfs_pootle_staged_real(localfs):
+    from pytest_pootle.utils import add_store_fs
+
+    from pootle_store.models import Store
+
+    plugin = localfs
+    stores = Store.objects.filter(translation_project__project=plugin.project)
+
+    for store in stores:
+        add_store_fs(
+            store=store,
+            fs_path=plugin.get_fs_path(store.pootle_path))
+
+    assert plugin.state()["pootle_staged"]
+    assert len(plugin.state()["pootle_staged"]) == len(stores)
+    return plugin

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ django-transaction-hooks
 # Libraries
 cssmin
 diff-match-patch>=20121119
+dirsync
 elasticsearch>=1.0.0,<1.7
 jsonfield
 lxml>=2.2.0

--- a/tests/pootle_fs/delegate.py
+++ b/tests/pootle_fs/delegate.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle.core.plugin import provider
+from pootle_fs.delegate import fs_plugins
+from pootle_fs.localfs import LocalFSPlugin
+from pootle_fs.plugin import Plugin
+
+
+@pytest.mark.django_db
+def test_local_plugin_provider():
+    assert fs_plugins.gather()["localfs"] == LocalFSPlugin
+
+
+@pytest.mark.django_db
+def test_plugin_providers():
+
+    class CustomPlugin(Plugin):
+        pass
+
+    @provider(fs_plugins)
+    def custom_fs_plugin(**kwargs):
+        return dict(custom=CustomPlugin)
+
+    assert fs_plugins.gather()["custom"] == CustomPlugin

--- a/tests/pootle_fs/fs_response.py
+++ b/tests/pootle_fs/fs_response.py
@@ -65,8 +65,8 @@ class DummyFSState(State):
 
     item_state_class = DummyFSItemState
 
-    def state_fs_added(self, **kwargs):
-        for store_fs in kwargs.get("fs_added", []):
+    def state_fs_staged(self, **kwargs):
+        for store_fs in kwargs.get("fs_staged", []):
             yield dict(store_fs=store_fs)
 
     def state_fs_ahead(self, **kwargs):
@@ -192,15 +192,15 @@ def test_fs_response_store_fs_no_store_items(settings, tmpdir):
     pootle_fs_path = os.path.join(str(tmpdir), "fs_response_test")
     settings.POOTLE_FS_PATH = pootle_fs_path
     project = Project.objects.get(code="project0")
-    fs_added = []
+    fs_staged = []
     for i in range(0, 2):
-        pootle_path = "/language0/%s/fs_added_%s.po" % (project.code, i)
-        fs_path = "/some/fs/fs_added_%s.po" % i
-        fs_added.append(
+        pootle_path = "/language0/%s/fs_staged_%s.po" % (project.code, i)
+        fs_path = "/some/fs/fs_staged_%s.po" % i
+        fs_staged.append(
             StoreFS.objects.create(
                 pootle_path=pootle_path,
                 path=fs_path))
     _test_fs_response(
-        fs_added=fs_added,
+        fs_staged=fs_staged,
         action_type="pulled_to_pootle",
-        state_type="fs_added")
+        state_type="fs_staged")

--- a/tests/pootle_fs/plugin.py
+++ b/tests/pootle_fs/plugin.py
@@ -1,0 +1,625 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+from fnmatch import fnmatch
+
+import pytest
+
+from pootle.core.response import Response
+from pootle.core.state import State
+from pootle_fs.matcher import FSPathMatcher
+from pootle_fs.plugin import Plugin
+from pootle_fs.utils import FSPlugin
+from pootle_project.models import Project
+from pootle_store.models import Store
+
+
+def _test_dummy_response(responses, **kwargs):
+    stores = kwargs.pop("stores", None)
+    if stores:
+        assert len(responses) == len(stores)
+    stores_fs = kwargs.pop("stores_fs", None)
+    if stores_fs:
+        assert len(responses) == len(stores_fs)
+    paths = kwargs.pop("paths", None)
+    if paths:
+        assert len(responses) == len(paths)
+    expected_keys = [
+        "_added", "_fetched", "_pulled",
+        "_synced", "_pushed", "_merged",
+        "_removed"]
+    for response in responses:
+        if stores:
+            assert response.store_fs.store in stores
+        if stores_fs:
+            assert response.store_fs in stores_fs
+        if paths:
+            assert (response.pootle_path, response.fs_path) in paths
+        for k in expected_keys:
+            assert getattr(response.store_fs.file, k) == kwargs.get(k, False)
+        for k in kwargs:
+            if k not in expected_keys:
+                assert getattr(response.store_fs.file, k) == kwargs[k]
+
+
+def _filtered_stores(plugin, fs_path, pootle_path):
+    state = plugin.state(pootle_path=pootle_path, fs_path=fs_path)
+    stores = state.resources.store_filter.filtered(
+        Store.objects.filter(translation_project__project=plugin.project))
+    if fs_path:
+        return state, [
+            store for store
+            in stores
+            if fnmatch(plugin.get_fs_path(store.pootle_path), fs_path)]
+    else:
+        return state, list(stores)
+
+
+def _filtered_matches(plugin, fs_path, pootle_path):
+    state = plugin.state(pootle_path=pootle_path, fs_path=fs_path)
+    matches = []
+    for pootle_match, fs_match in plugin.find_translations():
+        if pootle_path and not fnmatch(pootle_match, pootle_path):
+            continue
+        if fs_path and not fnmatch(fs_match, fs_path):
+            continue
+        matches.append((pootle_match, fs_match))
+    return state, matches
+
+
+@pytest.mark.django_db
+def test_plugin_instance_bad_args(project_fs_empty):
+    fs_plugin = project_fs_empty.plugin
+
+    with pytest.raises(TypeError):
+        fs_plugin.__class__()
+
+    with pytest.raises(TypeError):
+        fs_plugin.__class__("FOO")
+
+
+@pytest.mark.django_db
+def test_plugin_pull(project_fs_empty):
+    assert project_fs_empty.is_cloned is False
+    project_fs_empty.pull()
+    assert project_fs_empty.is_cloned is True
+    project_fs_empty.clear_repo()
+    assert project_fs_empty.is_cloned is False
+
+
+@pytest.mark.django_db
+def test_plugin_instance(project_fs_empty):
+    project_fs = project_fs_empty
+    assert project_fs.project == project_fs.plugin.project
+    assert project_fs.project.local_fs_path.endswith(project_fs.project.code)
+    assert project_fs.is_cloned is False
+    assert project_fs.resources.stores.exists() is False
+    assert project_fs.resources.tracked.exists() is False
+    # any instance of the same plugin is equal
+    new_plugin = FSPlugin(project_fs.project)
+    assert project_fs == new_plugin
+    assert project_fs is not new_plugin
+    # but the plugin doesnt equate to a cabbage 8)
+    assert not project_fs == "a cabbage"
+
+
+@pytest.mark.django_db
+def test_plugin_pootle_user(project_fs_empty, member):
+    project = project_fs_empty.project
+    assert "pootle_fs.pootle_user" not in project.config
+    assert project_fs_empty.pootle_user is None
+    project.config["pootle_fs.pootle_user"] = member.username
+    assert project_fs_empty.pootle_user is None
+    project_fs_empty.reload()
+    assert project_fs_empty.pootle_user == member
+
+
+@pytest.mark.django_db
+def test_plugin_pootle_user_bad(project_fs_empty, member):
+    project = project_fs_empty.project
+    project.config["pootle_fs.pootle_user"] = "USER_DOES_NOT_EXIST"
+    project_fs_empty.reload()
+    assert project_fs_empty.pootle_user is None
+
+
+###########
+# ADD TESTS
+###########
+
+@pytest.mark.django_db
+def test_fs_plugin_add(fs_path_qs, localfs_pootle_untracked):
+    """tests `add` against `pootle_untracked`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_pootle_untracked
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["pootle_untracked"])
+    _test_dummy_response(
+        plugin.add(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["added_from_pootle"],
+        stores=stores,
+        _added=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_add_fs_removed(fs_path_qs, localfs_fs_removed):
+    """tests `add` against `fs_removed`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_fs_removed
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["fs_removed"])
+    response = plugin.add(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["added_from_pootle"]) == 0
+    _test_dummy_response(
+        plugin.add(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["added_from_pootle"],
+        stores=stores,
+        _added=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_add_conflict(fs_path_qs, localfs_conflict):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_conflict
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict"])
+    response = plugin.add(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["added_from_pootle"]) == 0
+    response = plugin.add(pootle_path=pootle_path, fs_path=fs_path, force=True)
+    assert len(response["added_from_pootle"]) == len(stores)
+    _test_dummy_response(
+        plugin.add(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["added_from_pootle"],
+        stores=stores,
+        _added=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_add_conflict_untracked(fs_path_qs,
+                                          project0_fs_conflict_untracked):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = project0_fs_conflict_untracked
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    response = plugin.add(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["added_from_pootle"]) == 0
+    _test_dummy_response(
+        plugin.add(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["added_from_pootle"],
+        stores=stores,
+        _added=True)
+
+
+#############
+# FETCH TESTS
+#############
+
+@pytest.mark.django_db
+def test_fs_plugin_fetch(fs_path_qs, localfs_fs_untracked):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_fs_untracked
+    state, matches = _filtered_matches(plugin, fs_path, pootle_path)
+    assert len(matches) == len(state["fs_untracked"])
+    _test_dummy_response(
+        plugin.fetch(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["fetched_from_fs"],
+        _fetched=True,
+        paths=matches)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_fetch_conflict(fs_path_qs, localfs_conflict):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_conflict
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict"])
+    response = plugin.fetch(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["fetched_from_fs"]) == 0
+    _test_dummy_response(
+        plugin.fetch(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["fetched_from_fs"],
+        stores=stores,
+        _fetched=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_fetch_pootle_removed(fs_path_qs,
+                                        localfs_pootle_removed):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_pootle_removed
+    state = plugin.state(fs_path=fs_path, pootle_path=pootle_path)
+    stores_fs = state.resources.storefs_filter.filtered(
+        plugin.project.store_fs.all())
+    assert len(stores_fs) == len(state["pootle_removed"])
+    response = plugin.fetch(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["fetched_from_fs"]) == 0
+    _test_dummy_response(
+        plugin.fetch(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["fetched_from_fs"],
+        stores_fs=stores_fs,
+        _fetched=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_fetch_conflict_untracked(fs_path_qs,
+                                            project0_fs_conflict_untracked):
+    """tests `fetch` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = project0_fs_conflict_untracked
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict_untracked"])
+    response = plugin.fetch(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["fetched_from_fs"]) == 0
+    _test_dummy_response(
+        plugin.fetch(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["fetched_from_fs"],
+        stores=stores,
+        _fetched=True)
+
+
+#############
+# MERGE TESTS
+#############
+
+@pytest.mark.django_db
+def test_fs_plugin_merge_conflict_untr(fs_path_qs,
+                                       project0_fs_conflict_untracked):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = project0_fs_conflict_untracked
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict_untracked"])
+    _test_dummy_response(
+        plugin.merge(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["staged_for_merge_fs"],
+        stores=stores,
+        _merged=True,
+        _merge_fs=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_merge_conflict_untr_pootle(fs_path_qs,
+                                              project0_fs_conflict_untracked):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = project0_fs_conflict_untracked
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict_untracked"])
+    _test_dummy_response(
+        plugin.merge(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            pootle_wins=True)["staged_for_merge_pootle"],
+        stores=stores,
+        _merged=True,
+        _merge_pootle=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_merge_conflict(fs_path_qs,
+                                  localfs_conflict):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_conflict
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict"])
+    _test_dummy_response(
+        plugin.merge(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["staged_for_merge_fs"],
+        stores=stores,
+        _merged=True,
+        _merge_fs=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_merge_conflict_pootle(fs_path_qs,
+                                         localfs_conflict):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_conflict
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["conflict"])
+    _test_dummy_response(
+        plugin.merge(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            pootle_wins=True)["staged_for_merge_pootle"],
+        stores=stores,
+        _merged=True,
+        _merge_pootle=True)
+
+
+##########
+# RM TESTS
+##########
+
+@pytest.mark.django_db
+def test_fs_plugin_rm_pootle_removed(fs_path_qs,
+                                     localfs_pootle_removed):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_pootle_removed
+    state = plugin.state(fs_path=fs_path, pootle_path=pootle_path)
+    stores_fs = state.resources.storefs_filter.filtered(
+        plugin.project.store_fs.all())
+    assert len(stores_fs) == len(state["pootle_removed"])
+    _test_dummy_response(
+        plugin.rm(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["staged_for_removal"],
+        stores_fs=stores_fs,
+        _removed=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_rm_fs_removed(fs_path_qs,
+                                 localfs_fs_removed):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_fs_removed
+    state = plugin.state(fs_path=fs_path, pootle_path=pootle_path)
+    stores_fs = state.resources.storefs_filter.filtered(
+        plugin.project.store_fs.all())
+    assert len(stores_fs) == len(state["fs_removed"])
+    _test_dummy_response(
+        plugin.rm(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["staged_for_removal"],
+        stores_fs=stores_fs,
+        _removed=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_rm_pootle_untracked(fs_path_qs,
+                                       localfs_pootle_untracked):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_pootle_untracked
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["pootle_untracked"])
+    response = plugin.rm(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["staged_for_removal"]) == 0
+    _test_dummy_response(
+        plugin.rm(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["staged_for_removal"],
+        stores=stores,
+        _removed=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_rm_fs_untracked(fs_path_qs,
+                                   localfs_fs_untracked):
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_fs_untracked
+    state, matches = _filtered_matches(plugin, fs_path, pootle_path)
+    assert len(matches) == len(state["fs_untracked"])
+    response = plugin.rm(pootle_path=pootle_path, fs_path=fs_path)
+    assert len(response["staged_for_removal"]) == 0
+    _test_dummy_response(
+        plugin.rm(
+            pootle_path=pootle_path,
+            fs_path=fs_path,
+            force=True)["staged_for_removal"],
+        _removed=True)
+
+
+#######################
+# MERGE RESOURCES TESTS
+#######################
+
+@pytest.mark.django_db
+def test_fs_plugin_merge_pootle(fs_path_qs, localfs_merge_pootle_wins):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_merge_pootle_wins
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["merge_pootle_wins"])
+    _test_dummy_response(
+        plugin.sync_merge(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["merged_from_pootle"],
+        stores=stores,
+        _pulled=True,
+        _pushed=True,
+        _pull_data=[("merge", True), ("pootle_wins", True), ("user", None)])
+
+
+@pytest.mark.django_db
+def test_fs_plugin_merge_fs(fs_path_qs, localfs_merge_fs_wins):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_merge_fs_wins
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["merge_fs_wins"])
+    _test_dummy_response(
+        plugin.sync_merge(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["merged_from_fs"],
+        stores=stores,
+        _pulled=True,
+        _pushed=True,
+        _pull_data=[("merge", True), ("pootle_wins", False), ("user", None)])
+
+
+######################
+# PULL RESOURCES TESTS
+######################
+
+@pytest.mark.django_db
+def test_fs_plugin_sync_pull_fs_ahead(fs_path_qs, localfs_fs_ahead):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_fs_ahead
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["fs_ahead"])
+    _test_dummy_response(
+        plugin.sync_pull(
+            pootle_path=pootle_path, fs_path=fs_path)["pulled_to_pootle"],
+        _pulled=True,
+        stores=stores,
+        _pull_data=[("user", None)])
+
+
+@pytest.mark.django_db
+def test_fs_plugin_sync_pull_fs_staged(fs_path_qs, localfs_fs_staged):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_fs_staged
+    state, matches = _filtered_matches(plugin, fs_path, pootle_path)
+    assert len(matches) == len(state["fs_staged"])
+    _test_dummy_response(
+        plugin.sync_pull(
+            pootle_path=pootle_path, fs_path=fs_path)["pulled_to_pootle"],
+        _pulled=True,
+        paths=matches,
+        _pull_data=[("user", None)])
+
+
+####################
+# RM RESOURCES TESTS
+####################
+
+@pytest.mark.django_db
+def test_fs_plugin_sync_rm(fs_path_qs, localfs_remove):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_remove
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["remove"])
+    _test_dummy_response(
+        plugin.sync_rm(
+            pootle_path=pootle_path, fs_path=fs_path)["removed"],
+        stores=stores,
+        _deleted=True)
+
+
+######################
+# PUSH RESOURCES TESTS
+######################
+
+@pytest.mark.django_db
+def test_fs_plugin_sync_push_pootle_ahead(fs_path_qs, localfs_pootle_ahead):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_pootle_ahead
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["pootle_ahead"])
+    _test_dummy_response(
+        plugin.sync_push(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["pushed_to_fs"],
+        stores=stores,
+        _pushed=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_sync_push_pootle_staged(fs_path_qs, localfs_pootle_staged):
+    """tests `add` against `conflict`"""
+    (qfilter, pootle_path, fs_path) = fs_path_qs
+    plugin = localfs_pootle_staged
+    state, stores = _filtered_stores(plugin, fs_path, pootle_path)
+    assert len(stores) == len(state["pootle_staged"])
+    _test_dummy_response(
+        plugin.sync_push(
+            pootle_path=pootle_path,
+            fs_path=fs_path)["pushed_to_fs"],
+        stores=stores,
+        _pushed=True)
+
+
+@pytest.mark.django_db
+def test_fs_plugin_sync_all():
+
+    class SyncPlugin(Plugin):
+
+        sync_order = []
+
+        def push(self, response):
+            self._push_response = response
+            self.sync_order.append("plugin_push")
+            return response
+
+        def sync_merge(self, state, response, fs_path=None, pootle_path=None):
+            self._merged = (state, response, fs_path, pootle_path)
+            self.sync_order.append("merge")
+
+        def sync_pull(self, state, response, fs_path=None, pootle_path=None):
+            self._pulled = (state, response, fs_path, pootle_path)
+            self.sync_order.append("pull")
+
+        def sync_push(self, state, response, fs_path=None, pootle_path=None):
+            self._pushed = (state, response, fs_path, pootle_path)
+            self.sync_order.append("push")
+
+        def sync_rm(self, state, response, fs_path=None, pootle_path=None):
+            self._rmed = (state, response, fs_path, pootle_path)
+            self.sync_order.append("rm")
+
+    project = Project.objects.get(code="project0")
+    plugin = SyncPlugin(project)
+    state = State("dummy")
+    response = Response(state)
+    plugin.sync(state, response, fs_path="FOO", pootle_path="BAR")
+    for result in [plugin._merged, plugin._pushed, plugin._rmed, plugin._pulled]:
+        assert result[0] is state
+        assert result[1] is response
+        assert result[2] == "FOO"
+        assert result[3] == "BAR"
+    assert plugin._push_response is response
+    assert plugin.sync_order == ["rm", "merge", "pull", "push", "plugin_push"]
+
+
+@pytest.mark.django_db
+def test_fs_plugin_not_implemented():
+    project = Project.objects.get(code="project0")
+    plugin = Plugin(project)
+
+    with pytest.raises(NotImplementedError):
+        plugin.pull()
+
+    with pytest.raises(NotImplementedError):
+        plugin.push()
+
+
+@pytest.mark.django_db
+def test_fs_plugin_matcher(localfs):
+    matcher = localfs.matcher
+    assert isinstance(matcher, FSPathMatcher)
+    assert matcher is localfs.matcher
+    localfs.reload()
+    assert matcher is not localfs.matcher
+
+
+@pytest.mark.django_db
+def test_fs_plugin_localfs_push(localfs_pootle_staged_real):
+    plugin = localfs_pootle_staged_real
+    response = plugin.sync()
+    for response_item in response["pushed_to_fs"]:
+        src_file = os.path.join(
+            plugin.fs_url,
+            response_item.store_fs.file.path.lstrip("/"))
+        target_file = response_item.store_fs.file.file_path
+        with open(src_file) as target:
+            with open(target_file) as src:
+                assert src.read() == target.read()

--- a/tests/pootle_fs/signals.py
+++ b/tests/pootle_fs/signals.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.dispatch import receiver
+
+from pootle_fs.signals import (
+    fs_pre_push, fs_post_push, fs_pre_pull, fs_post_pull)
+
+
+@pytest.mark.django_db
+def test_fs_pull_signal(project_fs):
+
+    project_fs.fetch(force=True)
+    state = project_fs.state()
+
+    class Success(object):
+        expected = len(state["fs_staged"]) + len(state["fs_ahead"])
+        pre_pull_called = False
+        post_pull_called = False
+    success = Success()
+
+    @receiver(fs_pre_pull)
+    def fs_pre_pull_handler(**kwargs):
+        assert kwargs["plugin"] is project_fs.plugin
+        assert "No changes made" in str(kwargs["response"])
+        assert "pulled_to_pootle" not in kwargs["response"]
+        # we see the original state
+        assert (
+            success.expected
+            == (len(kwargs["state"]["fs_staged"])
+                + len(kwargs["state"]["fs_ahead"])))
+        success.pre_pull_called = True
+
+    @receiver(fs_post_pull)
+    def fs_post_pull_handler(**kwargs):
+        assert kwargs["plugin"] is project_fs.plugin
+        # we still see the original state
+        assert (
+            success.expected
+            == (len(kwargs["state"]["fs_staged"])
+                + len(kwargs["state"]["fs_ahead"])))
+        # but the response has been updated
+        assert (
+            success.expected
+            == len(kwargs["response"]["pulled_to_pootle"]))
+        success.post_pull_called = True
+        success.response = kwargs["response"]
+
+    assert project_fs.sync_pull() == success.response
+    assert success.pre_pull_called is True
+    assert success.post_pull_called is True
+
+
+@pytest.mark.django_db
+def test_fs_push_signal(project_fs):
+
+    project_fs.add(force=True)
+    state = project_fs.state()
+
+    class Success(object):
+        expected = len(state["pootle_staged"]) + len(state["pootle_ahead"])
+        pre_push_called = False
+        post_push_called = False
+    success = Success()
+
+    @receiver(fs_pre_push)
+    def fs_pre_push_handler(**kwargs):
+        assert kwargs["plugin"] is project_fs.plugin
+        assert "No changes made" in str(kwargs["response"])
+        assert "pushed_to_pootle" not in kwargs["response"]
+        # we see the original state
+        assert (
+            success.expected
+            == (len(kwargs["state"]["pootle_staged"])
+                + len(kwargs["state"]["pootle_ahead"])))
+        success.pre_push_called = True
+
+    @receiver(fs_post_push)
+    def fs_post_push_handler(**kwargs):
+        assert kwargs["plugin"] is project_fs.plugin
+        # we still see the original state
+        assert (
+            success.expected
+            == (len(kwargs["state"]["pootle_staged"])
+                + len(kwargs["state"]["pootle_ahead"])))
+        # but the response has been updated
+        assert (
+            success.expected
+            == len(kwargs["response"]["pushed_to_fs"]))
+        success.post_push_called = True
+        success.response = kwargs["response"]
+
+    assert project_fs.sync_push() == success.response
+    assert success.pre_push_called is True
+    assert success.post_push_called is True


### PR DESCRIPTION
This PR provides a pluggable system for configuring projects to sync to/from filesystems.

The configuration is managed using pootle_config and is stored against Projects.

Tracked Stores/files are remembered using a StoreFS object.

pootle_fs comes with a plugin for syncing to local fileystem

there is also a git plugin available here https://github.com/translate/pootle_fs_git