### PR TITLE
Always filter by accessible projects for user

### DIFF
--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -196,11 +196,11 @@ class Language(models.Model, TreeItem):
         return self.get_stats()
 
     def get_children_for_user(self, user, select_related=None):
-        tps = self.translationproject_set.for_user(
-            user, select_related=select_related).select_related("project")
-        return filter(
-            lambda x: x.is_accessible_by(user),
-            tps.order_by('project__fullname'))
+        return self.translationproject_set.for_user(
+            user, select_related=select_related
+        ).select_related(
+            "project"
+        ).order_by('project__fullname')
 
     def get_announcement(self, user=None):
         """Return the related announcement, if any."""

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -235,7 +235,7 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
         if user.is_superuser:
             key = iri_to_uri('projects:all')
         else:
-            username = 'nobody' if user.is_anonymous() else user.username
+            username = user.username
             key = iri_to_uri('projects:accessible:%s' % username)
         user_projects = cache.get(key, None)
 

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -56,10 +56,14 @@ PROJECT_CHECKERS = {
 class ProjectManager(models.Manager):
 
     def cached_dict(self, user):
-        """Return a cached list of projects tuples for `user`.
+        """Return a cached ordered dictionary of projects tuples for `user`.
+
+        - Admins always get all projects.
+        - Regular users only get enabled projects accessible to them.
 
         :param user: The user for whom projects need to be retrieved for.
-        :return: A list of project tuples including (code, fullname)
+        :return: An ordered dictionary of project tuples including
+          (`fullname`, `disabled`) and `code` is a key in the dictionary.
         """
         if not user.is_superuser:
             cache_params = {'username': user.username}

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -15,7 +15,6 @@ from translate.filters import checks
 from translate.lang.data import langcode_re
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
@@ -599,13 +598,6 @@ def invalidate_accessible_projects_cache(sender, instance, **kwargs):
         ['Project', 'TranslationProject', 'PermissionSet']):
         return
 
-    # FIXME: use Redis directly to clear these caches effectively
-
-    cache.delete_many([
-        make_method_key('Project', 'cached_dict', {'is_admin': False}),
-        make_method_key('Project', 'cached_dict', {'is_admin': True}),
-    ])
-
-    User = get_user_model()
-    users_list = User.objects.values_list('username', flat=True)
-    cache.delete_many(map(lambda x: 'projects:accessible:%s' % x, users_list))
+    cache.delete_pattern(make_method_key('Project', 'cached_dict', '*'))
+    cache.delete('projects:all')
+    cache.delete_pattern('projects:accessible:*')

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -329,10 +329,8 @@ class ProjectsMixin(object):
 
     @lru_cache()
     def get_object(self):
-        user_projects = Project.accessible_by_user(self.request.user)
         user_projects = (
             Project.objects.for_user(self.request.user)
-                           .filter(code__in=user_projects)
                            .select_related("directory__pootle_path"))
         return ProjectSet(user_projects)
 

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -114,7 +114,8 @@ class TranslationProjectManager(models.Manager):
         """Filters translation projects for a specific user.
 
         - Admins always get all translation projects.
-        - Regular users only get enabled translation projects.
+        - Regular users only get enabled translation projects
+            accessible to them.
 
         :param user: The user for whom the translation projects need to be
             retrieved for.
@@ -127,7 +128,9 @@ class TranslationProjectManager(models.Manager):
         if user.is_superuser:
             return qs
 
-        return qs.filter(project__disabled=False)
+        return qs.filter(
+            project__disabled=False,
+            project__code__in=Project.accessible_by_user(user))
 
     def get_for_user(self, user, project_code, language_code,
                      select_related=None):
@@ -137,7 +140,7 @@ class TranslationProjectManager(models.Manager):
         - Admins can get the translation project even
             if its project is disabled.
         - Regular users only get a translation project
-            if its project isn't disabled.
+            if its project isn't disabled and it is accessible to them.
 
         :param user: The user for whom the translation project needs
             to be retrieved.

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -101,10 +101,7 @@ def get_path_obj(func):
             except Project.DoesNotExist:
                 raise Http404
         else:  # No arguments: all user-accessible projects
-            user_projects = Project.accessible_by_user(request.user)
-            user_projects = Project.objects.for_user(request.user) \
-                                           .filter(code__in=user_projects)
-
+            user_projects = Project.objects.for_user(request.user)
             path_obj = ProjectSet(user_projects)
 
         request.ctx_obj = path_obj

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,14 +19,15 @@ ROOT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 POOTLE_TRANSLATION_DIRECTORY = os.path.join(ROOT_DIR, 'pytest_pootle', 'data', 'po')
 
 
-# Dummy caching
+# Using the only Redis DB for testing
 CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'pootle-tests'
-    },
     # Must set up entries for persistent stores here because we have a check in
     # place that will abort everything otherwise
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/15',
+        'TIMEOUT': None,
+    },
     'redis': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://127.0.0.1:6379/15',


### PR DESCRIPTION
We had filter enabled projects for regular users and shown all projects for admin users. So we didn't handle permissions which didn't make sense. This PR will address all these concerns and check accessible projects for getting TP, Stores, Units in accessible projects only.
Thanks to @francescortiz who raised this question in #4596. 