### PR TITLE
Move a few bits away from pootle_misc

### DIFF
--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -23,7 +23,7 @@ from django_rq.queues import get_failed_queue, get_queue
 from django_rq.workers import Worker
 
 from pootle.core.decorators import admin_required
-from pootle_misc.aggregate import sum_column
+from pootle.core.utils.aggregate import sum_column
 from pootle_statistics.models import Submission
 from pootle_store.models import Suggestion, Unit
 from pootle_store.util import TRANSLATED

--- a/pootle/apps/pootle_store/fields.py
+++ b/pootle/apps/pootle_store/fields.py
@@ -222,7 +222,7 @@ class TranslationStoreFieldFile(FieldFile):
         avoid the need for locking.
         """
         import shutil
-        from pootle_misc import ptempfile as tempfile
+        from pootle.core.utils import ptempfile as tempfile
         tmpfile, tmpfilename = tempfile.mkstemp(suffix=self.filename)
         os.close(tmpfile)
         self.store.savefile(tmpfilename)

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -42,8 +42,8 @@ from pootle.core.storage import PootleFileSystemStorage
 from pootle.core.url_helpers import (
     get_all_pootle_paths, get_editor_filter, split_pootle_path)
 from pootle.core.utils import dateformat
+from pootle.core.utils.aggregate import max_column
 from pootle.core.utils.timezone import datetime_min, make_aware
-from pootle_misc.aggregate import max_column
 from pootle_misc.checks import check_names, get_checker
 from pootle_misc.util import import_func
 from pootle_statistics.models import (Submission, SubmissionFields,

--- a/pootle/core/models/__init__.py
+++ b/pootle/core/models/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from .revision import Revision
+from .virtualresource import VirtualResource
+
+
+__all__ = ('Revision', 'VirtualResource')

--- a/pootle/core/models/revision.py
+++ b/pootle/core/models/revision.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
@@ -7,9 +6,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-
-from .cache import get_cache
-from .mixins import TreeItem
+from ..cache import get_cache
 
 
 cache = get_cache('redis')
@@ -76,37 +73,3 @@ class Revision(object):
             return cache.incr(cls.CACHE_KEY)
         except ValueError:
             raise NoRevision()
-
-
-class VirtualResource(TreeItem):
-    """An object representing a virtual resource.
-
-    A virtual resource doesn't live in the DB and has a unique
-    `pootle_path` of its own. It's a simple collection of actual
-    resources.
-
-    For instance, this can be used in projects to have cross-language
-    references.
-
-    Don't use this object as-is, rather subclass it and adapt the
-    implementation details for each context.
-    """
-
-    def __init__(self, resources, pootle_path, *args, **kwargs):
-        self.resources = resources  #: Collection of underlying resources
-        self.pootle_path = pootle_path
-
-        super(VirtualResource, self).__init__(*args, **kwargs)
-
-    def __unicode__(self):
-        return self.pootle_path
-
-    # # # TreeItem
-
-    def get_children(self):
-        return self.resources
-
-    def get_cachekey(self):
-        return self.pootle_path
-
-    # # # /TreeItem

--- a/pootle/core/models/virtualresource.py
+++ b/pootle/core/models/virtualresource.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+
+from ..mixins import TreeItem
+
+
+class VirtualResource(TreeItem):
+    """An object representing a virtual resource.
+
+    A virtual resource doesn't live in the DB and has a unique
+    `pootle_path` of its own. It's a simple collection of actual
+    resources.
+
+    For instance, this can be used in projects to have cross-language
+    references.
+
+    Don't use this object as-is, rather subclass it and adapt the
+    implementation details for each context.
+    """
+
+    def __init__(self, resources, pootle_path, *args, **kwargs):
+        self.resources = resources  #: Collection of underlying resources
+        self.pootle_path = pootle_path
+
+        super(VirtualResource, self).__init__(*args, **kwargs)
+
+    def __unicode__(self):
+        return self.pootle_path
+
+    # # # TreeItem
+
+    def get_children(self):
+        return self.resources
+
+    def get_cachekey(self):
+        return self.pootle_path
+
+    # # # /TreeItem

--- a/pootle/core/utils/aggregate.py
+++ b/pootle/core/utils/aggregate.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
@@ -14,11 +13,9 @@ from django.db.models import Count, Max, Sum
 
 def max_column(queryset, column, default):
     result = queryset.aggregate(result=Max(column))['result']
-
     if result is None:
         return default
-    else:
-        return result
+    return result
 
 
 def sum_column(queryset, columns, count=False):

--- a/pootle/core/utils/ptempfile.py
+++ b/pootle/core/utils/ptempfile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.

--- a/pootle/core/utils/stats.py
+++ b/pootle/core/utils/stats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -33,7 +33,6 @@ from django.views.generic import View, DetailView
 from pootle.core.delegate import search_backend
 from pootle_app.models.permissions import (
     check_permission, get_matching_permissions)
-from pootle_misc.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_misc.util import ajax_required
@@ -46,6 +45,7 @@ from .helpers import (SIDEBAR_COOKIE_NAME,
 from .http import JsonResponse, JsonResponseBadRequest
 from .url_helpers import get_path_parts, get_previous_url
 from .utils.json import PootleJSONEncoder, jsonify
+from .utils.stats import get_translation_states
 
 
 def check_directory_permission(permission_codename, request, directory):

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -22,9 +22,9 @@ from pootle.core.helpers import (
     get_filter_name, get_sidebar_announcements_context)
 from pootle.core.url_helpers import get_previous_url
 from pootle.core.utils.json import jsonify
+from pootle.core.utils.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
-from pootle_misc.stats import get_translation_states
 from pootle_store.forms import UnitExportForm
 from pootle_store.models import Unit
 

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -28,9 +28,9 @@ from pootle.core.helpers import (
     get_filter_name, get_sidebar_announcements_context)
 from pootle.core.utils.json import jsonify
 from pootle.core.url_helpers import get_previous_url, get_path_parts
+from pootle.core.utils.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
-from pootle_misc.stats import get_translation_states
 from pootle_project.models import Project, ProjectResource, ProjectSet
 from pootle_store.forms import UnitExportForm
 from pootle_store.models import Store, Unit

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -24,9 +24,9 @@ from pootle.core.helpers import (
     get_filter_name, get_sidebar_announcements_context)
 from pootle.core.url_helpers import get_previous_url, get_path_parts
 from pootle.core.utils.json import jsonify
+from pootle.core.utils.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
-from pootle_misc.stats import get_translation_states
 from pootle_store.forms import UnitExportForm
 from pootle_store.models import Store, Unit
 from virtualfolder.helpers import (


### PR DESCRIPTION
This PR moves some utilities away from `pootle_misc` into `pootle.core`.

Refs. #3656.