### PR TITLE
Store terminology

### DIFF
--- a/pootle/apps/import_export/views.py
+++ b/pootle/apps/import_export/views.py
@@ -52,8 +52,6 @@ def export(request):
     with BytesIO() as f:
         with ZipFile(f, "w") as zf:
             for store in stores:
-                if store.is_terminology:
-                    continue
                 try:
                     data = store.serialize()
                 except Exception as e:

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1324,7 +1324,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         return self.file.name
 
     @property
-    def is_terminology(self):
+    def has_terminology(self):
         """is this a project specific terminology store?"""
         # TODO: Consider if this should check if the store belongs to a
         # terminology project. Probably not, in case this might be called over

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1754,9 +1754,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
     def serialize(self):
         from django.core.cache import caches
 
-        if self.is_terminology:
-            raise NotImplementedError("Cannot serialize terminology stores")
-
         cache = caches["exports"]
         rev = self.get_max_unit_revision()
         path = self.pootle_path

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -377,7 +377,7 @@ class UnitTimelineJSON(PootleUnitJSON):
 class UnitEditJSON(PootleUnitJSON):
 
     def get_edit_template(self):
-        if self.project.is_terminology or self.store.is_terminology:
+        if self.project.is_terminology or self.store.has_terminology:
             return loader.get_template('editor/units/term_edit.html')
         return loader.get_template('editor/units/edit.html')
 


### PR DESCRIPTION
This PR

- removes the is_terminology conditions on im/export
- renames Store.is_terminology to Store.is_store_terminology to make it less confusing as to whether a store is in a terminology project