### PR TITLE
Set unit state to untranslated when remove translation via store.update()

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -734,9 +734,13 @@ class Unit(models.Model, base.TranslationUnit):
             notempty = filter(None, self.target_f.strings)
             self.target = unit.target
 
-            if filter(None, self.target_f.strings) or notempty:
+            if not filter(None, self.target_f.strings):
                 # FIXME: we need to do this cause we discard nplurals for empty
                 # plurals
+                if notempty:
+                    unit.state = UNTRANSLATED
+                    changed = True
+            else:
                 changed = True
 
         notes = unit.getnotes(origin="developer")


### PR DESCRIPTION
There were missed submissions (state: Translated -> Untranslated) when translations were removed via `update_stores` or `import`.
Refs. https://github.com/translate/pootle/issues/4298