### PR TITLE
Remove uid lists

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -480,9 +480,9 @@ class UnitSearchForm(forms.Form):
             self.cleaned_data["user"] = self.request_user
         if self.errors:
             return
-        if self.cleaned_data['count'] is None:
-            self.cleaned_data["count"] = (
-                self.cleaned_data["user"].get_unit_rows())
+        self.cleaned_data['count'] = min(
+            self.cleaned_data.get("count", 10) or 10,
+            self.cleaned_data["user"].get_unit_rows() or 10)
         self.cleaned_data["vfolder"] = None
         pootle_path = self.cleaned_data.get("path")
         if 'virtualfolder' in settings.INSTALLED_APPS:

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -413,11 +413,14 @@ def unit_comment_form_factory(language):
 
 class UnitSearchForm(forms.Form):
 
-    initial = forms.BooleanField(required=False)
     count = forms.IntegerField(required=False)
+    offset = forms.IntegerField(required=False)
     path = forms.CharField(
         max_length=2048,
         required=True)
+    previous_uids = MultipleArgsField(
+        field=forms.IntegerField(),
+        required=False)
     uids = MultipleArgsField(
         field=forms.IntegerField(),
         required=False)

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -17,7 +17,7 @@ from pootle_store.views import SIMPLY_SORTED
 
 class DBSearchBackend(object):
 
-    default_chunk_size = 9
+    default_chunk_size = 10
     default_order = "store__pootle_path", "index"
     select_related = (
         'store__translation_project__project',

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -18,7 +18,7 @@ from pootle_store.views import SIMPLY_SORTED
 class DBSearchBackend(object):
 
     default_chunk_size = 9
-    default_order = "store", "index"
+    default_order = "store__pootle_path", "index"
     select_related = (
         'store__translation_project__project',
         'store__translation_project__language')

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -210,20 +210,13 @@ def get_units(request):
                     raise Http400(_('Arguments missing.'))
         raise Http404(forms.ValidationError(search_form.errors).messages)
 
-    uid_list, units_qs = get_search_backend()(
+    total, start, end, units_qs = get_search_backend()(
         request.user, **search_form.cleaned_data).search()
-
-    bad_uid = (
-        search_form.cleaned_data["initial"]
-        and len(search_form.cleaned_data["uids"]) == 1
-        and search_form.cleaned_data["uids"][0] not in uid_list)
-    if bad_uid:
-        raise Http404
-
-    response = {'unitGroups': GroupedResults(units_qs).data}
-    if uid_list:
-        response['uIds'] = uid_list
-    return JsonResponse(response)
+    return JsonResponse(
+        {'start': start,
+         'end': end,
+         'total': total,
+         'unitGroups': GroupedResults(units_qs).data})
 
 
 @ajax_required

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -685,14 +685,14 @@ class PootleExportView(PootleDetailView):
             raise Http404(
                 ValidationError(search_form.errors).messages)
 
-        uid_list, units_qs = get_search_backend()(
+        total, start, end, units_qs = get_search_backend()(
             self.request.user, **search_form.cleaned_data).search()
 
         units_qs = units_qs.select_related('store')
 
-        if len(uid_list) > search_form.cleaned_data["count"]:
+        if total > search_form.cleaned_data["count"]:
             ctx.update(
-                {'unit_total_count': len(uid_list),
+                {'unit_total_count': total,
                  'displayed_unit_count': search_form.cleaned_data["count"]})
 
         unit_groups = [

--- a/pootle/static/js/browser.js
+++ b/pootle/static/js/browser.js
@@ -78,7 +78,9 @@ function navigateTo(languageCode, projectCode, resource) {
 
   const PTL = window.PTL || {};
   if (PTL.hasOwnProperty('editor')) {
-    const hash = utils.getHash().replace(/&?unit=\d+/, '');
+    const hash = utils.getHash()
+          .replace(/&?unit=\d+/, '')
+          .replace(/&?offset=\d+/, '');
     if (hash !== '') {
       newUrl = [newUrl, hash].join('#');
     }

--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -18,7 +18,7 @@ import pytest
 from django.core.urlresolvers import reverse
 
 from pytest_pootle.env import TEST_USERS
-from pytest_pootle.utils import create_store, get_translated_uids
+from pytest_pootle.utils import create_store, get_test_uids
 
 
 DAY_AGO = (datetime.now() - timedelta(days=1))
@@ -67,9 +67,8 @@ BAD_VIEW_TESTS = OrderedDict(
 
      ("/xhr/units/1/edit/", dict(code=400)),
      ("/xhr/units/?path=/%s" % ("BAD" * 800),
-      dict(ajax=True, code=400)),
-     ("/xhr/units?filter=translated&path=/&initial=True&uids=75000",
-      dict(ajax=True))))
+      dict(ajax=True, code=400))))
+
 
 GET_UNITS_TESTS = OrderedDict(
     (("default_path", {}),
@@ -77,22 +76,28 @@ GET_UNITS_TESTS = OrderedDict(
       {"filter": "translated"}),
      ("state_translated_continued",
       {"filter": "translated",
-       "uids": functools.partial(get_translated_uids, count=9),
-       "initial": False}),
+       "uids": functools.partial(get_test_uids, count=9),
+       "offset": 10}),
      ("state_untranslated",
       {"filter": "untranslated"}),
+     ("state_untranslated",
+      {"filter": "untranslated",
+       "offset": 100000}),
      ("state_incomplete",
       {"filter": "incomplete"}),
      ("state_fuzzy",
       {"filter": "fuzzy"}),
      ("sort_units_oldest",
       {"sort_by_param": "oldest"}),
-     ("filter_translated_from_uid",
-      {"uids": get_translated_uids,
-       "filter": "translated"}),
-     ("filter_translated_from_uid_sort_priority",
-      {"uids": get_translated_uids,
-       "filter": "translated",
+     ("filter_from_uid",
+      {"path": "/language0/project0/store0.po",
+       "uids": functools.partial(get_test_uids,
+                                 pootle_path="/language0/project0/store0.po"),
+       "filter": "all"}),
+     ("filter_from_uid_sort_priority",
+      {"uids": functools.partial(get_test_uids,
+                                 pootle_path="/language0/project0/store0.po"),
+       "filter": "all",
        "sort": "priority"}),
      ("translated_by_member",
       {"filter": "translated",
@@ -248,12 +253,7 @@ DISABLED_PROJECT_URL_PARAMS = OrderedDict(
 @pytest.fixture(params=GET_UNITS_TESTS.keys())
 def get_units_views(request, client, request_users):
     params = GET_UNITS_TESTS[request.param].copy()
-    params["path"] = params.get("path", "/")
-
-    if "initial" in params and not params["initial"]:
-        del params["initial"]
-    else:
-        params["initial"] = "true"
+    params["path"] = params.get("path", "/language0/project0/")
 
     user = request_users["user"]
     if user.username != "nobody":

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -57,14 +57,15 @@ def create_store(pootle_path=None, store_revision=None, units=None):
     return getclass(io_store)(io_store.read())
 
 
-def get_translated_uids(offset=0, count=1):
+def get_test_uids(offset=0, count=1, pootle_path=None):
     """Returns a list translated unit uids from ~middle of
     translated units dataset
     """
     from pootle_store.models import Unit
-    from pootle_store.util import TRANSLATED
 
-    units = Unit.objects.filter(state=TRANSLATED)
+    units = Unit.objects.all()
+    if pootle_path:
+        units = units.filter(store__pootle_path=pootle_path)
     begin = (units.count() / 2) + offset
     return list(units[begin: begin + count].values_list("pk", flat=True))
 

--- a/tests/views/get_units.py
+++ b/tests/views/get_units.py
@@ -12,6 +12,8 @@ import pytest
 
 from pytest_pootle.search import calculate_search_results
 
+from pootle_store.models import Unit
+
 
 @pytest.mark.django_db
 def test_get_units(get_units_views):
@@ -20,19 +22,186 @@ def test_get_units(get_units_views):
 
     assert "unitGroups" in result
     assert isinstance(result["unitGroups"], list)
+
+    for k in "start", "end", "total":
+        assert k in result
+        assert isinstance(result[k], int)
+
     if result["unitGroups"]:
-        expected_uids, expected_units = calculate_search_results(
+        total, start, end, expected_units = calculate_search_results(
             search_params, user)
 
-        if search_params.get("initial"):
-            assert list(result["uIds"]) == list(expected_uids)
-        else:
-            assert "uIds" not in result
+        assert result["total"] == total
+        assert result["start"] == start
+        assert result["end"] == end
 
         for i, group in enumerate(expected_units):
             result_group = result["unitGroups"][i]
             for store, data in group.items():
                 result_data = result_group[store]
                 assert (
-                    [u["url"] for u in result_data["units"]]
-                    == [u["url"] for u in data["units"]])
+                    [u["id"] for u in result_data["units"]]
+                    == [u["id"] for u in data["units"]])
+
+
+@pytest.mark.django_db
+def test_get_previous_slice(client):
+    import json
+    resp = client.get(
+        "/xhr/units/?filter=all&count=5&path=/&offset=60",
+        HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+    result = json.loads(resp.content)
+
+    qs = Unit.objects.get_translatable(
+        user=resp.wsgi_request.user).order_by("store__pootle_path", "index")
+
+    uids = []
+    for group in result["unitGroups"]:
+        for group_data in group.values():
+            for unit in group_data["units"]:
+                uids.append(unit["id"])
+
+    assert result["start"] == 60
+    assert result["end"] == 70
+    assert result["total"] == qs.count()
+    assert uids == list(qs[60:70].values_list("pk", flat=True))
+
+    resp2 = client.get(
+        "/xhr/units/",
+        dict(
+            filter="all",
+            count=5,
+            path="/",
+            offset=50),
+        HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+    result2 = json.loads(resp2.content)
+
+    uids2 = []
+    for group in result2["unitGroups"]:
+        for group_data in group.values():
+            for unit in group_data["units"]:
+                uids2.append(unit["id"])
+
+    assert result2["start"] == 50
+    assert result2["end"] == 60
+    assert result2["total"] == qs.count()
+    assert uids2 == list(qs[50:60].values_list("pk", flat=True))
+
+    expected = list(qs[40:50].values_list("pk", flat=True))
+
+    to_obsolete = [uid for i, uid in enumerate(uids2) if i % 2]
+    for unit in Unit.objects.filter(id__in=to_obsolete):
+        unit.makeobsolete()
+        unit.save()
+
+    assert expected == list(qs.all()[40:50].values_list("pk", flat=True))
+
+    resp3 = client.get(
+        "/xhr/units/",
+        dict(
+            filter="all",
+            count=5,
+            path="/",
+            offset=40),
+        HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+    result3 = json.loads(resp3.content)
+
+    uids3 = []
+    for group in result3["unitGroups"]:
+        for group_data in group.values():
+            for unit in group_data["units"]:
+                uids3.append(unit["id"])
+
+    # obsoleting the units makes no difference when paginating backwards
+    assert result3["start"] == 40
+    assert result3["end"] == 50
+    assert result3["total"] == qs.count()
+    assert uids3 == list(
+        qs[40:50].values_list("pk", flat=True))
+
+
+@pytest.mark.django_db
+def test_get_next_slice(client):
+    import json
+    resp = client.get(
+        "/xhr/units/?filter=all&count=5&path=/",
+        HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+    result = json.loads(resp.content)
+
+    qs = Unit.objects.get_translatable(
+        user=resp.wsgi_request.user).order_by("store__pootle_path", "index")
+
+    uids = []
+    for group in result["unitGroups"]:
+        for group_data in group.values():
+            for unit in group_data["units"]:
+                uids.append(unit["id"])
+
+    assert result["start"] == 0
+    assert result["end"] == 10
+    assert result["total"] == qs.count()
+    assert uids == list(qs[:10].values_list("pk", flat=True))
+
+    resp2 = client.get(
+        "/xhr/units/",
+        dict(
+            filter="all",
+            count=5,
+            path="/",
+            offset=10,
+            previous_uids=uids),
+        HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+    result2 = json.loads(resp2.content)
+
+    uids2 = []
+    for group in result2["unitGroups"]:
+        for group_data in group.values():
+            for unit in group_data["units"]:
+                uids2.append(unit["id"])
+
+    assert result2["start"] == 10
+    assert result2["end"] == 20
+    assert result2["total"] == qs.count()
+    assert uids2 == list(qs[10:20].values_list("pk", flat=True))
+
+    expected = list(qs[20:30].values_list("pk", flat=True))
+
+    to_obsolete = [uid for i, uid in enumerate(uids2) if i % 2]
+    for unit in Unit.objects.filter(id__in=to_obsolete):
+        unit.makeobsolete()
+        unit.save()
+
+    assert expected == list(qs.all()[15:25].values_list("pk", flat=True))
+
+    resp3 = client.get(
+        "/xhr/units/",
+        dict(
+            filter="all",
+            count=5,
+            path="/",
+            offset=20,
+            previous_uids=uids2),
+        HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+    result3 = json.loads(resp3.content)
+
+    uids3 = []
+    for group in result3["unitGroups"]:
+        for group_data in group.values():
+            for unit in group_data["units"]:
+                uids3.append(unit["id"])
+
+    assert result3["start"] == 20 - len(to_obsolete)
+    assert result3["end"] == 30 - len(to_obsolete)
+    assert result3["total"] == qs.count()
+
+    start = 20 - len(to_obsolete)
+    end = 30 - len(to_obsolete)
+
+    assert uids3 == list(
+        qs[start:end].values_list("pk", flat=True))

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -106,7 +106,7 @@ def _test_export_view(language, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    uid_list, units_qs = get_search_backend()(
+    total, start, end, units_qs = get_search_backend()(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -147,7 +147,7 @@ def _test_export_view(project, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    uid_list, units_qs = get_search_backend()(
+    total, start, end, units_qs = get_search_backend()(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [
@@ -257,7 +257,7 @@ def test_view_projects_export(client):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    uid_list, units_qs = get_search_backend()(
+    total, start, end, units_qs = get_search_backend()(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -200,7 +200,7 @@ def _test_export_view(tp, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    uid_list, units_qs = get_search_backend()(
+    total, start, end, units_qs = get_search_backend()(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [


### PR DESCRIPTION
This PR removes the uid_list of full search results in the translation editor.

Instead the units are paginated forwards/backwards using offsets.

You can jump to a given index ~as before.

When paginating forwards the editor sends the previous units to adjust the offsets for units that may have been removed eg from being edited.

You can jump to a unit in any results set if you know the offset. If the uid is not in the result set at that offset - you will be shown the units currently at that offset.

For the Store translation view you can also search by uid of a unit without knowing the offset beforehand, in which case the backend will calculate the offset for the client