### PR TITLE
Factories: adjust naming to be explicit when they require DB access

### DIFF
--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -274,26 +274,26 @@ class PootleTestEnv(object):
             parent=DirectoryFactory(parent=None, name=""))
 
     def setup_site_matrix(self):
-        from pytest_pootle.factories import ProjectFactory, LanguageFactory
+        from pytest_pootle.factories import ProjectDBFactory, LanguageDBFactory
 
         from pootle_language.models import Language
 
         # add 2 languages
         for i in range(0, 2):
-            LanguageFactory()
+            LanguageDBFactory()
 
         source_language = Language.objects.get(code="en")
         for i in range(0, 2):
             # add 2 projects
-            ProjectFactory(source_language=source_language)
+            ProjectDBFactory(source_language=source_language)
 
     def setup_terminology(self):
-        from pytest_pootle.factories import (ProjectFactory,
+        from pytest_pootle.factories import (ProjectDBFactory,
                                              TranslationProjectFactory)
         from pootle_language.models import Language
 
         source_language = Language.objects.get(code="en")
-        terminology = ProjectFactory(code="terminology",
+        terminology = ProjectDBFactory(code="terminology",
                                      checkstyle="terminology",
                                      fullname="Terminology",
                                      source_language=source_language)
@@ -302,13 +302,13 @@ class PootleTestEnv(object):
 
     def setup_disabled_project(self):
         from pytest_pootle.factories import (DirectoryFactory,
-                                             ProjectFactory,
+                                             ProjectDBFactory,
                                              TranslationProjectFactory)
 
         from pootle_language.models import Language
 
         source_language = Language.objects.get(code="en")
-        project = ProjectFactory(code="disabled_project0",
+        project = ProjectDBFactory(code="disabled_project0",
                                  fullname="Disabled Project 0",
                                  source_language=source_language)
         project.disabled = True
@@ -359,38 +359,38 @@ class PootleTestEnv(object):
                 self._add_stores(tp)
 
     def setup_vfolders(self):
-        from pytest_pootle.factories import VirtualFolderFactory
+        from pytest_pootle.factories import VirtualFolderDBFactory
 
-        VirtualFolderFactory(filter_rules="store0.po")
-        VirtualFolderFactory(filter_rules="store1.po")
-        VirtualFolderFactory(
+        VirtualFolderDBFactory(filter_rules="store0.po")
+        VirtualFolderDBFactory(filter_rules="store1.po")
+        VirtualFolderDBFactory(
             location='/{LANG}/project0/',
             is_public=False,
             filter_rules="store0.po")
-        VirtualFolderFactory(
+        VirtualFolderDBFactory(
             location='/{LANG}/project0/',
             is_public=False,
             filter_rules="store1.po")
-        VirtualFolderFactory(
+        VirtualFolderDBFactory(
             location='/language0/project0/',
             filter_rules="subdir0/store4.po")
 
     def _add_stores(self, tp, n=(3, 2), parent=None):
-        from pytest_pootle.factories import StoreFactory, UnitFactory
+        from pytest_pootle.factories import StoreDBFactory, UnitDBFactory
 
         from pootle_store.models import UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE
 
         for i in range(0, n[0]):
             # add 3 stores
             if parent is None:
-                store = StoreFactory(translation_project=tp)
+                store = StoreDBFactory(translation_project=tp)
             else:
-                store = StoreFactory(translation_project=tp, parent=parent)
+                store = StoreDBFactory(translation_project=tp, parent=parent)
 
             # add 8 units to each store
             for state in [UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE]:
                 for i in range(0, n[1]):
-                    UnitFactory(store=store, state=state)
+                    UnitDBFactory(store=store, state=state)
 
     def _update_submission_times(self, update_time, last_update=None):
         from pootle_statistics.models import Submission

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -72,7 +72,7 @@ class DirectoryFactory(factory.django.DjangoModelFactory):
     obsolete = False
 
 
-class LanguageFactory(factory.django.DjangoModelFactory):
+class LanguageDBFactory(factory.django.DjangoModelFactory):
 
     class Meta(object):
         model = 'pootle_language.Language'
@@ -93,7 +93,7 @@ class LanguageFactory(factory.django.DjangoModelFactory):
         return 'Language %s' % (Language.objects.count() - 1)
 
 
-class ProjectFactory(factory.django.DjangoModelFactory):
+class ProjectDBFactory(factory.django.DjangoModelFactory):
 
     class Meta(object):
         model = 'pootle_project.Project'
@@ -117,7 +117,7 @@ class ProjectFactory(factory.django.DjangoModelFactory):
     checkstyle = "standard"
 
 
-class StoreFactory(factory.django.DjangoModelFactory):
+class StoreDBFactory(factory.django.DjangoModelFactory):
 
     class Meta(object):
         model = 'pootle_store.Store'
@@ -145,7 +145,7 @@ class TranslationProjectFactory(factory.django.DjangoModelFactory):
         model = 'pootle_translationproject.TranslationProject'
 
 
-class UnitFactory(factory.django.DjangoModelFactory):
+class UnitDBFactory(factory.django.DjangoModelFactory):
 
     class Meta(object):
         model = 'pootle_store.Unit'
@@ -192,7 +192,7 @@ class UnitFactory(factory.django.DjangoModelFactory):
         return ""
 
 
-class VirtualFolderFactory(factory.django.DjangoModelFactory):
+class VirtualFolderDBFactory(factory.django.DjangoModelFactory):
 
     class Meta(object):
         model = 'virtualfolder.VirtualFolder'

--- a/pytest_pootle/fixtures/models/translation_project.py
+++ b/pytest_pootle/fixtures/models/translation_project.py
@@ -86,10 +86,10 @@ def afrikaans_vfolder_test(afrikaans, vfolder_project):
 
 @pytest.fixture
 def tp_checker_tests(request, english, checkers):
-    from pytest_pootle.factories import ProjectFactory
+    from pytest_pootle.factories import ProjectDBFactory
 
     checker_name = checkers
-    project = ProjectFactory(
+    project = ProjectDBFactory(
         checkstyle=checker_name,
         source_language=english)
 

--- a/tests/import_export/import.py
+++ b/tests/import_export/import.py
@@ -84,11 +84,11 @@ def test_import_new_file(import_tps, site_users):
 
 @pytest.mark.django_db
 def test_import_to_empty(import_tps, site_users):
-    from pytest_pootle.factories import StoreFactory
+    from pytest_pootle.factories import StoreDBFactory
 
     tp = import_tps
     user = site_users["user"]
-    store = StoreFactory(translation_project=tp, name="import_to_empty.po")
+    store = StoreDBFactory(translation_project=tp, name="import_to_empty.po")
     filestore = create_store(store.pootle_path, "0",
                              [("Unit Source", "Unit Target")])
     import_file(SimpleUploadedFile(store.name,
@@ -108,12 +108,12 @@ def test_import_to_empty(import_tps, site_users):
 
 @pytest.mark.django_db
 def test_import_add_and_obsolete_units(import_tps, site_users):
-    from pytest_pootle.factories import StoreFactory, UnitFactory
+    from pytest_pootle.factories import StoreDBFactory, UnitDBFactory
 
     tp = import_tps
     user = site_users["user"]
-    store = StoreFactory(translation_project=tp)
-    unit = UnitFactory(store=store, state=TRANSLATED)
+    store = StoreDBFactory(translation_project=tp)
+    unit = UnitDBFactory(store=store, state=TRANSLATED)
     filestore = create_store(
         store.pootle_path,
         "0",

--- a/tests/models/translationproject.py
+++ b/tests/models/translationproject.py
@@ -15,7 +15,7 @@ from translate.filters import checks
 
 from django.db import IntegrityError
 
-from pytest_pootle.factories import LanguageFactory, TranslationProjectFactory
+from pytest_pootle.factories import LanguageDBFactory, TranslationProjectFactory
 
 from pootle_language.models import Language
 from pootle_project.models import Project
@@ -86,7 +86,7 @@ def test_tp_empty_stats():
     TranslationProjectFactory(project=project, language=english)
 
     # Create a new language to test.
-    language = LanguageFactory()
+    language = LanguageDBFactory()
     tp = TranslationProject.objects.create(language=language, project=project)
     tp.init_from_templates()
 
@@ -104,7 +104,7 @@ def test_tp_empty_stats():
 
 @pytest.mark.django_db
 def test_tp_stats_created_from_template(tutorial, templates):
-    language = LanguageFactory()
+    language = LanguageDBFactory()
     tp = TranslationProject.objects.create(language=language, project=tutorial)
     tp.init_from_templates()
 
@@ -119,14 +119,14 @@ def test_tp_stats_created_from_template(tutorial, templates):
 
 @pytest.mark.django_db
 def test_can_be_inited_from_templates(tutorial, templates):
-    language = LanguageFactory()
+    language = LanguageDBFactory()
     tp = TranslationProject(project=tutorial, language=language)
     assert tp.can_be_inited_from_templates()
 
 
 @pytest.mark.django_db
 def test_cannot_be_inited_from_templates():
-    language = LanguageFactory()
+    language = LanguageDBFactory()
     project = Project.objects.get(code='project0')
     tp = TranslationProject(project=project, language=language)
     assert not tp.can_be_inited_from_templates()

--- a/tests/models/virtualfolder.py
+++ b/tests/models/virtualfolder.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ValidationError
 
 import pytest
 
-from pytest_pootle.factories import VirtualFolderFactory
+from pytest_pootle.factories import VirtualFolderDBFactory
 
 from pootle_store.models import Unit
 from pootle_store.util import OBSOLETE, TRANSLATED
@@ -155,7 +155,7 @@ def test_vfolder_with_no_filter_rules():
 @pytest.mark.django_db
 def test_vfolder_membership():
 
-    vfolder = VirtualFolderFactory(filter_rules="store0.po")
+    vfolder = VirtualFolderDBFactory(filter_rules="store0.po")
 
     live_units = Unit.objects.filter(state__gt=OBSOLETE)
 
@@ -213,7 +213,7 @@ def test_vfolder_unit_priorities():
         for priority
         in Unit.objects.values_list("priority", flat=True))
 
-    vfolder0 = VirtualFolderFactory(filter_rules="store0.po", priority=3)
+    vfolder0 = VirtualFolderDBFactory(filter_rules="store0.po", priority=3)
 
     assert all(
         priority == 3
@@ -240,7 +240,7 @@ def test_vfolder_unit_priorities():
         in Unit.objects.filter(vfolders__isnull=True)
                        .values_list("priority", flat=True))
 
-    vfolder1 = VirtualFolderFactory(
+    vfolder1 = VirtualFolderDBFactory(
         location='/{LANG}/project0/',
         filter_rules="store1.po",
         priority=4)

--- a/tests/views/admin.py
+++ b/tests/views/admin.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse_lazy, reverse
 from django.utils.safestring import mark_safe
 
 from pytest_pootle.env import TEST_USERS
-from pytest_pootle.factories import LanguageFactory
+from pytest_pootle.factories import LanguageDBFactory
 
 from pootle.core.paginator import paginate
 from pootle.core.url_helpers import split_pootle_path
@@ -159,7 +159,7 @@ def test_admin_view_projects_add_tp(english, client, admin):
     user = admin
     project = Project.objects.get(code="project0")
 
-    new_language = LanguageFactory()
+    new_language = LanguageDBFactory()
     TranslationProject.objects.create(language=english, project=project)
 
     client.login(


### PR DESCRIPTION
It's surprising the fact that factories depend directly on the DB, hence
mutilating the option to use a "build" strategy (no DB writes) over a "create"
strategy (writes to the DB).

These resulted to be footguns when using them as subfactories in other
factories, so for now it'll be better to explicitly mention that they require DB
access.