### PR TITLE
Lang mapper

### DIFF
--- a/pootle/apps/pootle_config/utils.py
+++ b/pootle/apps/pootle_config/utils.py
@@ -29,6 +29,10 @@ class ConfigDict(object):
     def conf(self):
         return OrderedDict(self.__config__.list_config())
 
+    def reload(self):
+        if "conf" in self.__dict__:
+            del self.__dict__["conf"]
+
     def __contains__(self, k):
         return self.conf.__contains__(k)
 
@@ -40,8 +44,7 @@ class ConfigDict(object):
 
     def __setitem__(self, k, v):
         self.__config__.set_config(k, v)
-        if "conf" in self.__dict__:
-            del self.__dict__["conf"]
+        self.reload()
 
     def get(self, k, default=None):
         return self.conf.get(k, default)

--- a/pootle/apps/pootle_project/apps.py
+++ b/pootle/apps/pootle_project/apps.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import importlib
+
 from django.apps import AppConfig
 
 
@@ -13,3 +15,6 @@ class PootleProjectConfig(AppConfig):
 
     name = "pootle_project"
     verbose_name = "Pootle Project"
+
+    def ready(self):
+        importlib.import_module("pootle_project.getters")

--- a/pootle/apps/pootle_project/getters.py
+++ b/pootle/apps/pootle_project/getters.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.delegate import lang_mapper
+from pootle.core.plugin import getter
+
+from .lang_mapper import ProjectLanguageMapper
+from .models import Project
+
+
+@getter(lang_mapper, sender=Project)
+def get_lang_mapper(sender, instance, **kwargs):
+    return ProjectLanguageMapper(instance)

--- a/pootle/apps/pootle_project/lang_mapper.py
+++ b/pootle/apps/pootle_project/lang_mapper.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import logging
+from collections import OrderedDict
+
+from django.utils.functional import cached_property
+from django.utils.lru_cache import lru_cache
+
+from pootle_config.utils import SiteConfig
+from pootle_language.models import Language
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectLanguageMapper(object):
+    """For a given code find the relevant Pootle lang taking account of any
+    lang mapping configuration.
+
+    Presets can be defined with a dictionary of named mappings on the site_config
+    `pootle.core.lang_mapping_presets`.
+
+    Presets are enabled with a list on the project_config
+    `pootle.core.use_lang_mapping_presets`.
+
+    Lang mappings can also be configured per-project using the config setting
+    `pootle.core.lang_mapping`, which should be a k, v dictionary of
+    upstream_code, pootle_code. This will override any mappings in configured
+    presets.
+    """
+
+    def __init__(self, project):
+        self.project = project
+
+    def __getitem__(self, k):
+        return self.get_lang(k)
+
+    def __contains__(self, k):
+        return self.get_lang(k) and True or False
+
+    @cached_property
+    def site_config(self):
+        return SiteConfig()
+
+    @property
+    def site_presets(self):
+        """Get the pret mappings from the site config"""
+        return OrderedDict(
+            self.site_config.get(
+                "pootle.core.lang_mapping_presets", {}))
+
+    @property
+    def project_presets(self):
+        """Get the projects mapping from the Project.config"""
+        return self.project.config.get(
+            "pootle.core.use_lang_mapping_presets", [])
+
+    @property
+    def project_mappings(self):
+        """Get the projects mapping from the Project.config"""
+        return OrderedDict(
+            self.project.config.get(
+                "pootle.core.lang_mapping", {}))
+
+    @property
+    def mappings_from_presets(self):
+        mappings = OrderedDict()
+        for preset_name in self.project_presets:
+            if preset_name not in self.site_presets:
+                logger.warning(
+                    "Unrecognised lang mapping preset: %s"
+                    % preset_name)
+                continue
+            mappings.update(self.site_presets[preset_name])
+        return mappings
+
+    @cached_property
+    def lang_mappings(self):
+        """Language mappings after Project.config and presets are parsed"""
+        return self._parse_mappings()
+
+    @lru_cache()
+    def get_lang(self, upstream_code):
+        """Return a `Language` for a given code after mapping"""
+        try:
+            return Language.objects.get(
+                code=self.get_pootle_code(upstream_code))
+        except Language.DoesNotExist:
+            return None
+
+    def get_pootle_code(self, upstream_code):
+        """Returns a pootle code for a given upstream code"""
+        if upstream_code in self.lang_mappings:
+            return self.lang_mappings[upstream_code]
+        if upstream_code not in self.lang_mappings.values():
+            return upstream_code
+
+    def get_upstream_code(self, pootle_code):
+        """Returns an upstream code for a given pootle code"""
+        for _upstream_code, _pootle_code in self.lang_mappings.items():
+            if pootle_code == _pootle_code:
+                return _upstream_code
+        if pootle_code not in self.lang_mappings:
+            return pootle_code
+
+    def _add_lang_to_mapping(self, upstream_code, pootle_code):
+        # as its a 1 to 1 mapping remove any previous items with
+        # same value
+        if pootle_code in self._mapping.values():
+            for k, v in self._mapping.items():
+                if v == pootle_code:
+                    del self._mapping[k]
+                    break
+        self._mapping[upstream_code] = pootle_code
+
+    def _parse_mappings(self):
+        self._mapping = OrderedDict()
+        mappings = self.mappings_from_presets
+        mappings.update(self.project_mappings)
+
+        for upstream_code, pootle_code in mappings.items():
+            self._add_lang_to_mapping(upstream_code, pootle_code)
+        return self._mapping

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -32,6 +32,7 @@ from pootle.core.url_helpers import (get_editor_filter, get_path_sortkey,
                                      split_pootle_path, to_tp_relative_path)
 from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import PermissionSet
+from pootle_config.utils import ObjectConfig
 from pootle_store.filetypes import factory_classes
 from pootle_store.models import Store
 from pootle_store.util import absolute_real_path
@@ -293,6 +294,10 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
         return user_projects
 
     # # # # # # # # # # # # # #  Properties # # # # # # # # # # # # # # # # # #
+
+    @cached_property
+    def config(self):
+        return ObjectConfig(self)
 
     @property
     def name(self):

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -12,6 +12,7 @@ from pootle.core.plugin.delegate import Getter, Provider
 
 config = Getter(providing_args=["instance"])
 search_backend = Getter(providing_args=["instance"])
+lang_mapper = Getter(providing_args=["instance"])
 
 serializers = Provider(providing_args=["instance"])
 deserializers = Provider(providing_args=["instance"])

--- a/tests/misc/lang_mapper.py
+++ b/tests/misc/lang_mapper.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from collections import OrderedDict
+
+import pytest
+
+from pytest_pootle.factories import ProjectDBFactory
+
+from pootle.core.delegate import lang_mapper
+from pootle_config.utils import ObjectConfig, SiteConfig
+from pootle_language.models import Language
+
+
+@pytest.mark.django_db
+def test_lang_mapper_bad_preset(english, caplog):
+    project = ProjectDBFactory(source_language=english)
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    assert mapper.lang_mappings == {}
+    project_config = ObjectConfig(project)
+    project_config[
+        "pootle.core.use_lang_mapping_presets"] = ["PRESET_DOES_NOT_EXIST"]
+    project.config.reload()
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    assert mapper.lang_mappings == {}
+    assert (
+        "Unrecognised lang mapping preset"
+        in ''.join([l.message for l in caplog.records()]))
+
+
+@pytest.mark.django_db
+def test_lang_mapper_no_config(english):
+    project = ProjectDBFactory(source_language=english)
+    mapper = lang_mapper.get(project.__class__, instance=project)
+
+    # lang exists and its valid
+    assert mapper["en"] == english
+    assert mapper.get_pootle_code("en") == "en"
+    assert mapper.get_upstream_code("en") == "en"
+    assert "en" in mapper
+
+    # The lang doesnt exist but its not excluded
+    assert mapper["en_FOO"] is None
+    assert mapper.get_pootle_code("en_FOO") == "en_FOO"
+    assert mapper.get_upstream_code("en_FOO") == "en_FOO"
+    assert "en_FOO" not in mapper
+
+
+@pytest.mark.django_db
+def test_lang_mapper_project_config(english):
+    project = ProjectDBFactory(source_language=english)
+    project_config = ObjectConfig(project)
+    # upstream_code="en_US", pootle_code="en"
+    project_config["pootle.core.lang_mapping"] = dict(en_US="en")
+    project.config.reload()
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    assert mapper["en_US"] == english
+    assert mapper.get_pootle_code("en_US") == "en"
+    assert mapper.get_upstream_code("en") == "en_US"
+    assert "en_US" in mapper
+
+    # as en_US is mapped to pootle's en its not valid as upstream code
+    assert mapper.get_upstream_code("en_US") is None
+    # as en is mapped to en_US its not valid as a pootle_code
+    assert mapper.get_pootle_code("en") is None
+    assert "en" not in mapper
+
+    # we can swap codes
+    project_config["pootle.core.lang_mapping"] = dict(
+        language0="en", en="language0")
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    project.config.reload()
+    language0 = Language.objects.get(code="language0")
+    assert mapper["en"] == language0
+    assert mapper["language0"] == english
+    assert mapper.get_pootle_code("en") == "language0"
+    assert mapper.get_pootle_code("language0") == "en"
+    assert mapper.get_upstream_code("en") == "language0"
+    assert mapper.get_upstream_code("language0") == "en"
+
+
+@pytest.mark.django_db
+def test_lang_mapper_preset_config(english):
+    project = ProjectDBFactory(source_language=english)
+    project_config = ObjectConfig(project)
+    site_config = SiteConfig()
+    # add the preset
+    site_config["pootle.core.lang_mapping_presets"] = dict(
+        preset_1=dict(en_US="en"))
+
+    # project not configured yet tho
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    assert mapper["en_US"] is None
+    assert mapper["en"] == english
+
+    # configure project to use preset
+    project_config["pootle.core.use_lang_mapping_presets"] = ["preset_1"]
+    project.config.reload()
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    assert mapper["en_US"] == english
+    assert mapper["en"] is None
+
+
+@pytest.mark.django_db
+def test_lang_mapper_mappings(english):
+    project = ProjectDBFactory(source_language=english)
+    _test_mapper(project)
+    ObjectConfig(project)["pootle.core.lang_mapping"] = dict(lang0="language0")
+    _test_mapper(project)
+    ObjectConfig(project)["pootle.core.lang_mapping"] = dict(
+        lang0="language1", lang1="language0")
+    _test_mapper(project)
+    SiteConfig()["pootle.core.lang_mapping_presets"] = dict(
+        preset_1=dict(lang0="language1", lang1="language0"))
+    _test_mapper(project)
+    ObjectConfig(project)["pootle.core.lang_mapping"] = dict(
+        lang0="language1", lang1="en")
+    _test_mapper(project)
+    ObjectConfig(project)["pootle.core.use_lang_mapping_presets"] = ["preset_1"]
+    _test_mapper(project)
+    ObjectConfig(project)["pootle.core.use_lang_mapping_presets"] = [
+        "preset_1", "preset_2"]
+    _test_mapper(project)
+    ObjectConfig(project)["pootle.core.lang_mapping"] = dict(lang1="language1")
+    _test_mapper(project, True)
+
+
+def _test_mapper(project, debug=False):
+    project.config.reload()
+    mapper = lang_mapper.get(project.__class__, instance=project)
+    assert mapper.site_config.items() == SiteConfig().items()
+    assert mapper.project.config.items() == ObjectConfig(project).items()
+    assert mapper.project_mappings == ObjectConfig(project).get(
+        "pootle.core.lang_mapping", {})
+    assert mapper.project_presets == ObjectConfig(project).get(
+        "pootle.core.use_lang_mapping_presets", [])
+    assert mapper.site_presets == SiteConfig().get(
+        "pootle.core.lang_mapping_presets", {})
+
+    _preset_mappings = OrderedDict()
+    for preset_name in mapper.project_presets:
+        if preset_name not in mapper.site_presets:
+            continue
+        _preset_mappings.update(
+            mapper.site_presets[preset_name])
+
+    assert mapper.mappings_from_presets == _preset_mappings
+
+    _mapping = OrderedDict()
+
+    def _add_lang_to_mapping(upstream_code, pootle_code):
+        # as its a 1 to 1 mapping remove any previous items with
+        # same value
+        if pootle_code in _mapping.values():
+            for k, v in _mapping.items():
+                if v == pootle_code:
+                    del _mapping[k]
+                    break
+        _mapping[upstream_code] = pootle_code
+    mappings = OrderedDict(mapper.mappings_from_presets)
+    mappings.update(OrderedDict(mapper.project_mappings))
+    for upstream_code, pootle_code in mappings.items():
+        _add_lang_to_mapping(upstream_code, pootle_code)
+
+    assert mapper.lang_mappings == _mapping
+    assert len(_mapping.values()) == len(set(_mapping.values()))


### PR DESCRIPTION
Adds a language mapper with presets for Projects

At the moment its not hooked up (other than in pootle_fs), but im thinking that Store.update/sync should also respect any configured lang mappings.

initial docs here https://github.com/translate/pootle/wiki/DocsDevLangMapper