### PR TITLE
LegalPages: do not perform checking for XHR views

### DIFF
--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -48,6 +48,7 @@ POOTLE_LEGALPAGE_NOCHECK_PREFIXES = (
     '/contact',
     '/jsi18n',
     '/pages',
+    '/xhr',
 )
 
 # Pootle META users


### PR DESCRIPTION
The check is only relevant for views rendering `layout.html`.