### PR TITLE
Add pootle comments app

### DIFF
--- a/pootle/apps/pootle_comment/__init__.py
+++ b/pootle/apps/pootle_comment/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+default_app_config = 'pootle_comment.apps.PootleCommentConfig'
+
+
+def get_model():
+    from pootle_comment.models import Comment
+    return Comment

--- a/pootle/apps/pootle_comment/apps.py
+++ b/pootle/apps/pootle_comment/apps.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.apps import AppConfig
+
+
+class PootleCommentConfig(AppConfig):
+
+    name = "pootle_comment"
+    verbose_name = "Pootle Comments"

--- a/pootle/apps/pootle_comment/delegate.py
+++ b/pootle/apps/pootle_comment/delegate.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.plugin.delegate import Getter
+
+
+comment_should_not_be_saved = Getter(providing_args=["instance", "comment"])

--- a/pootle/apps/pootle_comment/exceptions.py
+++ b/pootle/apps/pootle_comment/exceptions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.forms import ValidationError
+
+
+class CommentNotSaved(ValidationError):
+    pass

--- a/pootle/apps/pootle_comment/forms.py
+++ b/pootle/apps/pootle_comment/forms.py
@@ -61,6 +61,7 @@ class CommentForm(DjCommentForm):
 class UnsecuredCommentForm(CommentForm):
 
     def __init__(self, target_object, data=None, *args, **kwargs):
-        super(UnsecuredCommentForm, self).__init__(target_object, data, *args, **kwargs)
+        super(UnsecuredCommentForm, self).__init__(
+            target_object, data, *args, **kwargs)
         if data:
             data.update(self.generate_security_data())

--- a/pootle/apps/pootle_comment/migrations/0001_initial.py
+++ b/pootle/apps/pootle_comment/migrations/0001_initial.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('sites', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Comment',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('object_pk', models.TextField(verbose_name='object ID')),
+                ('user_name', models.CharField(max_length=50, verbose_name="user's name", blank=True)),
+                ('user_email', models.EmailField(max_length=254, verbose_name="user's email address", blank=True)),
+                ('user_url', models.URLField(verbose_name="user's URL", blank=True)),
+                ('comment', models.TextField(max_length=3000, verbose_name='comment')),
+                ('submit_date', models.DateTimeField(default=None, verbose_name='date/time submitted', db_index=True)),
+                ('ip_address', models.GenericIPAddressField(unpack_ipv4=True, null=True, verbose_name='IP address', blank=True)),
+                ('is_public', models.BooleanField(default=True, help_text='Uncheck this box to make the comment effectively disappear from the site.', verbose_name='is public')),
+                ('is_removed', models.BooleanField(default=False, help_text='Check this box if the comment is inappropriate. A "This comment has been removed" message will be displayed instead.', verbose_name='is removed')),
+                ('content_type', models.ForeignKey(related_name='content_type_set_for_comment', verbose_name='content type', to='contenttypes.ContentType')),
+                ('site', models.ForeignKey(to='sites.Site')),
+                ('user', models.ForeignKey(related_name='comment_comments', verbose_name='user', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+            options={
+                'ordering': ('submit_date',),
+                'abstract': False,
+                'verbose_name': 'comment',
+                'verbose_name_plural': 'comments',
+                'permissions': [('can_moderate', 'Can moderate comments')],
+            },
+        ),
+    ]

--- a/pootle/apps/pootle_comment/models.py
+++ b/pootle/apps/pootle_comment/models.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django_comments.models import CommentAbstractModel
+
+
+class Comment(CommentAbstractModel):
+    """Custom model to make it easier to change if required"""

--- a/pootle/apps/pootle_comment/signals.py
+++ b/pootle/apps/pootle_comment/signals.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.dispatch import Signal
+
+comment_was_saved = Signal(providing_args=["comment"])

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -83,6 +83,7 @@ INSTALLED_APPS = [
     'import_export',  # Put before 'pootle' to ensure overextends works.
     'pootle',
     'pootle_app',
+    'pootle_comment',
     'pootle_misc',
     'pootle_store',
     'pootle_language',
@@ -111,3 +112,5 @@ AUTHENTICATION_BACKENDS = [
 ROOT_URLCONF = 'pootle.urls'
 
 AUTH_USER_MODEL = 'accounts.User'
+
+COMMENTS_APP = "pootle_comment"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,8 @@ django-redis
 django-rq>=0.8.0
 django-transaction-hooks
 
+django-contrib-comments
+
 # Libraries
 cssmin
 diff-match-patch>=20121119

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,8 @@ skip=.tox,
      pootle/core/search/backends/elasticsearch.py,
      pootle/core/utils/version.py,
      pootle/core/views.py,
-     pootle/middleware/errorpages.py
+     pootle/middleware/errorpages.py,
+     pootle/apps/pootle_comment/forms.py
 
 known_standard_library=
 known_third_party=elasticsearch,translate

--- a/tests/forms/comment.py
+++ b/tests/forms/comment.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle.core.plugin import getter
+from pootle_comment.delegate import comment_should_not_be_saved
+from pootle_comment.models import Comment
+from pootle_comment.forms import CommentForm, UnsecuredCommentForm
+
+from pootle_store.models import Unit
+
+
+@pytest.mark.django_db
+def test_comment_form():
+    # must be bound to an object
+    with pytest.raises(TypeError):
+        CommentForm()
+    with pytest.raises(AttributeError):
+        CommentForm("some string")
+    unit = Unit.objects.first()
+    form = CommentForm(unit)
+    secdata = form.generate_security_data()
+    assert secdata["object_pk"] == str(unit.pk)
+    assert secdata["content_type"] == str(unit._meta)
+    assert "timestamp" in secdata
+    assert "security_hash" in secdata
+
+
+@pytest.mark.django_db
+def test_comment_form_post(admin):
+    unit = Unit.objects.first()
+    form = CommentForm(unit)
+    kwargs = dict(
+        comment="Foo!",
+        user=admin,
+        timestamp=form.initial.get("timestamp"),
+        security_hash=form.initial.get("security_hash"))
+    post_form = CommentForm(unit, kwargs)
+    if post_form.is_valid():
+        post_form.save()
+    comment = Comment.objects.first()
+    assert comment.comment == "Foo!"
+    assert ".".join(comment.content_type.natural_key()) == str(unit._meta)
+    assert comment.object_pk == str(unit.pk)
+    assert comment.user == admin
+    assert comment.name == admin.display_name
+    assert comment.email == admin.email
+
+
+@pytest.mark.django_db
+def test_unsecured_comment_form_post(admin):
+    unit = Unit.objects.first()
+    kwargs = dict(
+        comment="Foo!",
+        user=admin)
+    post_form = UnsecuredCommentForm(unit, kwargs)
+    if post_form.is_valid():
+        post_form.save()
+    comment = Comment.objects.first()
+    assert comment.comment == "Foo!"
+    assert ".".join(comment.content_type.natural_key()) == str(unit._meta)
+    assert comment.object_pk == str(unit.pk)
+    assert comment.user == admin
+    assert comment.name == admin.display_name
+    assert comment.email == admin.email
+
+
+@pytest.mark.django_db
+def test_unsecured_comment_form_should_save(admin):
+    unit = Unit.objects.first()
+    BAD_WORDS = ["google", "oracle", "apple", "microsoft"]
+
+    @getter(comment_should_not_be_saved, sender=Unit)
+    def comment_handler(sender, **kwargs):
+        for bad_word in BAD_WORDS:
+            if bad_word in kwargs["comment"].comment:
+                return "You cant say '%s' round here" % bad_word
+
+    kwargs = dict(
+        comment="google is foo!",
+        user=admin)
+    post_form = UnsecuredCommentForm(unit, kwargs)
+    assert not post_form.is_valid()
+    assert post_form.errors["comment"] == ["You cant say 'google' round here"]
+    kwargs = dict(
+        comment="You can say linux though, or gnu/linux if you prefer",
+        user=admin)
+    post_form = UnsecuredCommentForm(unit, kwargs)
+    assert post_form.is_valid()


### PR DESCRIPTION
This PR adds a pootle_comments app to:

- add django_comments (previously ka django.contrib.comments)
- customize comment forms
- create custom comment model - this is not used but would make it much easier in the event that we do want to customize the model
