### PR TITLE
Pin npm left-pad module version

### DIFF
--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -30,6 +30,7 @@
     "codemirror": "^5.7.0",
     "diff-match-patch": "^1.0.0",
     "imports-loader": "^0.6.3",
+    "left-pad": "^0.0.9",
     "md5": "^2.0.0",
     "object-assign": "^2.0.0",
     "react": "^0.14.6",


### PR DESCRIPTION
travis failed with
```
-npm ERR! Error: version not found: left-pad@0.0.3
```