### PR TITLE
utils: add helper to retrieve online docs URLs

### DIFF
--- a/pootle/core/utils/docs.py
+++ b/pootle/core/utils/docs.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from ..url_helpers import urljoin
+from .version import get_rtd_version
+
+
+DOCS_BASE = u'https://docs.translatehouse.org/projects/pootle/en/'
+
+
+def get_docs_url(path_name, version=None):
+    """Returns the absolute URL to `path_name` in the RTD docs."""
+    return urljoin(DOCS_BASE, get_rtd_version(version=version), path_name)

--- a/pootle/core/utils/version.py
+++ b/pootle/core/utils/version.py
@@ -168,6 +168,16 @@ def get_docs_version(version=None, positions=2):
     return _get_version_string(version[:positions])
 
 
+def get_rtd_version(version=None):
+    """Return the docs version string reported in the RTD site."""
+    version_str = get_docs_version(version=version, positions=3)
+    return (
+        'latest'
+        if version_str == 'dev'
+        else 'stable-%s' % (version_str, )
+    )
+
+
 def _shell_command(command):
     """Return the first result of a shell ``command``"""
     repo_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Passing a path relative to the docs directory will build the absolute URL for
it, including the version string.

Example usage: `get_docs_url('server/commands.html')`