### PR TITLE
Save submissions in a proper order

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -267,17 +267,25 @@ def unit_form_factory(language, snplurals=None, request=None):
         def __init__(self, *args, **kwargs):
             self.request = kwargs.pop('request', None)
             super(UnitForm, self).__init__(*args, **kwargs)
-            self.updated_fields = []
+            self._updated_fields = []
 
             self.fields['target_f'].widget.attrs['data-translation-aid'] = \
                 self['target_f'].value()
+
+        @property
+        def updated_fields(self):
+            order_dict = {
+                SubmissionFields.STATE: 0,
+                SubmissionFields.TARGET: 1,
+            }
+            return sorted(self._updated_fields, key=lambda x: order_dict[x[0]])
 
         def clean_target_f(self):
             value = self.cleaned_data['target_f']
 
             if self.instance.target.strings != multistring(value or [u'']):
                 self.instance._target_updated = True
-                self.updated_fields.append((SubmissionFields.TARGET,
+                self._updated_fields.append((SubmissionFields.TARGET,
                                             to_db(self.instance.target),
                                             to_db(value)))
 
@@ -347,7 +355,7 @@ def unit_form_factory(language, snplurals=None, request=None):
 
             if old_state not in [new_state, OBSOLETE]:
                 self.instance._state_updated = True
-                self.updated_fields.append((SubmissionFields.STATE,
+                self._updated_fields.append((SubmissionFields.STATE,
                                             old_state, new_state))
 
                 self.cleaned_data['state'] = new_state

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -12,6 +12,8 @@ import operator
 import os
 from hashlib import md5
 
+from collections import OrderedDict
+
 from translate.filters.decorators import Category
 from translate.storage import base
 
@@ -1138,11 +1140,11 @@ class Unit(models.Model, base.TranslationUnit):
         suggestion.review_time = current_time
         suggestion.save()
 
-        create_subs = {}
-        create_subs[SubmissionFields.TARGET] = [old_target, self.target]
+        create_subs = OrderedDict()
         if old_state != self.state:
             create_subs[SubmissionFields.STATE] = [old_state, self.state]
             self.store.mark_dirty(CachedMethods.WORDCOUNT_STATS)
+        create_subs[SubmissionFields.TARGET] = [old_target, self.target]
 
         for field in create_subs:
             kwargs = {
@@ -1576,20 +1578,20 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         being available in `unit`. Let's look into replacing such members with
         something saner (#3895).
         """
-        create_subs = {}
-
-        # FIXME: extreme implicit hazard
-        if unit._target_updated:
-            create_subs[SubmissionFields.TARGET] = [
-                old_target,
-                unit.target_f,
-            ]
+        create_subs = OrderedDict()
 
         # FIXME: extreme implicit hazard
         if unit._state_updated:
             create_subs[SubmissionFields.STATE] = [
                 old_state,
                 unit.state,
+            ]
+
+        # FIXME: extreme implicit hazard
+        if unit._target_updated:
+            create_subs[SubmissionFields.TARGET] = [
+                old_target,
+                unit.target_f,
             ]
 
         # FIXME: extreme implicit hazard

--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -303,10 +303,16 @@ class Timeline(object):
                 ]
             ])
         )
+
+        # Target field timeline entry should go first
+        def target_field_should_be_first(x):
+            return 0 if x["field"] == SubmissionFields.TARGET else 1
+
         # Group by submitter id and creation_time because
         # different submissions can have same creation time
         for key, values in grouped_timeline:
             entry_group = {'entries': []}
+            values = sorted(values, key=target_field_should_be_first)
             for item in values:
                 if "submitter" not in entry_group:
                     entry_group['submitter'] = DisplayUser(


### PR DESCRIPTION
This PR addresses #4621 issue.
Target field submission are saved after state field always.