### PR TITLE
[WIP] Fix: explicitly coerce fileunitid when matching to existing unitids i…

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -197,7 +197,7 @@ class StoreDiff(object):
         for (insert_at, uids_add, next_index, delta) in self.insert_points:
             for index, uid in enumerate(uids_add):
                 file_unit = self.file_store.findid(uid)
-                if file_unit and file_unit.getid() not in self.db_units:
+                if file_unit and str(file_unit.getid()) not in self.db_units:
                     new_unit_index = insert_at + index + 1 + offset
                     to_add += [(file_unit, new_unit_index)]
             if delta > 0:


### PR DESCRIPTION
…n pootle_store.diff

fixes #4594

This is only exposed by plural form multistrings afaict.

This PR restores the old behaviour, but i need to check that the old behaviour is in fact correct.

Im also wondering if it should coerce with `unicode` or `str`

Once im clear about what the right thing is, ill add a test for it 8/