### PR TITLE
ENChecker: fix running checks via `calculate_checks`

### DIFF
--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -271,15 +271,14 @@ class ENChecker(checks.UnitChecker):
 
     def run_test(self, test, unit):
         """Runs the given test on the given unit."""
-        return test(self.source_string, self.target_string,
-                    language_code=self.language_code)
+        return test(self.str1, self.str2, language_code=self.language_code)
 
     def run_filters(self, unit, categorised=False):
         """Make some optimizations before running individual filters in
         `run_test`.
         """
-        self.source_string = data.normalized_unicode(unit.source) or u''
-        self.target_string = data.normalized_unicode(unit.target) or u''
+        self.str1 = data.normalized_unicode(unit.source) or u''
+        self.str2 = data.normalized_unicode(unit.target) or u''
 
         self.language_code = unit.store.translation_project.language.code
 
@@ -1009,6 +1008,7 @@ def run_given_filters(checker, unit, check_names=None):
 
     checker.str1 = data.normalized_unicode(unit.source) or u""
     checker.str2 = data.normalized_unicode(unit.target) or u""
+    checker.language_code = unit.language_code  # XXX: comes from `CheckableUnit`
     checker.hasplural = unit.hasplural()
     checker.locations = unit.getlocations()
 

--- a/pootle/core/checks/checker.py
+++ b/pootle/core/checks/checker.py
@@ -42,6 +42,10 @@ class CheckableUnit(UnitProxy):
     def tp(self):
         return self.store__translation_project__id
 
+    @property
+    def language_code(self):
+        return self.store__translation_project__language__code
+
 
 class UnitQualityCheck(object):
 
@@ -293,7 +297,9 @@ class QualityCheckUpdater(object):
         """Update checks for translated Units
         """
         unit_fields = [
-            "id", "source_f", "target_f", "locations", "store__id"]
+            "id", "source_f", "target_f", "locations", "store__id",
+            "store__translation_project__language__code",
+        ]
 
         tp_key = "store__translation_project__id"
         if self.translation_project is None:


### PR DESCRIPTION
Due to the confusing double code-path for running checks, checkers are locked
into the setup being done in `run_given_filters()` if they want to remain
compatible with running individual checks from the CLI.

At the same time, note `calculate_checks` never passes an actual unit to the
check runners for performance reasons, but a trimmed-down version of it, and
checkers need to therefore implicitly rely on a CLI command's implementation
details.

These extra concerns should be addressed when dealing with #4553.