### PR TITLE
Add search_backend getter

### DIFF
--- a/pootle/apps/pootle_store/apps.py
+++ b/pootle/apps/pootle_store/apps.py
@@ -6,4 +6,15 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-default_app_config = 'pootle_store.apps.PootleStoreConfig'
+import importlib
+
+from django.apps import AppConfig
+
+
+class PootleStoreConfig(AppConfig):
+
+    name = "pootle_store"
+    verbose_name = "Pootle Store"
+
+    def ready(self):
+        importlib.import_module("pootle_store.getters")

--- a/pootle/apps/pootle_store/getters.py
+++ b/pootle/apps/pootle_store/getters.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+
+from pootle.core.delegate import search_backend
+from pootle.core.plugin import getter
+
+from .models import Unit
+from .unit.search import DBSearchBackend
+
+
+@getter(search_backend, sender=Unit)
+def get_search_backend(**kwargs):
+    return DBSearchBackend

--- a/pootle/apps/pootle_store/util.py
+++ b/pootle/apps/pootle_store/util.py
@@ -8,7 +8,6 @@
 # AUTHORS file for copyright and authorship information.
 
 import os
-from importlib import import_module
 
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
@@ -113,11 +112,3 @@ def get_state_name(code, default="untranslated"):
 
 def vfolders_installed():
     return "virtualfolder" in settings.INSTALLED_APPS
-
-
-def get_search_backend():
-    search_backend_module = import_module(
-        ".".join(settings.POOTLE_SEARCH_BACKEND.split(".")[:-1]))
-    return getattr(
-        search_backend_module,
-        settings.POOTLE_SEARCH_BACKEND.split(".")[-1])

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -24,6 +24,7 @@ from django.views.decorators.http import require_http_methods
 
 from pootle.core.decorators import (get_path_obj, get_resource,
                                     permission_required)
+from pootle.core.delegate import search_backend
 from pootle.core.exceptions import Http400
 from pootle.core.http import JsonResponse, JsonResponseBadRequest
 from pootle.core.views import PootleJSON
@@ -43,7 +44,7 @@ from .templatetags.store_tags import (highlight_diffs, pluralize_source,
                                       pluralize_target)
 from .unit.results import GroupedResults
 from .unit.timeline import Timeline
-from .util import find_altsrcs, get_search_backend
+from .util import find_altsrcs
 
 
 #: Mapping of allowed sorting criteria.
@@ -202,7 +203,7 @@ def get_units(request):
                     raise Http400(_('Arguments missing.'))
         raise Http404(forms.ValidationError(search_form.errors).messages)
 
-    total, start, end, units_qs = get_search_backend()(
+    total, start, end, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     return JsonResponse(
         {'start': start,

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+
+from pootle.core.plugin.delegate import Getter
+
+
+search_backend = Getter(providing_args=["instance"])

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -30,6 +30,7 @@ from django.views.defaults import (permission_denied as django_403,
                                    server_error as django_500)
 from django.views.generic import View, DetailView
 
+from pootle.core.delegate import search_backend
 from pootle_app.models.permissions import (
     check_permission, get_matching_permissions)
 from pootle_misc.stats import get_translation_states
@@ -37,7 +38,7 @@ from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_misc.util import ajax_required
 from pootle_store.forms import UnitExportForm
-from pootle_store.util import get_search_backend
+from pootle_store.models import Unit
 
 from .browser import get_table_headings
 from .helpers import (SIDEBAR_COOKIE_NAME,
@@ -699,7 +700,7 @@ class PootleExportView(PootleDetailView):
             raise Http404(
                 ValidationError(search_form.errors).messages)
 
-        total, start, end, units_qs = get_search_backend()(
+        total, start, end, units_qs = search_backend.get(Unit)(
             self.request.user, **search_form.cleaned_data).search()
 
         units_qs = units_qs.select_related('store')

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -77,5 +77,3 @@ RQ_QUEUES = {
         'DEFAULT_TIMEOUT': 360,
     },
 }
-
-POOTLE_SEARCH_BACKEND = "pootle_store.unit.search.DBSearchBackend"

--- a/tests/search.py
+++ b/tests/search.py
@@ -8,14 +8,18 @@
 
 import pytest
 
+from pootle.core.delegate import search_backend
+from pootle.core.plugin import getter
 from pootle_project.models import Project
 from pootle_statistics.models import SubmissionTypes
+from pootle_store.getters import get_search_backend
 from pootle_store.models import (
     FUZZY, TRANSLATED, UNTRANSLATED,
     SuggestionStates, Unit)
 from pootle_store.unit.filters import (
     FilterNotFound, UnitChecksFilter, UnitContributionFilter, UnitSearchFilter,
     UnitStateFilter, UnitTextSearch)
+from pootle_store.unit.search import DBSearchBackend
 
 
 def _expected_text_search_words(text, exact):
@@ -291,3 +295,31 @@ def test_units_checks_filter_bad():
 def test_units_filters():
     qs = Unit.objects.all()
     assert UnitSearchFilter().filter(qs, "FOO").count() == 0
+
+
+@pytest.mark.django_db
+def test_unit_search_backend():
+    assert search_backend.get() is None
+    assert search_backend.get(Unit) is DBSearchBackend
+
+
+@pytest.mark.django_db
+def test_unit_search_backend_custom():
+
+    class CustomSearchBackend(DBSearchBackend):
+        pass
+
+    # add a custom getter, simulating adding before pootle_store
+    # in INSTALLED_APPS
+
+    # disconnect the default search_backend
+    search_backend.disconnect(get_search_backend, sender=Unit)
+
+    @getter(search_backend, sender=Unit)
+    def custom_get_search_backend(**kwargs):
+        return CustomSearchBackend
+
+    # reconnect the default search_backend
+    search_backend.connect(get_search_backend, sender=Unit)
+
+    assert search_backend.get(Unit) is CustomSearchBackend

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -16,6 +16,7 @@ from pytest_pootle.suite import view_context_test
 
 from pootle_app.models.permissions import check_permission
 from pootle.core.browser import make_project_item, get_table_headings
+from pootle.core.delegate import search_backend
 from pootle.core.helpers import (
     SIDEBAR_COOKIE_NAME,
     get_filter_name, get_sidebar_announcements_context)
@@ -25,7 +26,7 @@ from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_misc.stats import get_translation_states
 from pootle_store.forms import UnitExportForm
-from pootle_store.util import get_search_backend
+from pootle_store.models import Unit
 
 
 def _test_browse_view(language, request, response, kwargs):
@@ -106,7 +107,7 @@ def _test_export_view(language, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = get_search_backend()(
+    total, start, end, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -22,6 +22,7 @@ from pootle_app.models.permissions import check_permission
 from pootle.core.browser import (
     get_table_headings, make_language_item, make_xlanguage_item,
     make_project_list_item)
+from pootle.core.delegate import search_backend
 from pootle.core.helpers import (
     SIDEBAR_COOKIE_NAME,
     get_filter_name, get_sidebar_announcements_context)
@@ -32,8 +33,7 @@ from pootle_misc.forms import make_search_form
 from pootle_misc.stats import get_translation_states
 from pootle_project.models import Project, ProjectResource, ProjectSet
 from pootle_store.forms import UnitExportForm
-from pootle_store.models import Store
-from pootle_store.util import get_search_backend
+from pootle_store.models import Store, Unit
 from virtualfolder.models import VirtualFolderTreeItem
 
 
@@ -163,7 +163,7 @@ def _test_export_view(project, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = get_search_backend()(
+    total, start, end, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [
@@ -298,7 +298,7 @@ def test_view_projects_export(client):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = get_search_backend()(
+    total, start, end, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -18,6 +18,7 @@ from pootle_app.models import Directory
 from pootle_app.models.permissions import check_permission
 from pootle.core.browser import (
     get_parent, get_table_headings, make_directory_item, make_store_item)
+from pootle.core.delegate import search_backend
 from pootle.core.helpers import (
     SIDEBAR_COOKIE_NAME,
     get_filter_name, get_sidebar_announcements_context)
@@ -27,8 +28,7 @@ from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_misc.stats import get_translation_states
 from pootle_store.forms import UnitExportForm
-from pootle_store.models import Store
-from pootle_store.util import get_search_backend
+from pootle_store.models import Store, Unit
 from virtualfolder.helpers import (
     extract_vfolder_from_path, make_vfolder_treeitem_dict)
 from virtualfolder.helpers import vftis_for_child_dirs
@@ -200,7 +200,7 @@ def _test_export_view(tp, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = get_search_backend()(
+    total, start, end, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [


### PR DESCRIPTION
Replaces POOTLE_SEARCH_BACKEND settings with a search_backend getter.

To add a custom search backend, an app with the relevant getter and backend should be added before pootle_store in INSTALLED_APPS