### PR TITLE
Timeline: show if unit was changed via file upload

### DIFF
--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -321,6 +321,8 @@ class Timeline(object):
                         item["submitter__email"])
                 if "datetime" not in entry_group:
                     entry_group['datetime'] = item['creation_time']
+                via_upload = item["type"] == SubmissionTypes.UPLOAD
+                entry_group["via_upload"] = via_upload
                 entry_group['entries'].append(self.get_entry(item))
             grouped_entries.append(entry_group)
         return grouped_entries

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -28,6 +28,7 @@ from pootle.core.decorators import (get_path_obj, get_resource,
 from pootle.core.delegate import search_backend
 from pootle.core.exceptions import Http400
 from pootle.core.http import JsonResponse, JsonResponseBadRequest
+from pootle.core.utils import dateformat
 from pootle.core.views import PootleJSON
 from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import (check_permission,
@@ -369,11 +370,22 @@ class UnitTimelineJSON(PootleUnitJSON):
     def get_response_data(self, context):
         return {
             'uid': self.object.id,
+            'entries_group': self.get_entries_group_data(context),
             'timeline': self.render_timeline(context)}
 
     def render_timeline(self, context):
         return loader.get_template(
             self.template_name).render(context).replace('\n', '')
+
+    def get_entries_group_data(self, context):
+        result = []
+        for entry_group in context['entries_group']:
+            result.append({
+                "display_datetime": dateformat.format(entry_group['datetime']),
+                "iso_datetime": entry_group['datetime'].isoformat(),
+                "via_upload": entry_group.get('via_upload', False),
+            })
+        return result
 
 
 class UnitEditJSON(PootleUnitJSON):

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -11,6 +11,9 @@ import _ from 'underscore';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import TimeSince from 'components/TimeSince';
+import ReactRenderer from 'utils/ReactRenderer';
+
 // jQuery plugins
 import 'jquery-caret';
 import 'jquery-easing';
@@ -33,6 +36,7 @@ import fetch from 'utils/fetch';
 import linkHashtags from 'utils/linkHashtags';
 
 import SuggestionFeedbackForm from './components/SuggestionFeedbackForm';
+import UploadTimeSince from './components/UploadTimeSince';
 
 import captcha from '../captcha';
 import { UnitSet } from '../collections';
@@ -380,6 +384,7 @@ PTL.editor = {
       if (this.selectedSuggestionId !== undefined) {
         this.closeSuggestion({ checkIfCanNavigate: false });
       }
+      ReactRenderer.unmountComponents();
 
       // Walk through known filtering criterias and apply them to the editor object
 
@@ -2094,8 +2099,17 @@ PTL.editor = {
         $(data.timeline).hide().prependTo('#extras-container')
                         .slideDown(1000, 'easeOutQuad');
       }
-
-      helpers.updateRelativeDates();
+      [...document.querySelectorAll('.js-mount-timesince')].forEach((el, i) => {
+        const props = {
+          title: data.entries_group[i].display_datetime,
+          dateTime: data.entries_group[i].iso_datetime,
+        };
+        if (data.entries_group[i].via_upload) {
+          ReactRenderer.render(<UploadTimeSince {...props} />, el);
+        } else {
+          ReactRenderer.render(<TimeSince {...props} />, el);
+        }
+      });
 
       $('.timeline-field-body').filter(':not([dir])').bidi();
       $('#js-show-timeline').addClass('selected');

--- a/pootle/static/js/editor/components/UploadTimeSince.js
+++ b/pootle/static/js/editor/components/UploadTimeSince.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React, { PropTypes } from 'react';
+import { PureRenderMixin } from 'react-addons-pure-render-mixin';
+
+import TimeSince from 'components/TimeSince';
+import { t } from 'utils/i18n';
+
+const UploadTimeSince = React.createClass({
+
+  propTypes: {
+    dateTime: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+  },
+
+  mixins: [PureRenderMixin],
+
+  render() {
+    const timeSince = (
+      <TimeSince
+        className=""
+        {...this.props}
+      />
+    );
+
+    return (
+      <span className="extra-item-meta">
+        {t('%(timeSince)s via file upload', { timeSince })}
+      </span>
+    );
+  },
+
+});
+
+
+export default UploadTimeSince;

--- a/pootle/static/js/shared/components/TimeSince.js
+++ b/pootle/static/js/shared/components/TimeSince.js
@@ -77,6 +77,7 @@ const TimeSince = React.createClass({
         className="extra-item-meta"
         title={this.props.title}
         dateTime={this.props.dateTime}
+        {...this.props}
       >
         {displayTime}
       </time>

--- a/pootle/static/js/shared/utils/ReactRenderer.js
+++ b/pootle/static/js/shared/utils/ReactRenderer.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import ReactDOM from 'react-dom';
+
+
+const ReactRenderer = {
+
+  nodes: [],
+
+  render(component, node) {
+    ReactDOM.render(component, node);
+    this.nodes.push(node);
+  },
+
+  unmountComponents() {
+    this.nodes.forEach((node) => ReactDOM.unmountComponentAtNode(node));
+    this.nodes = [];
+  },
+
+};
+
+
+export default ReactRenderer;

--- a/pootle/static/js/shared/utils/i18n.js
+++ b/pootle/static/js/shared/utils/i18n.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+
+/**
+ * Make it possible React components can be added as placeholders.
+ *
+ * Example:
+ * `formatComponent(%(foo)s bar %(baz)s)` returns `[ctx.foo, bar, ctx.baz]` list.
+ */
+function formatComponent(str, ctx) {
+  const result = [];
+  let id = 0;
+  let _fmt = str;
+  let match = [];
+
+  while (_fmt) {
+    match = /^[^\x25]+/.exec(_fmt);
+    if (match !== null) {
+      result.push(match[0]);
+    } else {
+      match = /^\x25\(([^\)]+)\)s/.exec(_fmt);
+      if (match === null) {
+        throw new Error('Wrong format');
+      }
+      if (match[1]) {
+        const arg = ctx[match[1]];
+        if (React.isValidElement(arg)) {
+          result.push(React.cloneElement(arg, { key: id++ }));
+        } else {
+          result.push(arg);
+        }
+      }
+    }
+    _fmt = _fmt.substring(match[0].length);
+  }
+  return result;
+}
+
+export function t(string, ctx = null) {
+  if (!ctx) {
+    return gettext(string);
+  }
+  return formatComponent(gettext(string), ctx);
+}

--- a/pootle/templates/editor/units/xhr_timeline.html
+++ b/pootle/templates/editor/units/xhr_timeline.html
@@ -55,10 +55,17 @@
           {% endif %}
         </div>
       </div>
-      {% if entry_group.datetime %}
-      <time class="extra-item-meta js-relative-date"
-        title="{{ entry_group.datetime|dateformat }}"
-        datetime="{{ entry_group.datetime.isoformat }}">&nbsp;</time>
+      {% if entry_group.datetime or entry_group.via_upload %}
+      <div class="extra-item-meta">
+        {% if entry_group.datetime %}
+          <time class="js-relative-date"
+            title="{{ entry_group.datetime|dateformat }}"
+            datetime="{{ entry_group.datetime.isoformat }}">&nbsp;</time>
+        {% endif %}
+        {% if entry_group.via_upload %}
+          <div class="item-source">{% trans "via file upload" %}</div>
+        {% endif %}
+      </div>
       {% endif %}
     </div>
   </div>

--- a/pootle/templates/editor/units/xhr_timeline.html
+++ b/pootle/templates/editor/units/xhr_timeline.html
@@ -56,16 +56,7 @@
         </div>
       </div>
       {% if entry_group.datetime or entry_group.via_upload %}
-      <div class="extra-item-meta">
-        {% if entry_group.datetime %}
-          <time class="js-relative-date"
-            title="{{ entry_group.datetime|dateformat }}"
-            datetime="{{ entry_group.datetime.isoformat }}">&nbsp;</time>
-        {% endif %}
-        {% if entry_group.via_upload %}
-          <div class="item-source">{% trans "via file upload" %}</div>
-        {% endif %}
-      </div>
+        <div class="js-mount-timesince"></div>
       {% endif %}
     </div>
   </div>

--- a/pootle/tools/createpootlepot
+++ b/pootle/tools/createpootlepot
@@ -41,7 +41,7 @@ django-admin.py makemessages -v $VERBOSITY $ignore --ignore static/js -e py,txt,
 # makemessages is rubbish at this so use xgettext directly
 # Until xgettext properly supports JavaScript extraction we use Python, but
 # first we extract using JavaScript just to get the ones that do actually work.
-find static/js -name "*.js" |  egrep -v "(node_modules|\.bundle\.js)" | xargs xgettext --output=$DJANGO_JS_POT --language=JavaScript --from-code=utf-8
+find static/js -name "*.js" |  egrep -v "(node_modules|\.bundle\.js)" | xargs xgettext --keyword=t --output=$DJANGO_JS_POT --language=JavaScript --from-code=utf-8
 sed -i"" -e "s/charset=CHARSET/charset=UTF-8/" $DJANGO_JS_POT
 find static/js -name "*.js" |  egrep -v "(node_modules|\.bundle\.js)" | xargs xgettext --join-existing --output=$DJANGO_JS_POT --language=Python --from-code=utf-8
 


### PR DESCRIPTION
There are some cases when we can say if unit was changed or created via file upload. It will be addressed later. 
This PR adds `via file upload` label to every timeline if it was loaded via file upload.
![image](https://cloud.githubusercontent.com/assets/682845/14077298/d077631c-f4f2-11e5-9ee6-cb9cdfe71cd9.png)
Refs. #3745 