### PR TITLE
Expose leaderboard at Project, Language and TP pages

### DIFF
--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -1080,8 +1080,6 @@ def get_qualitychecks():
 
 
 def get_qualitycheck_schema(path_obj=None):
-    # TODO: add tests
-
     d = {}
     checks = get_qualitychecks()
 
@@ -1102,6 +1100,31 @@ def get_qualitycheck_schema(path_obj=None):
     result = sorted([item for code, item in d.items()],
                     key=lambda x: x['code'],
                     reverse=True)
+
+    return result
+
+
+def get_qualitycheck_list(path_obj):
+    """
+    Returns list of checks sorted in alphabetical order
+    but having critical checks first.
+    """
+    result = []
+    checks = get_qualitychecks()
+
+    for check, cat in checks.items():
+        result.append({
+            'code': check,
+            'is_critical': cat == Category.CRITICAL,
+            'title': u"%s" % check_names.get(check, check),
+            'url': path_obj.get_translate_url(check=check)
+        })
+
+    def alphabetical_critical_first(item):
+        critical_first = 0 if item['is_critical'] else 1
+        return critical_first, item['title'].lower()
+
+    result = sorted(result, key=alphabetical_critical_first)
 
     return result
 

--- a/pootle/apps/pootle_misc/templatetags/common_tags.py
+++ b/pootle/apps/pootle_misc/templatetags/common_tags.py
@@ -62,7 +62,7 @@ def top_scorers(*args, **kwargs):
     User = get_user_model()
     allowed_kwargs = ('days', 'language', 'project', 'limit')
     lookup_kwargs = dict(
-        (k, v) for (k, v) in kwargs.iteritems() if k in allowed_kwargs
+        (k, v) for (k, v) in kwargs.iteritems() if k in allowed_kwargs and v
     )
 
     return {

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -30,6 +30,7 @@ from django.views.defaults import (permission_denied as django_403,
 from django.views.generic import View, DetailView
 
 from pootle.core.delegate import search_backend
+from pootle.core.url_helpers import split_pootle_path
 from pootle_app.models.permissions import (
     check_permission, get_matching_permissions)
 from pootle_misc.checks import get_qualitycheck_schema
@@ -607,6 +608,7 @@ class PootleBrowseView(PootleDetailView):
         filters = {}
         can_translate = False
         can_translate_stats = False
+        User = get_user_model()
         if self.has_vfolders:
             filters['sort'] = 'priority'
 
@@ -632,6 +634,9 @@ class PootleBrowseView(PootleDetailView):
         ctx, cookie_data = self.sidebar_announcements
         ctx.update(
             super(PootleBrowseView, self).get_context_data(*args, **kwargs))
+
+        language_code, project_code = split_pootle_path(self.pootle_path)[:2]
+
         ctx.update(
             {'page': 'browse',
              'stats': jsonify(self.stats),
@@ -645,6 +650,9 @@ class PootleBrowseView(PootleDetailView):
              'url_action_view_all': url_action_view_all,
              'table': self.table,
              'is_store': self.is_store,
+             'top_scorers': User.top_scorers(project=project_code,
+                                             language=language_code,
+                                             limit=10),
              'browser_extends': self.template_extends})
         return ctx
 

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -33,7 +33,7 @@ from pootle.core.delegate import search_backend
 from pootle.core.url_helpers import split_pootle_path
 from pootle_app.models.permissions import (
     check_permission, get_matching_permissions)
-from pootle_misc.checks import get_qualitycheck_schema
+from pootle_misc.checks import get_qualitycheck_list, get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_misc.util import ajax_required
 from pootle_store.forms import UnitExportForm
@@ -641,7 +641,7 @@ class PootleBrowseView(PootleDetailView):
             {'page': 'browse',
              'stats': jsonify(self.stats),
              'translation_states': get_translation_states(self.object),
-             'check_categories': get_qualitycheck_schema(self.object),
+             'checks': get_qualitycheck_list(self.object),
              'can_translate': can_translate,
              'can_translate_stats': can_translate_stats,
              'url_action_continue': url_action_continue,

--- a/pootle/static/css/navbar.css
+++ b/pootle/static/css/navbar.css
@@ -174,7 +174,7 @@ html[dir="rtl"] #nav-main > li
     height: 24px;
     margin: 0 8px;
     border: 2px solid white;
-    border-radius: 3px;
+    border-radius: 50%;
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
 }
 

--- a/pootle/static/css/scores.css
+++ b/pootle/static/css/scores.css
@@ -67,3 +67,73 @@
     opacity: 0.8;
     text-decoration: none;
 }
+
+.path-summary-more .path-summary-collapsed .number
+{
+    color: #999;
+}
+
+.path-summary-more .top-scorers .top-scorer,
+.path-summary-more .top-scorers .user,
+.path-summary-more .top-scorers .number,
+.path-summary-more .top-scorers .place,
+.path-summary-more .path-summary-collapsed label
+{
+    padding-right: 3px;
+    float: left;
+}
+
+.path-summary-more .top-scorer .user-name
+{
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 1em;
+    white-space: nowrap;
+    display: block;
+}
+
+.path-summary-more .path-summary-collapsed .top-scorer .user-name
+{
+    max-width: 10em;
+}
+
+.path-summary-more .top-scorers .top-scorer
+{
+    padding-left: 1em;
+}
+
+.path-summary-more .top-scorers-table
+{
+    font-size: 1em;
+    width: 100%;
+    table-layout: fixed;
+}
+
+.path-summary-more .top-scorers-table tr td.number:last-child
+{
+    width: 20%;
+    text-align: right;
+}
+
+.path-summary-more .top-scorers-table tr td.number:first-child
+{
+    text-align: left;
+    width: 2em;
+}
+
+.top-scorer a
+{
+    position: relative;
+    vertical-align: bottom;
+}
+
+.top-scorer .user-name
+{
+    margin-left: 24px;
+}
+
+.top-scorer img.avatar
+{
+    position: absolute;
+    top: -3px;
+}

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1603,32 +1603,51 @@ html[dir="rtl"] ul.pager li:last-child > *
     height: 1.8em;
 }
 
-.summary-col
+.summary-1-col,
+.summary-2-col
 {
-    width: 25%;
+    width: 18.75%;
     float: left;
 }
 
-.summary-col.third
+.summary-3-col
 {
-    width: 50%;
+    float: left;
 }
+
+.path-summary-more .summary-3-col
+{
+    width: 43.75%;
+    margin: 0 0 0 6.25%;
+}
+
+.path-summary-more .summary-1-col
+{
+    margin: 0 6.25% 0 0;
+}
+
+.path-summary-more .summary-2-col
+{
+    margin: 0 3.125% 0 3.125%;
+}
+
 
 @media screen and (max-width: 1440px)
 {
-    .summary-col
+    .path-summary-more .summary-1-col,
+    .path-summary-more .summary-2-col
     {
-        width: 50%;
+        width: 43.75%;
         display: table-cell;
     }
 
-    .summary-col.third
+    .path-summary-more .summary-3-col
     {
         width: 100%;
-        float: left;
+        margin: 0;
     }
 
-    #top-stats .path-summary-more .summary-col.third h3.top
+    #top-stats .path-summary-more .summary-3-col h3.top
     {
         margin: 1em 0 0 0;
     }
@@ -1637,7 +1656,28 @@ html[dir="rtl"] ul.pager li:last-child > *
     {
         margin: 2.5em 0 1em 0;
     }
+
+    .path-summary-more .summary-2-col
+    {
+        margin: 0 0 0 6.25%;
+    }
+
+    .path-summary-more .summary-1-col
+    {
+        margin: 0 6.25% 0 0;
+    }
 }
+
+.path-summary-more .bd
+{
+    margin: 1em 0 1em 0;
+}
+
+.path-summary-more .summary-3-col .bd
+{
+    margin: 1em 0 1em 0;
+}
+
 
 #top-stats .path-summary-more h3
 {
@@ -1645,7 +1685,7 @@ html[dir="rtl"] ul.pager li:last-child > *
     margin: 2em 0 0 0;
 }
 
-#top-stats .path-summary-more .summary-col h3.top
+#top-stats .path-summary-more h3.top
 {
     margin: 0;
 }
@@ -1653,25 +1693,6 @@ html[dir="rtl"] ul.pager li:last-child > *
 .path-summary-more table.stats
 {
     width: 100%;
-}
-
-.path-summary-more .bd
-{
-    margin: 1em 25% 1em 0;
-}
-
-.path-summary-more .summary-col.third .bd
-{
-    margin: 1em 1em 1em 0;
-}
-.path-summary-more table.last
-{
-    width: 100%;
-}
-
-.path-summary-more table.last td:first-child
-{
-    min-width: 5em;
 }
 
 .path-summary-more td.stats-number

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -820,10 +820,6 @@ html[dir="rtl"] .hd h2
         display: none;
     }
 
-    table.last .last-updated .action-text
-    {
-        display: none;
-    }
 }
 
 html[dir="rtl"] .last-action
@@ -1518,7 +1514,6 @@ html[dir="rtl"] ul.pager li:last-child > *
 
 #progressbar
 {
-    margin-left: 10px;
     position: relative;
 }
 
@@ -1526,26 +1521,142 @@ html[dir="rtl"] ul.pager li:last-child > *
 {
     width: 100%;
     position: absolute;
+    height: 12px;
+}
+
+.expand-stats
+{
+    float: right;
+    position: relative;
+    width: 0;
+    height: 0;
+}
+
+.expand-stats .icon-expand-stats,
+.expand-stats .icon-collapse-stats
+{
+    position: relative;
+    top: 20px;
+    left: 0px;
 }
 
 .path-summary-more
 {
     padding: 0 2em;
-    display: none;
     border: 1px solid #d9d9d9;
     background: #f4f4f4;
-
     border-radius: 0 0 5px 5px;
+}
+
+.path-summary-more .path-summary-expanded,
+.path-summary-more.expand .path-summary-collapsed
+{
+    display: none;
+}
+
+.path-summary-more .path-summary-collapsed
+{
+    display: block;
+    margin-top: 11px;
+}
+
+.path-summary-more.expand .path-summary-expanded
+{
+    display: block;
+    margin-top: 2.5em;
+}
+
+.path-summary-more .path-summary-collapsed
+{
+    margin-left: -10px;
+    padding: 10px 0 10px 0;
+    height: 15px;
+}
+
+.path-summary-more .path-summary-collapsed label
+{
+    color: #999;
+}
+
+.path-summary-more table tr:hover
+{
+    background: rgba(0, 0, 0, 0.05);
+}
+
+.path-summary-more td
+{
+    height: 1.8em;
+}
+
+.summary-col
+{
+    width: 25%;
+    float: left;
+}
+
+.summary-col.third
+{
+    width: 50%;
+}
+
+@media screen and (max-width: 1440px)
+{
+    .summary-col
+    {
+        width: 50%;
+        display: table-cell;
+    }
+
+    .summary-col.third
+    {
+        width: 100%;
+        float: left;
+    }
+
+    #top-stats .path-summary-more .summary-col.third h3.top
+    {
+        margin: 1em 0 0 0;
+    }
+
+    .path-summary-more.expand .path-summary-expanded
+    {
+        margin: 2.5em 0 1em 0;
+    }
+}
+
+#top-stats .path-summary-more h3
+{
+    border: 0;
+    margin: 2em 0 0 0;
+}
+
+#top-stats .path-summary-more .summary-col h3.top
+{
+    margin: 0;
 }
 
 .path-summary-more table.stats
 {
-    width: 40em;
+    width: 100%;
 }
 
+.path-summary-more .bd
+{
+    margin: 1em 25% 1em 0;
+}
+
+.path-summary-more .summary-col.third .bd
+{
+    margin: 1em 1em 1em 0;
+}
 .path-summary-more table.last
 {
-    width: 90em;
+    width: 100%;
+}
+
+.path-summary-more table.last td:first-child
+{
+    min-width: 5em;
 }
 
 .path-summary-more td.stats-number
@@ -1553,6 +1664,22 @@ html[dir="rtl"] ul.pager li:last-child > *
     padding-right: 3em !important;
 }
 
+.path-summary-more .graph
+{
+    height: 8em;
+    background-color: #ccc;
+    width: 100%;
+    margin-bottom: 1em;
+    /* hide graph areas while we don't render anything there */
+    display: none;
+}
+
+.path-summary-more .action-wrapper label,
+.path-summary-more .action-wrapper .last-action,
+.path-summary-more .action-wrapper .last-updated
+{
+    display: inline-block;
+}
 
 /* Tabs */
 

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1229,51 +1229,49 @@ html[dir="rtl"] td.stats-name,
 
 /* Expanded checks */
 
-.checks
+.stats-checks table
 {
-    height: 100%;
     width: 100%;
 }
 
-.checks a
+.check a
 {
     color: #444;
 }
 
-#check-critical a,
+.category-critical.check a,
 .checks-critical a,
-#check-critical .check-data,
+.category-critical.check .check-data,
 .checks-critical .check-data
 {
     color: #c00;
 }
 
-.checks h4
+.stats-checks a.toggle-more-checks
 {
-    padding: 1em 0 0.5em;
-    font-weight: normal;
-}
-
-.check
-{
-    float: left;
+    color: #0b8696;
 }
 
 .check-name
 {
-    width: 12em;
-    display: inline-block;
-    height: 4em;
+    width: 100%;
 }
 
 .check-count
 {
     text-align: right;
-    width: 3em;
-    padding-right: 6em;
-    display: inline-block;
-    vertical-align: top;
- }
+}
+
+.toggle-more-checks.collapsed .hide-more,
+.toggle-more-checks .show-more
+{
+    display: none;
+}
+
+.toggle-more-checks.collapsed .show-more
+{
+    display: inherit;
+}
 
 html[dir="rtl"] .check-count
 {

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -828,11 +828,28 @@ html[dir="rtl"] .last-action
     margin-right: 1em;
 }
 
+.last-action
+{
+    margin-top: 1px;
+}
+
 .last-action img
 {
     vertical-align: text-bottom;
     width: 20px;
     height: 20px;
+    position: absolute;
+    top: -2px;
+}
+
+.last-action a
+{
+    position: relative;
+}
+
+.last-action .user-name
+{
+    margin-left: 24px;
 }
 
 .last-action .extra-item-meta
@@ -1912,6 +1929,7 @@ html[dir="rtl"] #tabs li
 {
     display: inline-block;
     overflow: hidden;
+    border-radius: 50%;
 }
 
 a.collapse,

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -220,11 +220,11 @@ const stats = {
 
   updateLastUpdates(statsData) {
     if (statsData.lastupdated) {
-      const lastUpdated = document.querySelector('#js-last-updated .last-updated');
+      const lastUpdated = document.querySelector('#js-last-updated');
       this.renderLastUpdate(lastUpdated, statsData.lastupdated);
     }
     if (statsData.lastaction) {
-      const lastAction = document.querySelector('#js-last-action .last-action');
+      const lastAction = document.querySelector('#js-last-action');
       this.renderLastEvent(lastAction, statsData.lastaction);
     }
   },

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -84,6 +84,22 @@ const stats = {
       e.preventDefault();
       this.toggleChecks();
     });
+    $(document).on('click', '.js-toggle-more-checks', (e) => {
+      let count = 0;
+      const data = this.state.checksData;
+      e.preventDefault();
+      $('.js-check').each(function () {
+        const $check = $(this);
+        const code = $check.data('code');
+        if (code in data) {
+          if (count >= 4) {
+            $check.toggle();
+          }
+          count++;
+        }
+      });
+      $(e.target).parent().toggleClass('collapsed');
+    });
     $(document).on('click', '.js-stats-refresh', (e) => {
       e.preventDefault();
       this.refreshStats();
@@ -433,30 +449,25 @@ const stats = {
 
   updateChecksUI() {
     const data = this.state.checksData;
+    let count = 0;
 
     if (data === null || !Object.keys(data).length) {
       return;
     }
 
-    this.$extraDetails.find('.js-checks').each(function updateChecksCategory() {
-      const $cat = $(this);
-      let empty = true;
-
-      $cat.find('.js-check').each(function updateCheck() {
-        const $check = $(this);
-        const code = $(this).data('code');
-        if (code in data) {
-          empty = false;
-          $check.show();
-          $check.find('.check-count .check-data').html(data[code]);
-        } else {
-          $check.hide();
-        }
-      });
-
-      $cat.toggle(!empty);
+    this.$extraDetails.find('.js-check').each(function updateCheck() {
+      const $check = $(this);
+      const code = $(this).data('code');
+      if (code in data) {
+        count++;
+        $check.toggle(count < 5);
+        $check.find('.check-count .check-data').html(data[code]);
+      } else {
+        $check.hide();
+      }
     });
 
+    $('.js-more-checks').addClass('collapsed').toggle(count >= 5);
     $('#js-stats-checks').show();
   },
 

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -428,7 +428,7 @@ const stats = {
     this.$expandIcon.attr('class', `icon-${newClass}-stats`);
     this.$expandIcon.attr('title', newText);
 
-    this.$extraDetails.toggle(isExpanded);
+    this.$extraDetails.toggleClass('expand', isExpanded);
   },
 
   updateChecksUI() {

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -22,7 +22,7 @@
       {% include 'core/_top_scorers_as_ul.html' %}
     </div>
     <div class="path-summary-expanded">
-      <div class="summary-col">
+      <div class="summary-1-col">
         <h3 class="top">{% trans "Translation Statistics" %}</h3>
         <div class="bd">
           <table class="stats" lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
@@ -73,14 +73,14 @@
         </div>
       </div>
       {% if top_scorers %}
-        <div class="summary-col">
+        <div class="summary-2-col">
           <h3 class="top">{% trans "Top contributors Last 30 days" %}</h3>
           <div class="bd">
             {% include 'core/_top_scorers_as_table.html' %}
           </div>
         </div>
       {% endif %}
-      <div class="summary-col third">
+      <div class="summary-3-col">
         <h3 class="top">{% trans "Updates" %}</h3>
         <div class="bd">
           <div class="graph"></div>

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -10,68 +10,96 @@
   {% block header_content %}
   <a id="js-path-summary" href="#">
     <div id="progressbar">
-      <i id="js-expand-icon" class="icon-expand-stats"
-         title="{% trans 'Expand details' %}"></i>
       {% include "browser/_progressbar.html" %}
     </div>
   </a>
-
   <div class="path-summary-more" id="js-path-summary-more">
-    <h3>{% trans "Translation Statistics" %}</h3>
-    <div class="bd">
-      <table class="stats" lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
-        <tbody>
-          {% for item in translation_states %}
-          <tr id="stats-{{ item.state }}">
-            <td id="stats-name">{{ item.title }}</td>
-            <td class="stats-number">
-              {% if can_translate_stats %}
-              <a href="{{ item.url }}" class="stats-data"></a>
-              {% else %}
-              <span class="stats-data"></span>
-              {% endif %}
-            </td>
-            <td class="stats-percentage"><span></span>%</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+    <a id="js-path-summary" class="expand-stats" href="#">
+      <i id="js-expand-icon" class="icon-expand-stats"
+         title="{% trans 'Expand details' %}"></i>
+    </a>
+    <div class="path-summary-collapsed">
+      {% include 'core/_top_scorers_as_ul.html' %}
     </div>
-    <div class="bd">
-      <table class="last">
-        <tbody>
-          <tr id="js-last-updated">
-            <td>{% trans "Last updated" %}</td>
-            <td class="last-updated"></td>
-          </tr>
-          <tr id="js-last-action">
-            <td>{% trans "Last action" %}</td>
-            <td class="last-action"></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div id="js-stats-checks" class="hide stats-checks">
-      <h3>{% trans "Failing Checks" %}</h3>
-      <div class="bd">
-      {% for item in check_categories %}
-        <div id="check-{{ item.name }}" class="checks js-checks">
-          <h4 class="clear">{{ item.title }}</h4>
-          {% for check in item.checks %}
-          <div class="check js-check" data-code="{{ check.code }}">
-            {% if can_translate_stats %}
-            <div class="check-name"><a class="check-data" href="{{ check.url }}">{{ check.title }}</a></div>
-            <div class="check-count"><a class="check-data" href="{{ check.url }}">0</a></div>
-            {% else %}
-            <div class="check-name"><span class="check-data">{{ check.title }}</span></div>
-            <div class="check-count"><span class="check-data">0</span></div>
-            {% endif %}
-          </div>
-          {% endfor %}
+    <div class="path-summary-expanded">
+      <div class="summary-col">
+        <h3 class="top">{% trans "Translation Statistics" %}</h3>
+        <div class="bd">
+          <table class="stats" lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
+            <tbody>
+              {% for item in translation_states %}
+              <tr id="stats-{{ item.state }}">
+                <td id="stats-name">{{ item.title }}</td>
+                <td class="stats-number">
+                  {% if can_translate_stats %}
+                  <a href="{{ item.url }}" class="stats-data"></a>
+                  {% else %}
+                  <span class="stats-data"></span>
+                  {% endif %}
+                </td>
+                <td class="stats-percentage"><span></span>%</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
-      {% endfor %}
-      <div class="clear"></div>
+        <div id="js-stats-checks" class="hide stats-checks">
+          <h3>{% trans "Failing Checks" %}</h3>
+          <div class="bd">
+          {% for item in check_categories %}
+            <div id="check-{{ item.name }}" class="checks js-checks">
+              <h4 class="clear">{{ item.title }}</h4>
+              {% for check in item.checks %}
+              <div class="check js-check" data-code="{{ check.code }}">
+                {% if can_translate_stats %}
+                <div class="check-name"><a class="check-data" href="{{ check.url }}">{{ check.title }}</a></div>
+                <div class="check-count"><a class="check-data" href="{{ check.url }}">0</a></div>
+                {% else %}
+                <div class="check-name"><span class="check-data">{{ check.title }}</span></div>
+                <div class="check-count"><span class="check-data">0</span></div>
+                {% endif %}
+              </div>
+              {% endfor %}
+            </div>
+          {% endfor %}
+          </div>
+        </div>
       </div>
+      {% if top_scorers %}
+        <div class="summary-col">
+          <h3 class="top">{% trans "Top contributors Last 30 days" %}</h3>
+          <div class="bd">
+            {% include 'core/_top_scorers_as_table.html' %}
+          </div>
+        </div>
+      {% endif %}
+      <div class="summary-col third">
+        <h3 class="top">{% trans "Updates" %}</h3>
+        <div class="bd">
+          <div class="graph"></div>
+          <table class="last">
+            <tbody>
+              <tr id="js-last-updated">
+                <td>{% trans "Last action:" %}</td>
+                <td class="last-updated"></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <h3>{% trans "Translations" %}</h3>
+        <div class="bd">
+          <div class="graph"></div>
+          <table class="last">
+            <tbody>
+              <tr id="js-last-action">
+                <td>{% trans "Last action:" %}</td>
+                <td class="last-action"></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="clear"></div>
     </div>
   </div>
   {% endblock %}

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -77,26 +77,18 @@
         <h3 class="top">{% trans "Updates" %}</h3>
         <div class="bd">
           <div class="graph"></div>
-          <table class="last">
-            <tbody>
-              <tr id="js-last-updated">
-                <td>{% trans "Last action:" %}</td>
-                <td class="last-updated"></td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="action-wrapper">
+            <label>{% trans "Last action:" %}</label>
+            <div id="js-last-updated" class="last-updated"></div>
+          </div>
         </div>
         <h3>{% trans "Translations" %}</h3>
         <div class="bd">
           <div class="graph"></div>
-          <table class="last">
-            <tbody>
-              <tr id="js-last-action">
-                <td>{% trans "Last action:" %}</td>
-                <td class="last-action"></td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="action-wrapper">
+            <label>{% trans "Last action:" %}</label>
+            <div id="js-last-action" class="last-action"></div>
+          </div>
         </div>
       </div>
       <div class="clear"></div>

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -46,22 +46,29 @@
         <div id="js-stats-checks" class="hide stats-checks">
           <h3>{% trans "Failing Checks" %}</h3>
           <div class="bd">
-          {% for item in check_categories %}
-            <div id="check-{{ item.name }}" class="checks js-checks">
-              <h4 class="clear">{{ item.title }}</h4>
-              {% for check in item.checks %}
-              <div class="check js-check" data-code="{{ check.code }}">
+            <table>
+            {% for check in checks %}
+              <tr class="{% if check.is_critical %}category-critical{% endif %} check js-check" data-code="{{ check.code }}">
                 {% if can_translate_stats %}
-                <div class="check-name"><a class="check-data" href="{{ check.url }}">{{ check.title }}</a></div>
-                <div class="check-count"><a class="check-data" href="{{ check.url }}">0</a></div>
+                <td class="check-name">
+                  <a class="check-data" href="{{ check.url }}">{{ check.title }}</a>
+                </td>
+                <td class="check-count"><a class="check-data" href="{{ check.url }}">0</a></td>
                 {% else %}
-                <div class="check-name"><span class="check-data">{{ check.title }}</span></div>
-                <div class="check-count"><span class="check-data">0</span></div>
+                <td class="check-name"><span class="check-data">{{ check.title }}</span></td>
+                <td class="check-count"><span class="check-data">0</span></td>
                 {% endif %}
-              </div>
-              {% endfor %}
-            </div>
-          {% endfor %}
+              </tr>
+            {% endfor %}
+            <tr class="js-more-checks">
+              <td colspan="2">
+                <a class="js-toggle-more-checks toggle-more-checks collapsed">
+                  <span class="show-more">{% trans "more..." %}</span>
+                  <span class="hide-more">{% trans "less..." %}</span>
+                </a>
+              </td>
+            </tr>
+            </table>
           </div>
         </div>
       </div>

--- a/pootle/templates/core/_top_scorers.html
+++ b/pootle/templates/core/_top_scorers.html
@@ -1,4 +1,5 @@
 {% load i18n humanize profile_tags %}
+
 {% if top_scorers %}
 <table id="top-scorers">
   <thead>
@@ -20,7 +21,7 @@
           <li class="name"><a href="{{ user.get_absolute_url }}">{{ user.display_name }}</a></li>
         </ul>
       </td>
-      <td class="number">{{ user.public_total_score|intcomma }}</td>
+      <td class="number">{{ user.public_total_score|floatformat|intcomma }}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/pootle/templates/core/_top_scorers_as_table.html
+++ b/pootle/templates/core/_top_scorers_as_table.html
@@ -1,0 +1,19 @@
+{% load i18n humanize profile_tags %}
+<table class="top-scorers-table">
+  {% if top_scorers %}
+    <tbody>
+    {% for user in top_scorers %}
+      <tr>
+        <td class="number">{% blocktrans with position=forloop.counter %}#{{ position }}{% endblocktrans %}</td>
+        <td class="user top-scorer">
+          <a href="{{ user.get_absolute_url }}">
+            <img src="{{ user|gravatar:20 }}" class="avatar" />
+            <span class="user-name">{{ user.display_name }}</span>
+          </a>
+        </td>
+        <td class="number">{% if user.public_total_score > 0 %}+{% endif %}{{ user.public_total_score|intcomma }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  {% endif %}
+</table>

--- a/pootle/templates/core/_top_scorers_as_ul.html
+++ b/pootle/templates/core/_top_scorers_as_ul.html
@@ -1,0 +1,19 @@
+{% load i18n humanize profile_tags %}
+{% if top_scorers %}
+<label>{% trans 'Top contributors:' %}</label>
+<ul class="top-scorers">
+  {% for user in top_scorers|slice:":3" %}
+    <li class="top-scorer">
+      <div class="place">{% blocktrans with position=forloop.counter %}#{{ position }}{% endblocktrans %}</div>
+      <div class="user">
+        <a href="{{ user.get_absolute_url }}">
+          <img src="{{ user|gravatar:20 }}" class="avatar" />
+          <span class="user-name">{{ user.display_name }}</span>
+        </a>
+      </div>
+      <div class="number">{% if user.public_total_score > 0 %}+{% endif %}{{ user.public_total_score|floatformat:0|intcomma }}</div>
+    </li>
+  {% endfor %}
+</ul>
+<div class="clear"></div>
+{% endif %}

--- a/tests/misc/checks.py
+++ b/tests/misc/checks.py
@@ -10,7 +10,10 @@ import pytest
 
 from translate.filters.checks import FilterFailure
 
-from pootle_misc.checks import ENChecker
+from pootle_misc.checks import (Category, ENChecker, check_names,
+                                get_category_code, get_category_name,
+                                get_qualitychecks, get_qualitycheck_list,
+                                get_qualitycheck_schema)
 
 try:
     from plurr import Plurr
@@ -345,3 +348,48 @@ def test_plurr_format(source_string, target_string, should_skip):
     check = checker.plurr_format
     assert_check(check, source_string, target_string, should_skip,
                  language_code='ru')
+
+
+def test_get_qualitycheck_schema():
+    d = {}
+    checks = get_qualitychecks()
+    for check, cat in checks.items():
+        if cat not in d:
+            d[cat] = {
+                'code': cat,
+                'name': get_category_code(cat),
+                'title': get_category_name(cat),
+                'checks': []
+            }
+        d[cat]['checks'].append({
+            'code': check,
+            'title': u"%s" % check_names.get(check, check),
+            'url': ''
+        })
+
+    result = sorted([item for code, item in d.items()],
+                    key=lambda x: x['code'],
+                    reverse=True)
+
+    assert result == get_qualitycheck_schema()
+
+
+@pytest.mark.django_db
+def test_get_qualitycheck_list(tp0):
+    result = []
+    checks = get_qualitychecks()
+    for check, cat in checks.items():
+        result.append({
+            'code': check,
+            'is_critical': cat == Category.CRITICAL,
+            'title': u"%s" % check_names.get(check, check),
+            'url': tp0.get_translate_url(check=check)
+        })
+
+    def alphabetical_critical_first(item):
+        sort_prefix = 0 if item['is_critical'] else 1
+        return "%d%s" % (sort_prefix, item['title'].lower())
+
+    result = sorted(result, key=alphabetical_critical_first)
+
+    assert result == get_qualitycheck_list(tp0)

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -14,6 +14,8 @@ import pytest
 
 from pytest_pootle.suite import view_context_test
 
+from django.contrib.auth import get_user_model
+
 from pootle_app.models.permissions import check_permission
 from pootle.core.browser import make_project_item, get_table_headings
 from pootle.core.delegate import search_backend
@@ -64,6 +66,7 @@ def _test_browse_view(language, request, response, kwargs):
         # check_categories=get_qualitycheck_schema(language),
         table=table,
         translation_states=get_translation_states(language),
+        top_scorers=get_user_model().top_scorers(language=language.code, limit=10),
         stats=jsonify(language.get_stats_for_user(request.user)))
     sidebar = get_sidebar_announcements_context(
         request, (language, ))

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -30,7 +30,7 @@ from pootle.core.helpers import (
 from pootle.core.utils.json import jsonify
 from pootle.core.url_helpers import get_previous_url, get_path_parts
 from pootle.core.utils.stats import get_translation_states
-from pootle_misc.checks import get_qualitycheck_schema
+from pootle_misc.checks import get_qualitycheck_list, get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_project.models import Project, ProjectResource, ProjectSet
 from pootle_store.forms import UnitExportForm
@@ -146,7 +146,7 @@ def _test_browse_view(project, request, response, kwargs):
         url_action_review=url_action_review,
         url_action_view_all=url_action_view_all,
         translation_states=get_translation_states(ob),
-        check_categories=get_qualitycheck_schema(ob),
+        checks=get_qualitycheck_list(ob),
         table=table,
         top_scorers=User.top_scorers(project=project.code, limit=10),
         stats=jsonify(ob.get_stats()))
@@ -251,7 +251,7 @@ def test_view_projects_browse(client, request_users):
         table=table,
         browser_extends="projects/all/base.html",
         stats=jsonify(ob.get_stats()),
-        check_categories=get_qualitycheck_schema(ob),
+        checks=get_qualitycheck_list(ob),
         top_scorers=User.top_scorers(limit=10),
         translation_states=get_translation_states(ob),
         url_action_continue=url_action_continue,

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -13,6 +13,7 @@ from urllib import unquote
 
 import pytest
 
+from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 
 from pytest_pootle.suite import view_context_test
@@ -132,6 +133,7 @@ def _test_browse_view(project, request, response, kwargs):
          url_action_review,
          url_action_view_all) = [None] * 4
 
+    User = get_user_model()
     assertions = dict(
         page="browse",
         project=project,
@@ -146,6 +148,7 @@ def _test_browse_view(project, request, response, kwargs):
         translation_states=get_translation_states(ob),
         check_categories=get_qualitycheck_schema(ob),
         table=table,
+        top_scorers=User.top_scorers(project=project.code, limit=10),
         stats=jsonify(ob.get_stats()))
     sidebar = get_sidebar_announcements_context(
         request, (project, ))
@@ -238,6 +241,7 @@ def test_view_projects_browse(client, request_users):
          url_action_review,
          url_action_view_all) = [None] * 4
 
+    User = get_user_model()
     assertions = dict(
         page="browse",
         pootle_path="/projects/",
@@ -248,6 +252,7 @@ def test_view_projects_browse(client, request_users):
         browser_extends="projects/all/base.html",
         stats=jsonify(ob.get_stats()),
         check_categories=get_qualitycheck_schema(ob),
+        top_scorers=User.top_scorers(limit=10),
         translation_states=get_translation_states(ob),
         url_action_continue=url_action_continue,
         url_action_fixcritical=url_action_fixcritical,

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -27,7 +27,7 @@ from pootle.core.helpers import (
 from pootle.core.url_helpers import get_previous_url, get_path_parts
 from pootle.core.utils.json import jsonify
 from pootle.core.utils.stats import get_translation_states
-from pootle_misc.checks import get_qualitycheck_schema
+from pootle_misc.checks import get_qualitycheck_list, get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_store.forms import UnitExportForm
 from pootle_store.models import Store, Unit
@@ -129,7 +129,7 @@ def _test_browse_view(tp, request, response, kwargs):
         resource_path=resource_path,
         resource_path_parts=get_path_parts(resource_path),
         translation_states=get_translation_states(ob),
-        check_categories=get_qualitycheck_schema(ob),
+        checks=get_qualitycheck_list(ob),
         top_scorers=User.top_scorers(language=tp.language.code,
                                      project=tp.project.code, limit=10),
         url_action_continue=ob.get_translate_url(

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -14,6 +14,8 @@ import pytest
 
 from pytest_pootle.suite import view_context_test
 
+from django.contrib.auth import get_user_model
+
 from pootle_app.models import Directory
 from pootle_app.models.permissions import check_permission
 from pootle.core.browser import (
@@ -113,6 +115,7 @@ def _test_browse_view(tp, request, response, kwargs):
     else:
         table = None
 
+    User = get_user_model()
     assertions = dict(
         page="browse",
         object=ob,
@@ -127,6 +130,8 @@ def _test_browse_view(tp, request, response, kwargs):
         resource_path_parts=get_path_parts(resource_path),
         translation_states=get_translation_states(ob),
         check_categories=get_qualitycheck_schema(ob),
+        top_scorers=User.top_scorers(language=tp.language.code,
+                                     project=tp.project.code, limit=10),
         url_action_continue=ob.get_translate_url(
             state='incomplete', **filters),
         url_action_fixcritical=ob.get_critical_url(**filters),


### PR DESCRIPTION
This PR shows top contributors for Project, Language and TP. 
For paths below a TP it shows top contributors for the TP (we should discuss it and address later).
3 top contributors are displayed at collapsed panel. 10 - at expanded panel.
Layout is changed according @iafan mockup. 
All checks are displayed in one column (5 of them are displayed by default).
There are 2 grey areas in expanded panel for Translation and Updated graphs. I left them visible to allow to test a future layout. I'll make them hidden before landing.
Refs. #4210