### PR TITLE
Don't show warning popup after 100% autofill

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -2090,10 +2090,13 @@ PTL.editor = {
       const $element = $(this.focused);
       // set only if the textarea is empty
       if ($element.val() === '') {
+        // save unit editor state to restore it after autofill changes
+        const isUnitDirty = PTL.editor.isUnitDirty;
         const text = results[0].target;
         $element.val(text).trigger('input');
         $element.caret(text.length, text.length);
         this.goFuzzy();
+        PTL.editor.isUnitDirty = isUnitDirty;
       }
     }
 


### PR DESCRIPTION
This commit saves previous state of editor `PTL.editor.isUnitDirty` and
restores its value after 100% autofill changes are applied.
Fixes #4593