### PR TITLE
ProjectForm: ensure `clean_<field>` methods are used

### DIFF
--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -71,30 +71,30 @@ class ProjectForm(forms.ModelForm):
                 self.instance.treestyle == self.instance._detect_treestyle()):
                 self.fields['treestyle'].required = False
 
-        def clean_localfiletype(self):
-            value = self.cleaned_data.get('localfiletype', None)
-            if not value:
-                value = self.instance.localfiletype
-            filetypes = [x[0] for x in filetype_choices]
-            if value not in filetypes:
-                raise forms.ValidationError(
-                    "Unrecognised project filetype: %s" % value
-                )
-            return value
+    def clean_localfiletype(self):
+        value = self.cleaned_data.get('localfiletype', None)
+        if not value:
+            value = self.instance.localfiletype
+        filetypes = [x[0] for x in filetype_choices]
+        if value not in filetypes:
+            raise forms.ValidationError(
+                "Unrecognised project filetype: %s" % value
+            )
+        return value
 
-        def clean_treestyle(self):
-            value = self.cleaned_data.get('treestyle', None)
-            if not value:
-                value = self.instance.treestyle
-            return value
+    def clean_treestyle(self):
+        value = self.cleaned_data.get('treestyle', None)
+        if not value:
+            value = self.instance.treestyle
+        return value
 
-        def clean_code(self):
-            value = self.cleaned_data['code']
-            if value in RESERVED_PROJECT_CODES:
-                raise forms.ValidationError(
-                    _('"%s" cannot be used as a project code', value)
-                )
-            return value
+    def clean_code(self):
+        value = self.cleaned_data['code']
+        if value in RESERVED_PROJECT_CODES:
+            raise forms.ValidationError(
+                _('"%s" cannot be used as a project code', value)
+            )
+        return value
 
 
 class UserForm(forms.ModelForm):

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -17,7 +17,7 @@ from translate.lang.data import langcode_re
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
@@ -379,12 +379,6 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
         super(Project, self).delete(*args, **kwargs)
 
         directory.delete()
-
-    def clean(self):
-        if self.code in RESERVED_PROJECT_CODES:
-            raise ValidationError(
-                _('"%s" cannot be used as a project code', self.code)
-            )
 
     def directory_exists_on_disk(self):
         """Checks if the actual directory for the project exists on disk."""

--- a/tests/forms/project.py
+++ b/tests/forms/project.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle_app.forms import ProjectForm
+from pootle_project.models import (PROJECT_CHECKERS, RESERVED_PROJECT_CODES,
+                                   Project)
+from pootle_store.filetypes import filetype_choices
+
+
+@pytest.mark.parametrize('reserved_code', RESERVED_PROJECT_CODES)
+@pytest.mark.django_db
+def test_clean_code_invalid(reserved_code):
+    form_data = {
+        'code': reserved_code,
+        'checkstyle': PROJECT_CHECKERS.keys()[0],
+        'fullname': 'Foo',
+        'localfiletype': filetype_choices[0][0],
+        'source_language': 1,
+        'treestyle': Project.treestyle_choices[0][0],
+    }
+    form = ProjectForm(form_data)
+    assert not form.is_valid()
+    assert 'code' in form.errors
+    assert len(form.errors.keys()) == 1
+
+
+@pytest.mark.django_db
+def test_clean_localfiletype_invalid():
+    form_data = {
+        'code': 'foo',
+        'checkstyle': PROJECT_CHECKERS.keys()[0],
+        'fullname': 'Foo',
+        'localfiletype': 'invalid_filetype',
+        'source_language': 1,
+        'treestyle': Project.treestyle_choices[0][0],
+    }
+    form = ProjectForm(form_data)
+    assert not form.is_valid()
+    assert 'localfiletype' in form.errors
+    assert len(form.errors.keys()) == 1


### PR DESCRIPTION
An indenting mistake (cd323b3) was making the field-specific clean methods
useless. At the same time, duplicated validation added in the past (4c15390e)
can now be removed.