### PR TITLE
Cleanup: dont test for debugging messages

### DIFF
--- a/tests/commands/import.py
+++ b/tests/commands/import.py
@@ -71,7 +71,8 @@ def test_import_onefile_with_user(capfd, tmpdir, site_users):
                  os.path.join(p.dirname, p.basename))
     out, err = capfd.readouterr()
     assert user in out
-    assert "Updating /language0/project0/store0.po" in err
+    assert "[update]" in err
+    assert "units in /language0/project0/store0.po" in err
 
 
 @pytest.mark.cmd


### PR DESCRIPTION
The code here is testing for messages produced in logging.debug

This relies on debug being True and isnt what we should be testing for (if we really want to test for debugging messages then caplog is the way)