### PR TITLE
fix update_stores not changing fuzzy state

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -20,7 +20,7 @@ class UnitDiffProxy(UnitProxy):
     """Wraps File/DB Unit dicts used by StoreDiff for equality comparison"""
 
     match_attrs = ["context", "developer_comment", "locations",
-                   "source", "target", "translator_comment"]
+                   "source", "state", "target", "translator_comment"]
 
     def __eq__(self, other):
         return all(getattr(self, k) == getattr(other, k)


### PR DESCRIPTION
regression from 80d35df2b2c3987470873c541c288dc95c0ec79e
ignoring change in state makes it impossible to update the fuzzy state
of a translatin unit by modifying the files on disk, and running
update_stores. With state ignored in the comparison, those changes are
silently ignored (and thenget overridden again on next sync_stores)