### PR TITLE
Cleanup: move functions to manager methods

### DIFF
--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -388,6 +388,22 @@ class TranslationActionCodes(object):
     }
 
 
+class ScoreLogManager(models.Manager):
+
+    def for_user_in_range(self, user, start, end):
+        """Returns all logged scores for `user` in the [`start`, `end`] date
+        range.
+        """
+        return ScoreLog.objects.select_related(
+            'submission__translation_project__project',
+            'submission__translation_project__language',
+        ).filter(
+            user=user,
+            creation_time__gte=start,
+            creation_time__lte=end,
+        )
+
+
 class ScoreLog(models.Model):
     creation_time = models.DateTimeField(db_index=True, null=False)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, null=False)
@@ -403,6 +419,8 @@ class ScoreLog(models.Model):
     score_delta = models.FloatField(null=False)
     action_code = models.IntegerField(null=False)
     submission = models.ForeignKey(Submission, null=False)
+
+    objects = ScoreLogManager()
 
     class Meta(object):
         unique_together = ('submission', 'action_code')

--- a/pootle/apps/reports/models.py
+++ b/pootle/apps/reports/models.py
@@ -35,6 +35,17 @@ class ReportActionTypes(object):
     }
 
 
+class PaidTaskManager(models.Manager):
+
+    def for_user_in_range(self, user, start, end):
+        """Returns all tasks for `user` in the [`start`, `end`] date range."""
+        return self.get_queryset().filter(
+            user=user,
+            datetime__gte=start,
+            datetime__lte=end,
+        ).order_by('pk')
+
+
 class PaidTask(models.Model):
     """The Paid Task.
 
@@ -56,6 +67,8 @@ class PaidTask(models.Model):
     datetime = models.DateTimeField(_('Date'), null=False, db_index=True)
     description = models.TextField(_('Description'), null=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
+
+    objects = PaidTaskManager()
 
     @classmethod
     def get_task_type_title(cls, task_type):

--- a/pootle/apps/reports/views.py
+++ b/pootle/apps/reports/views.py
@@ -540,14 +540,6 @@ def get_daily_activity(user, scores, start, end):
     return result
 
 
-def get_tasks(user, start, end):
-    return PaidTask.objects \
-                   .filter(user=user,
-                           datetime__gte=start,
-                           datetime__lte=end) \
-                   .order_by('pk')
-
-
 def get_rates(user, start, end):
     """Get user rates that were set for the user during a period
     from start to end. Raise an exception if the user has multiple rates
@@ -571,7 +563,7 @@ def get_rates(user, start, end):
         rate = rates[0]['rate']
         review_rate = rates[0]['review_rate']
 
-    tasks = get_tasks(user, start, end)
+    tasks = PaidTask.objects.for_user_in_range(user, start, end)
     task_rates = tasks.values('task_type', 'rate').distinct()
     for task_rate in task_rates:
         if (task_rate['task_type'] == PaidTaskTypes.TRANSLATION and
@@ -598,7 +590,7 @@ def get_rates(user, start, end):
 def get_paid_tasks(user, start, end):
     result = []
 
-    tasks = get_tasks(user, start, end)
+    tasks = PaidTask.objects.for_user_in_range(user, start, end)
 
     for task in tasks:
         result.append({


### PR DESCRIPTION
This PR converts the `get_tasks()` and `get_scores()` functions from scores and paid tasks into manager methods because that's basically what they are.