### PR TITLE
Skip `data` checks for revision command 

### DIFF
--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -17,6 +17,21 @@ from pootle_project.models import Project
 from pootle_translationproject.models import TranslationProject
 
 
+class SkipChecksMixin(object):
+    def check(self, app_configs=None, tags=None, display_num_errors=False,
+              include_deployment_checks=False):
+        skip_tags = getattr(self, 'skip_system_check_tags', None)
+        if skip_tags is not None:
+            from django.core.checks.registry import registry
+            tags = registry.tags_available() - set(skip_tags)
+
+        super(SkipChecksMixin, self).check(
+            app_configs=app_configs,
+            tags=tags,
+            display_num_errors=display_num_errors,
+            include_deployment_checks=include_deployment_checks)
+
+
 class PootleCommand(BaseCommand):
     """Base class for handling recursive pootle store management commands."""
 

--- a/pootle/apps/pootle_app/management/commands/initdb.py
+++ b/pootle/apps/pootle_app/management/commands/initdb.py
@@ -15,10 +15,12 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from django.core.management.base import BaseCommand
 
 from pootle.core.initdb import InitDB
+from . import SkipChecksMixin
 
 
-class Command(BaseCommand):
+class Command(SkipChecksMixin, BaseCommand):
     help = 'Populates the database with initial values: users, projects, ...'
+    skip_system_check_tags = ('data', )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -29,18 +31,6 @@ class Command(BaseCommand):
             help="Do not create the default 'terminology' and 'tutorial' "
                  "projects.",
         )
-
-    def check(self, app_configs=None, tags=None, display_num_errors=False,
-              include_deployment_checks=False):
-        from django.core.checks.registry import registry
-
-        tags = registry.tags_available()
-        tags.remove('data')
-        super(Command, self).check(
-            app_configs=app_configs,
-            tags=tags,
-            display_num_errors=display_num_errors,
-            include_deployment_checks=include_deployment_checks)
 
     def handle(self, **options):
         self.stdout.write('Populating the database.')

--- a/pootle/apps/pootle_app/management/commands/revision.py
+++ b/pootle/apps/pootle_app/management/commands/revision.py
@@ -14,10 +14,12 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from django.core.management.base import BaseCommand
 
 from pootle.core.models import Revision
+from . import SkipChecksMixin
 
 
-class Command(BaseCommand):
+class Command(SkipChecksMixin, BaseCommand):
     help = "Print Pootle's current revision."
+    skip_system_check_tags = ('data', )
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
Moving overwritten BaseCommand.check() to a separate mixin class allows to skip `data` checks for other commands.

Fix #4575 