### PR TITLE
Improve performance of top_scorers

### DIFF
--- a/pootle/apps/accounts/managers.py
+++ b/pootle/apps/accounts/managers.py
@@ -79,3 +79,8 @@ class UserManager(BaseUserManager):
         return super(UserManager, self).get_queryset().exclude(
             username__in=self.META_USERS
         )
+
+    def meta_users(self):
+        return super(UserManager, self).get_queryset().filter(
+            username__in=self.META_USERS
+        )


### PR DESCRIPTION
We show top scorers on welcome page. `User.top_scorers()` triggers a relatively slow queries:
```sql
SELECT `accounts_user`.`id`, `accounts_user`.`password`, `accounts_user`.`last_login`, `accounts_user`.`username`, `accounts_user`.`email`, `accounts_user`.`full_name`, `accounts_user`.`is_active`, `accounts_user`.`is_superuser`, `accounts_user`.`date_joined`, `accounts_user`.`unit_rows`, `accounts_user`.`rate`, `accounts_user`.`review_rate`, `accounts_user`.`hourly_rate`, `accounts_user`.`score`, `accounts_user`.`currency`, `accounts_user`.`is_employee`, `accounts_user`.`twitter`, `accounts_user`.`website`, `accounts_user`.`linkedin`, `accounts_user`.`bio`, SUM(`pootle_statistics_scorelog`.`score_delta`) AS `total_score` FROM `accounts_user` INNER JOIN `pootle_statistics_scorelog` ON ( `accounts_user`.`id` = `pootle_statistics_scorelog`.`user_id` ) WHERE (NOT (`accounts_user`.`username` IN ('default', 'nobody', 'system')) AND `pootle_statistics_scorelog`.`creation_time` BETWEEN % AND %) GROUP BY `accounts_user`.`id` ORDER BY `total_score` DESC LIMIT 5;
```
`JOIN` seems to be expensive and unnecessary because we need only 5 joined rows. Result of  is cached in any case that's why this is not critical.
This PR replaces one slow query with two fast queries.