### PR TITLE
Tests: set up site-wide DB only if tests requested the DB

### DIFF
--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -12,7 +12,21 @@ from pytest_pootle.env import PootleTestEnv
 
 
 @pytest.fixture(autouse=True, scope='session')
+def setup_db_if_needed(request):
+    """Sets up the site DB only if tests requested to use the DB (autouse)."""
+    is_db_marker_set = [
+        item for item in request.node.items
+        if item.get_marker('django_db')
+    ]
+    if is_db_marker_set:
+        return request.getfuncargvalue('post_db_setup')
+
+    return None
+
+
+@pytest.fixture(scope='session')
 def post_db_setup(_django_db_setup, _django_cursor_wrapper, request):
+    """Sets up the site DB for the test session."""
     with _django_cursor_wrapper:
         PootleTestEnv(request).setup()
 


### PR DESCRIPTION
This is an attempt to avoid setting up the site-wide DB when the set of selected tests don't make use of the DB at all.

There shouldn't be any effects when running the entire suite via `py.test`, however running something like `py.test -k misc/checks` should be immediate, as the selected tests makes use of no DB and hence the expensive setup can be avoided.

Probably there is a better way to approach this and I'm happy to improve it based on feedback, although at its current state this worked for me perfectly.