### PR TITLE
Pull fuzzy update stores

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -20,7 +20,7 @@ class UnitDiffProxy(UnitProxy):
     """Wraps File/DB Unit dicts used by StoreDiff for equality comparison"""
 
     match_attrs = ["context", "developer_comment", "locations",
-                   "source", "target", "translator_comment"]
+                   "source", "state", "target", "translator_comment"]
 
     def __eq__(self, other):
         return all(getattr(self, k) == getattr(other, k)

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -13,7 +13,7 @@ from django.utils.functional import cached_property
 
 from .fields import to_python as multistring_to_python
 from .unit import UnitProxy
-from .util import OBSOLETE
+from .util import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 
 
 class UnitDiffProxy(UnitProxy):
@@ -31,7 +31,6 @@ class UnitDiffProxy(UnitProxy):
 
 
 class DBUnit(UnitDiffProxy):
-
     pass
 
 
@@ -80,13 +79,20 @@ class StoreDiff(object):
         for unit in self.file_store.units:
             if unit.isheader():
                 continue
+            state = UNTRANSLATED
+            if unit.isobsolete():
+                state = OBSOLETE
+            elif unit.istranslated():
+                state = TRANSLATED
+            elif unit.isfuzzy():
+                state = FUZZY
             file_units[unit.getid()] = {
                 "unitid": unit.getid(),
                 "context": unit.getcontext(),
                 "locations": unit.getlocations(),
                 "source": unit.source,
                 "target": unit.target,
-                "state": unit.get_state_n(),
+                "state": state,
                 "developer_comment": unit.getnotes(origin="developer"),
                 "translator_comment": unit.getnotes(origin="translator")}
         return file_units


### PR DESCRIPTION
If a units state has changed, but there are no other changes then the Store is not updated

This PR fixes that.

I think we need to ensure that *all* unit changes are properly registered regardless of source/target changes, and probs add some more tests around this. (ref #4715)

thanks to @cloph for spotting this and submitting initial fix #4713.