### PR TITLE
Add checkerstyle migration

### DIFF
--- a/pootle/apps/pootle_project/migrations/0004_correct_checkerstyle_options_order.py
+++ b/pootle/apps/pootle_project/migrations/0004_correct_checkerstyle_options_order.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+"""The order of the checkerstyle options changed when we moved management from
+Translate Toolkit into Pootle.  This simple migration realigns then to what is
+expected now, preventing false positive messages about still needing a
+migration.
+"""
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_project', '0003_case_sensitive_schema'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='checkstyle',
+            field=models.CharField(default=b'standard', max_length=50, verbose_name='Quality Checks', choices=[(b'creativecommons', b'creativecommons'), (b'drupal', b'drupal'), (b'gnome', b'gnome'), (b'kde', b'kde'), (b'libreoffice', b'libreoffice'), (b'mozilla', b'mozilla'), (b'openoffice', b'openoffice'), (b'standard', b'standard'), (b'terminology', b'terminology'), (b'wx', b'wx')]),
+        ),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ commands=
     bash -c "DATABASE_BACKEND=postgres python manage.py migrate --noinput --traceback"
     bash -c "DATABASE_BACKEND=postgres python manage.py initdb --no-projects"
     bash -c "DATABASE_BACKEND=sqlite python manage.py migrate --noinput --traceback"
+    # Second migration on sqlite to catch model changes not in DB
+    bash -c "DATABASE_BACKEND=sqlite python manage.py migrate --noinput | egrep 'Your models have changes that are not yet reflected in a migration'; test $? -eq 1"
     bash -c "DATABASE_BACKEND=sqlite python manage.py initdb --no-projects"
     # Other linting
     make travis-assets


### PR DESCRIPTION
This is a nuisance migration, but is needed to prevent the error

```
  Your models have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```

from appearing after running `pootle migrate` a second time.

This PR includes #4595 which was PRs to show that the check in Travis actually does catch unlanded migrations.