### PR TITLE
Pootle config

### DIFF
--- a/pootle/apps/pootle_config/__init__.py
+++ b/pootle/apps/pootle_config/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+default_app_config = 'pootle_config.apps.PootleConfigConfig'

--- a/pootle/apps/pootle_config/abstracts.py
+++ b/pootle/apps/pootle_config/abstracts.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import collections
+
+from jsonfield.fields import JSONField
+
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from .managers import ConfigManager, ConfigQuerySet
+
+
+class AbstractConfig(models.Model):
+    content_type = models.ForeignKey(
+        ContentType,
+        blank=True,
+        null=True,
+        db_index=True,
+        verbose_name=_('content type'),
+        related_name="content_type_set_for_%(class)s",
+        on_delete=models.CASCADE)
+    object_pk = models.CharField(
+        _('object ID'),
+        max_length=255,
+        db_index=True,
+        blank=True,
+        null=True)
+    content_object = GenericForeignKey(
+        ct_field="content_type",
+        fk_field="object_pk")
+    key = models.CharField(
+        _("Configuration key"),
+        max_length=255,
+        blank=False,
+        null=False,
+        db_index=True)
+    value = JSONField(
+        _("Configuration value"),
+        default="",
+        blank=True,
+        null=False,
+        load_kwargs={'object_pairs_hook': collections.OrderedDict})
+
+    objects = ConfigManager.from_queryset(ConfigQuerySet)()
+
+    class Meta(object):
+        abstract = True
+        ordering = ['pk']
+        index_together = ["content_type", "object_pk"]
+
+    def save(self, **kwargs):
+        if not self.key:
+            raise ValidationError("Config object must have a key")
+        if self.object_pk and not self.content_type:
+            raise ValidationError(
+                "Config object must have content_type when object_pk is set")
+        super(AbstractConfig, self).save(**kwargs)

--- a/pootle/apps/pootle_config/abstracts.py
+++ b/pootle/apps/pootle_config/abstracts.py
@@ -31,7 +31,6 @@ class AbstractConfig(models.Model):
     object_pk = models.CharField(
         _('object ID'),
         max_length=255,
-        db_index=True,
         blank=True,
         null=True)
     content_object = GenericForeignKey(

--- a/pootle/apps/pootle_config/apps.py
+++ b/pootle/apps/pootle_config/apps.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import importlib
+
+from django.apps import AppConfig
+
+
+class PootleConfigConfig(AppConfig):
+
+    name = "pootle_config"
+    verbose_name = "Pootle Config"
+
+    def ready(self):
+        importlib.import_module("pootle_config.getters")

--- a/pootle/apps/pootle_config/delegate.py
+++ b/pootle/apps/pootle_config/delegate.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.plugin.delegate import Getter
+
+
+config_should_not_be_set = Getter(providing_args=["instance", "key", "value"])
+config_should_not_be_appended = Getter(providing_args=["instance", "key", "value"])

--- a/pootle/apps/pootle_config/exceptions.py
+++ b/pootle/apps/pootle_config/exceptions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+
+class ConfigurationError(Exception):
+    """Problem trying to set a configuration"""
+
+    pass

--- a/pootle/apps/pootle_config/getters.py
+++ b/pootle/apps/pootle_config/getters.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.utils.translation import ugettext_lazy as _
+
+from pootle.core.delegate import config
+from pootle.core.plugin import getter
+
+from .exceptions import ConfigurationError
+from .models import Config
+
+
+@getter(config)
+def config_getter(sender=None, instance=None, key=None, **kwargs):
+
+    if sender:
+        if instance is not None and not isinstance(instance, sender):
+            raise ConfigurationError(
+                _("'instance' must be an instance of sender, when specified"))
+        conf = Config.objects.get_config_queryset(instance or sender)
+    elif instance:
+        raise ConfigurationError(
+            _("'sender' must be defined when 'instance' is specified"))
+    else:
+        conf = Config.objects.site_config()
+
+    if key is not None:
+        if isinstance(key, (list, tuple)):
+            return conf.list_config(key)
+        try:
+            return conf.get_config(key)
+        except Config.DoesNotExist:
+            return None
+        except Config.MultipleObjectsReturned as e:
+            raise ConfigurationError(e)
+    return conf

--- a/pootle/apps/pootle_config/managers.py
+++ b/pootle/apps/pootle_config/managers.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django.utils.encoding import force_text
+
+from .delegate import (
+    config_should_not_be_appended, config_should_not_be_set)
+from .exceptions import ConfigurationError
+
+
+class ConfigQuerySet(models.QuerySet):
+
+    def __init__(self, *args, **kwargs):
+        super(ConfigQuerySet, self).__init__(*args, **kwargs)
+        self.query_model = None
+
+    def _clone(self, klass=None, setup=None, **kwargs):
+        clone = super(ConfigQuerySet, self)._clone(klass, setup, **kwargs)
+        clone.query_model = self.query_model
+        return clone
+
+    @property
+    def base_qs(self):
+        qs = self.__class__(self.model)
+        qs.query_model = self.query_model
+        return qs
+
+    def append_config(self, key, value="", model=None):
+        model = self.get_query_model(model)
+        self.should_append_config(key, value, model)
+        return self.create(
+            key=key, value=value,
+            **self.get_model_kwargs(model))
+
+    def clear_config(self, key, model=None):
+        self.get_config_queryset(model).filter(key=key).delete()
+
+    def config_for(self, model):
+        """
+        QuerySet for all config for a particular model (either an instance or
+        a class).
+        """
+        self.query_model = model
+        return self.base_qs.filter(**self.get_model_kwargs(model))
+
+    def get_config(self, key, model=None):
+        return self.get_config_queryset(model).get(key=key).value
+
+    def get_config_queryset(self, model):
+        if model:
+            if isinstance(model, models.Model):
+                return self.config_for(model)
+            return self.config_for(model).filter(object_pk__isnull=True)
+        if self.query_model:
+            return self
+        return self.site_config()
+
+    def get_model_kwargs(self, model):
+        model = self.get_query_model(model)
+        if model is None:
+            return {}
+        ct = ContentType.objects.get_for_model(model)
+        kwargs = dict(content_type=ct)
+        if isinstance(model, models.Model):
+            kwargs["object_pk"] = force_text(model._get_pk_val())
+        return kwargs
+
+    def get_query_model(self, model=None):
+        if model:
+            self.query_model = model
+        elif self.query_model:
+            model = self.query_model
+        return model
+
+    def list_config(self, key=None, model=None):
+        conf = self.get_config_queryset(model)
+        conf_list = []
+
+        if isinstance(key, (list, tuple)):
+            if key:
+                conf = conf.filter(key__in=key)
+        elif key is not None:
+            conf = conf.filter(key=key)
+        for item in conf:
+            # dont use values_list to trigger to_python
+            conf_list.append((item.key, item.value))
+        return conf_list
+
+    def set_config(self, key, value="", model=None):
+        model = self.get_query_model(model)
+        conf = self.get_config_queryset(model)
+        self.should_set_config(key, value, model)
+        try:
+            conf = conf.get(key=key)
+        except conf.model.DoesNotExist:
+            return self.create(
+                key=key,
+                value=value,
+                **self.get_model_kwargs(model))
+        if conf.value != value:
+            conf.value = value
+            conf.save()
+        return conf
+
+    def should_append_config(self, key, value, model=None):
+        sender = model
+        instance = None
+        if isinstance(model, models.Model):
+            sender = model.__class__
+            instance = model
+        no_append = config_should_not_be_appended.get(
+            sender,
+            instance=instance,
+            key=key,
+            value=value)
+        if no_append:
+            raise ConfigurationError(no_append)
+
+    def should_set_config(self, key, value, model=None):
+        sender = model
+        instance = None
+        if isinstance(model, models.Model):
+            sender = model.__class__
+            instance = model
+        no_set = config_should_not_be_set.get(
+            sender,
+            instance=instance,
+            key=key,
+            value=value)
+        if no_set:
+            raise ConfigurationError(no_set)
+
+    def site_config(self):
+        self.query_model = None
+        return self.base_qs.filter(
+            content_type__isnull=True, object_pk__isnull=True)
+
+
+class ConfigManager(models.Manager):
+    pass

--- a/pootle/apps/pootle_config/migrations/0001_initial.py
+++ b/pootle/apps/pootle_config/migrations/0001_initial.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Config',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('object_pk', models.CharField(db_index=True, max_length=255, null=True, verbose_name='object ID', blank=True)),
+                ('key', models.CharField(max_length=255, verbose_name='Configuration key', db_index=True)),
+                ('value', jsonfield.fields.JSONField(default=b'', verbose_name='Configuration value', blank=True)),
+                ('content_type', models.ForeignKey(related_name='content_type_set_for_config', verbose_name='content type', blank=True, to='contenttypes.ContentType', null=True)),
+            ],
+            options={
+                'ordering': ['pk'],
+                'abstract': False,
+                'db_table': 'pootle_config',
+            },
+        ),
+        migrations.AlterIndexTogether(
+            name='config',
+            index_together=set([('content_type', 'object_pk')]),
+        ),
+    ]

--- a/pootle/apps/pootle_config/migrations/0001_initial.py
+++ b/pootle/apps/pootle_config/migrations/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             name='Config',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('object_pk', models.CharField(db_index=True, max_length=255, null=True, verbose_name='object ID', blank=True)),
+                ('object_pk', models.CharField(max_length=255, null=True, verbose_name='object ID', blank=True)),
                 ('key', models.CharField(max_length=255, verbose_name='Configuration key', db_index=True)),
                 ('value', jsonfield.fields.JSONField(default=b'', verbose_name='Configuration value', blank=True)),
                 ('content_type', models.ForeignKey(related_name='content_type_set_for_config', verbose_name='content type', blank=True, to='contenttypes.ContentType', null=True)),

--- a/pootle/apps/pootle_config/models.py
+++ b/pootle/apps/pootle_config/models.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from .abstracts import AbstractConfig
+
+
+class Config(AbstractConfig):
+
+    class Meta(AbstractConfig.Meta):
+        db_table = "pootle_config"

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -10,4 +10,5 @@
 from pootle.core.plugin.delegate import Getter
 
 
+config = Getter(providing_args=["instance"])
 search_backend = Getter(providing_args=["instance"])

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -83,6 +83,7 @@ INSTALLED_APPS = [
     'pootle',
     'pootle_app',
     'pootle_comment',
+    'pootle_config',
     'pootle_misc',
     'pootle_store',
     'pootle_language',

--- a/pytest_pootle/fixtures/jsondata.py
+++ b/pytest_pootle/fixtures/jsondata.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from collections import OrderedDict
+
+import pytest
+
+
+JSON_OBJECTS = (
+    3,
+    "four",
+    u"five ☠ ",
+    "six \n seven ",
+    [9, 10],
+    (11, 12, 13),
+    OrderedDict(foo="bar", foo2="baz"),
+    [1, "two", OrderedDict(three=3)])
+
+
+@pytest.fixture(params=JSON_OBJECTS)
+def json_objects(request):
+    return request.param

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ elasticsearch>=1.0.0,<1.7
 lxml>=2.2.0
 python-levenshtein
 rq>=0.5.0,<=0.5.6
+jsonfield
 
 # Translate Toolkit
 translate-toolkit>=1.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,7 +106,8 @@ skip=.tox,
      pootle/core/utils/version.py,
      pootle/core/views.py,
      pootle/middleware/errorpages.py,
-     pootle/apps/pootle_comment/forms.py
+     pootle/apps/pootle_comment/forms.py,
+     pootle/apps/pootle_config/managers.py
 
 known_standard_library=
 known_third_party=elasticsearch,translate

--- a/tests/models/config.py
+++ b/tests/models/config.py
@@ -1,0 +1,493 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+
+from pootle.core.delegate import config
+from pootle.core.plugin import getter
+from pootle_config.delegate import (
+    config_should_not_be_set, config_should_not_be_appended)
+from pootle_config.exceptions import ConfigurationError
+from pootle_config.models import Config
+from pootle_project.models import Project
+
+
+def _test_config_bad_create(create_func):
+
+    # a config object must have a key
+    with pytest.raises(ValidationError):
+        create_func().save()
+
+    # you cant set object_pk if content_type is not set
+    with pytest.raises(ValidationError):
+        create_func(
+            key="foo4", value="bar", object_pk="23").save()
+
+
+def _test_config_ob(conf, **kwargs):
+    conf.save()
+    conf = Config.objects.get(id=conf.id)
+    for k, v in kwargs.items():
+        if isinstance(v, tuple):
+            v = list(v)
+        assert getattr(conf, k) == v
+
+
+def _test_config_create(create_func):
+
+    # Create a site config
+    _test_config_ob(
+        create_func(key="foo"),
+        key=u"foo",
+        value="",
+        content_object=None,
+        content_type=None,
+        object_pk=None)
+
+    project = Project.objects.get(code="project0")
+    project_pk = str(project.pk)
+    project_ct = ContentType.objects.get_for_model(project)
+
+    # Create config for all projects
+    _test_config_ob(
+        create_func(
+            key="foo",
+            value="bar",
+            content_type=project_ct),
+        key=u"foo",
+        value=u"bar",
+        content_object=None,
+        content_type=project_ct,
+        object_pk=None)
+
+    # Create config for a project
+    _test_config_ob(
+        create_func(
+            key="foo",
+            value="bar",
+            content_object=project),
+        key=u"foo",
+        value=u"bar",
+        content_object=project,
+        content_type=project_ct,
+        object_pk=project_pk)
+
+
+def _test_config_clear(**kwargs):
+    conf = Config.objects.set_config(**kwargs)
+    assert conf.pk in Config.objects.values_list("pk", flat=True)
+    Config.objects.clear_config(**kwargs)
+    assert conf.pk not in Config.objects.values_list("pk", flat=True)
+
+
+@pytest.mark.django_db
+def test_config_create():
+    _test_config_create(Config.objects.create)
+    _test_config_create(Config)
+
+
+@pytest.mark.django_db
+def test_config_bad_create():
+    _test_config_bad_create(Config.objects.create)
+    _test_config_bad_create(Config)
+
+
+@pytest.mark.django_db
+def test_config_bad_getter():
+    project = Project.objects.get(code="project0")
+    with pytest.raises(ConfigurationError):
+        config.get(instance=project)
+    with pytest.raises(ConfigurationError):
+        config.get(str, instance=project)
+
+
+@pytest.mark.django_db
+def test_config_set():
+
+    # set site-wide config
+    _test_config_ob(
+        Config.objects.set_config("foo"),
+        key=u"foo",
+        value="",
+        content_type=None,
+        object_pk=None)
+    _test_config_ob(
+        Config.objects.set_config("foo", "bar"),
+        key=u"foo",
+        value="bar",
+        content_type=None,
+        object_pk=None)
+
+    project = Project.objects.get(code="project0")
+    project_pk = project.pk
+    project_ct = ContentType.objects.get_for_model(project)
+
+    # set config for all projects
+    _test_config_ob(
+        Config.objects.set_config(key="foo", model=Project),
+        key="foo",
+        value="",
+        content_type=project_ct,
+        object_pk=None,
+        content_object=None)
+    _test_config_ob(
+        Config.objects.set_config(key="foo", value="bar", model=Project),
+        key="foo",
+        value="bar",
+        content_type=project_ct,
+        object_pk=None,
+        content_object=None)
+
+    # set config for project
+    _test_config_ob(
+        Config.objects.set_config(key="foo", model=project),
+        key="foo",
+        value="",
+        content_type=project_ct,
+        object_pk=str(project_pk),
+        content_object=project)
+    # reset config for project
+    _test_config_ob(
+        Config.objects.set_config(key="foo", value="bar", model=project),
+        key="foo",
+        value="bar",
+        content_type=project_ct,
+        object_pk=str(project_pk),
+        content_object=project)
+
+
+@pytest.mark.django_db
+def test_config_clear():
+    _test_config_clear(**dict(key="foo"))
+    _test_config_clear(**dict(key="foo", model=Project))
+    project = Project.objects.get(code="project0")
+    _test_config_clear(**dict(key="foo", model=project))
+
+
+@pytest.mark.django_db
+def test_config_get():
+    Config.objects.set_config("foo", ["bar"])
+    assert Config.objects.get_config("foo") == ["bar"]
+
+    Config.objects.set_config("foo", ["bar2"], Project)
+    assert Config.objects.get_config("foo") == ["bar"]
+    assert Config.objects.get_config("foo", Project) == ["bar2"]
+
+    project = Project.objects.get(code="project0")
+    Config.objects.set_config("foo", ["bar3"], project)
+    assert Config.objects.get_config("foo") == ["bar"]
+    assert Config.objects.get_config("foo", Project) == ["bar2"]
+
+    assert Config.objects.get_config("foo", project) == ["bar3"]
+
+
+@pytest.mark.django_db
+def test_config_list():
+    Config.objects.set_config("foo", ["bar"])
+    assert Config.objects.list_config("foo") == [("foo", ["bar"])]
+
+    Config.objects.set_config("foo", ["bar2"], Project)
+    assert Config.objects.list_config("foo") == [("foo", ["bar"])]
+    assert Config.objects.list_config("foo", Project) == [("foo", ["bar2"])]
+
+    project = Project.objects.get(code="project0")
+    Config.objects.set_config("foo", ["bar3"], project)
+    assert Config.objects.list_config("foo") == [("foo", ["bar"])]
+    assert Config.objects.list_config("foo", Project) == [("foo", ["bar2"])]
+    assert Config.objects.list_config("foo", project) == [("foo", ["bar3"])]
+
+
+@pytest.mark.django_db
+def test_config_append():
+    Config.objects.append_config("foo", ["bar"])
+    assert Config.objects.list_config("foo") == [("foo", ["bar"])]
+    Config.objects.append_config("foo", ["bar"])
+    assert Config.objects.list_config("foo") == [
+        ("foo", ["bar"]), ("foo", ["bar"])]
+
+    Config.objects.set_config("foo", ["bar2"], Project)
+    assert Config.objects.list_config("foo") == [
+        ("foo", ["bar"]), ("foo", ["bar"])]
+    assert Config.objects.list_config("foo", Project) == [
+        ("foo", ["bar2"])]
+    Config.objects.append_config("foo", ["bar2"], Project)
+    assert Config.objects.list_config("foo") == [
+        ("foo", ["bar"]), ("foo", ["bar"])]
+    assert Config.objects.list_config("foo", Project) == [
+        ("foo", ["bar2"]), ("foo", ["bar2"])]
+
+    project = Project.objects.get(code="project0")
+    Config.objects.set_config("foo", ["bar3"], project)
+    assert Config.objects.list_config("foo") == [
+        ("foo", ["bar"]), ("foo", ["bar"])]
+    assert Config.objects.list_config("foo", Project) == [
+        ("foo", ["bar2"]), ("foo", ["bar2"])]
+    assert Config.objects.list_config("foo", project) == [
+        ("foo", ["bar3"])]
+    Config.objects.append_config("foo", ["bar3"], project)
+    assert Config.objects.list_config("foo") == [
+        ("foo", ["bar"]), ("foo", ["bar"])]
+    assert Config.objects.list_config("foo", Project) == [
+        ("foo", ["bar2"]), ("foo", ["bar2"])]
+    assert Config.objects.list_config("foo", project) == [
+        ("foo", ["bar3"]), ("foo", ["bar3"])]
+
+
+@pytest.mark.django_db
+def test_config_getter():
+    # getting a non-existent key returns None
+    assert config.get(key="DOESNT_EXIST") is None
+
+    Config.objects.set_config("foo", ["bar"])
+    # if key is not specified to the getter it returns the qs
+    assert config.get().get(key="foo").value == ["bar"]
+    # you can use get_config(key) with the qs
+    assert config.get().get_config("foo") == ["bar"]
+    # if key is specified it returns the key value
+    assert config.get(key="foo") == ["bar"]
+
+    Config.objects.set_config("foo", ["bar2"], Project)
+    # previous tests still work
+    assert config.get().get(key="foo").value == ["bar"]
+    assert config.get().get_config("foo") == ["bar"]
+    assert config.get(key="foo") == ["bar"]
+    # specifying only model gets the queryset
+    assert config.get(Project).get(key="foo").value == ["bar2"]
+    # which we can use get_config with
+    assert config.get(Project).get_config("foo") == ["bar2"]
+    # specifying key also gets the value
+    assert config.get(Project, key="foo") == ["bar2"]
+
+    project = Project.objects.get(code="project0")
+    Config.objects.set_config("foo", ["bar3"], project)
+    # previous tests still work
+    assert config.get().get(key="foo").value == ["bar"]
+    assert config.get().get_config("foo") == ["bar"]
+    assert config.get(key="foo") == ["bar"]
+    assert config.get(Project).get(key="foo").value == ["bar2"]
+    assert config.get(Project).get_config("foo") == ["bar2"]
+    assert config.get(Project, key="foo") == ["bar2"]
+
+    # we can get settings for an indiv project like so...
+    assert config.get(Project, instance=project).get(key="foo").value == ["bar3"]
+    assert config.get(Project, instance=project).get_config("foo") == ["bar3"]
+    assert config.get(Project, instance=project, key="foo") == ["bar3"]
+
+
+@pytest.mark.django_db
+def test_config_getter_list():
+    assert config.get(key=[]) == []
+
+    config.get().set_config("foo", ["bar0"])
+    config.get().append_config("foo", ["bar0"])
+
+    with pytest.raises(ConfigurationError):
+        config.get(key="foo")
+
+    # if we pass a list as key we get a k, v list mapping
+    assert config.get(key=["foo"]) == [
+        (u'foo', [u'bar0']), (u'foo', [u'bar0'])]
+    assert config.get(key=[]) == [
+        (u'foo', [u'bar0']), (u'foo', [u'bar0'])]
+
+    config.get().set_config("foo2", ["bar1"])
+
+    # this still works
+    assert config.get(key=["foo"]) == [
+        (u'foo', [u'bar0']), (u'foo', [u'bar0'])]
+
+    # this still works
+    assert config.get(key=["foo2"]) == [(u'foo2', [u'bar1'])]
+
+    # both keys are returned for key=[]
+    assert config.get(key=[]) == [
+        (u'foo', [u'bar0']),
+        (u'foo', [u'bar0']),
+        (u'foo2', [u'bar1'])]
+
+    assert config.get(Project, key=[]) == []
+
+    config.get(Project).set_config("foo", ["bar2"])
+    config.get(Project).append_config("foo", ["bar2"])
+
+    with pytest.raises(ConfigurationError):
+        config.get(Project, key="foo")
+
+    # if we pass a list as key we get a k, v list mapping
+    assert config.get(Project, key=["foo"]) == [
+        (u'foo', [u'bar2']), (u'foo', [u'bar2'])]
+    assert config.get(Project, key=[]) == [
+        (u'foo', [u'bar2']), (u'foo', [u'bar2'])]
+
+    config.get(Project).set_config("foo2", ["bar3"])
+
+    # this still works
+    assert config.get(Project, key=["foo"]) == [
+        (u'foo', [u'bar2']), (u'foo', [u'bar2'])]
+
+    # this still works
+    assert config.get(
+        Project, key=["foo2"]) == [(u'foo2', [u'bar3'])]
+
+    # both keys are returned for key=[]
+    assert config.get(Project, key=[]) == [
+        (u'foo', [u'bar2']),
+        (u'foo', [u'bar2']),
+        (u'foo2', [u'bar3'])]
+
+    # site config still works
+    assert config.get(key=[]) == [
+        (u'foo', [u'bar0']),
+        (u'foo', [u'bar0']),
+        (u'foo2', [u'bar1'])]
+
+    project = Project.objects.get(code="project0")
+    assert config.get(
+        Project, instance=project, key=[]) == []
+
+    config.get(
+        Project,
+        instance=project).set_config("foo", ["bar3"])
+    config.get(
+        Project,
+        instance=project).append_config("foo", ["bar3"])
+
+    with pytest.raises(ConfigurationError):
+        config.get(Project, instance=project, key="foo")
+
+    # if we pass a list as key we get a k, v list mapping
+    assert config.get(Project, instance=project, key=["foo"]) == [
+        (u'foo', [u'bar3']), (u'foo', [u'bar3'])]
+    assert config.get(Project, instance=project, key=[]) == [
+        (u'foo', [u'bar3']), (u'foo', [u'bar3'])]
+
+    config.get(Project, instance=project).set_config("foo2", ["bar4"])
+
+    # this still works
+    assert config.get(Project, instance=project, key=["foo"]) == [
+        (u'foo', [u'bar3']), (u'foo', [u'bar3'])]
+
+    # this still works
+    assert config.get(
+        Project,
+        instance=project,
+        key=["foo2"]) == [(u'foo2', [u'bar4'])]
+
+    # both keys are returned for key=[]
+    assert config.get(Project, instance=project, key=[]) == [
+        (u'foo', [u'bar3']),
+        (u'foo', [u'bar3']),
+        (u'foo2', [u'bar4'])]
+
+    # model config still works
+    assert config.get(Project, key=[]) == [
+        (u'foo', [u'bar2']),
+        (u'foo', [u'bar2']),
+        (u'foo2', [u'bar3'])]
+
+    # site config still works
+    assert config.get(key=[]) == [
+        (u'foo', [u'bar0']),
+        (u'foo', [u'bar0']),
+        (u'foo2', [u'bar1'])]
+
+
+@pytest.mark.django_db
+def test_config_setter():
+    config.get().set_config("foo", ["bar"])
+    assert config.get(key="foo") == ["bar"]
+
+    config.get(Project).set_config("foo", ["bar2"])
+    assert config.get(Project, key="foo") == ["bar2"]
+
+    project = Project.objects.get(code="project0")
+    config.get(Project).set_config("foo", ["bar3"], project)
+    assert config.get(Project, instance=project, key="foo") == ["bar3"]
+
+
+@pytest.mark.django_db
+def test_config_set_json(json_objects):
+
+    # set site-wide config
+    _test_config_ob(
+        Config.objects.set_config("foo", json_objects),
+        key=u"foo",
+        value=json_objects,
+        content_type=None,
+        object_pk=None)
+
+    project = Project.objects.get(code="project0")
+    project_pk = project.pk
+    project_ct = ContentType.objects.get_for_model(project)
+
+    # set config for all projects
+    _test_config_ob(
+        Config.objects.set_config("foo", json_objects, model=Project),
+        key="foo",
+        value=json_objects,
+        content_type=project_ct,
+        object_pk=None,
+        content_object=None)
+
+    # set config for project
+    _test_config_ob(
+        Config.objects.set_config("foo", json_objects, model=project),
+        key="foo",
+        value=json_objects,
+        content_type=project_ct,
+        object_pk=str(project_pk),
+        content_object=project)
+
+
+@pytest.mark.django_db
+def test_config_no_set():
+
+    @getter(config_should_not_be_set)
+    def config_should_be_set_checker(**kwargs):
+        if kwargs["key"] == "foo":
+            return True
+
+    with pytest.raises(ConfigurationError):
+        config.get().set_config("foo", "bar")
+    config.get().set_config("foo2", "bar")
+
+    @getter(config_should_not_be_set, sender=Project)
+    def config_should_be_set_model_checker(**kwargs):
+        if kwargs["key"] == "foo2":
+            return True
+
+    config.get().set_config("foo2", "bar")
+    with pytest.raises(ConfigurationError):
+        config.get(Project).set_config("foo2", "bar")
+    config.get(Project).set_config("foo3", "bar")
+
+
+@pytest.mark.django_db
+def test_config_no_append():
+
+    @getter(config_should_not_be_appended)
+    def config_should_be_appended_checker(**kwargs):
+        if kwargs["key"] == "foo":
+            return True
+
+    with pytest.raises(ConfigurationError):
+        config.get().append_config("foo", "bar")
+    config.get().append_config("foo2", "bar")
+
+    @getter(config_should_not_be_appended, sender=Project)
+    def config_should_be_appended_model_checker(**kwargs):
+        if kwargs["key"] == "foo2":
+            return True
+
+    config.get().append_config("foo2", "bar")
+    with pytest.raises(ConfigurationError):
+        config.get(Project).append_config("foo2", "bar")
+    config.get(Project).append_config("foo3", "bar")


### PR DESCRIPTION
This PR adds a generic configuration system for Pootle.

This is useful so that plugins can persist data without having to make schema changes or add additional models.

There are 3 types of config objects:
- config with content_type and object_pk - these are related to specific model instances
- config with only content_type - these are related to a particular model
- config with neither content_type, nor object_pk - these are for site configurations

keys are max 255 chars
values can be any json serializable value

example usage
---
https://github.com/translate/pootle/wiki/DocsDevConfig

