### PR TITLE
Travis: catch unmigrated models

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ commands=
     bash -c "DATABASE_BACKEND=postgres python manage.py migrate --noinput --traceback"
     bash -c "DATABASE_BACKEND=postgres python manage.py initdb --no-projects"
     bash -c "DATABASE_BACKEND=sqlite python manage.py migrate --noinput --traceback"
+    # Second migration on sqlite to catch model changes not in DB
+    bash -c "DATABASE_BACKEND=sqlite python manage.py migrate --noinput | egrep 'Your models have changes that are not yet reflected in a migration'; test $? -eq 1"
     bash -c "DATABASE_BACKEND=sqlite python manage.py initdb --no-projects"
     # Other linting
     make travis-assets


### PR DESCRIPTION
Run migrate a second time to catch when we have unmigrated models.