### PR TITLE
Cleanup: Django 1.7 is not tested anymore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{17,18}-{sqlite,mysql,postgres},project
+envlist = py27-django18-{sqlite,mysql,postgres},project
 basepython = python
 usedevelop = True
 skipsdist = True


### PR DESCRIPTION
*.travis.yml* already removed the `django17` environment some time ago.