### PR TITLE
Fix: serializers gather correctly and pass store

### DIFF
--- a/pootle/apps/pootle_store/store/deserialize.py
+++ b/pootle/apps/pootle_store/store/deserialize.py
@@ -34,7 +34,7 @@ class StoreDeserialization(object):
     @cached_property
     def deserializers(self):
         available_deserializers = deserializers.gather(
-            self.store.__class__, instance=self.store)
+            self.store.translation_project.project.__class__)
         found_deserializers = []
         for deserializer in self.project_deserializers:
             found_deserializers.append(available_deserializers[deserializer])
@@ -44,7 +44,7 @@ class StoreDeserialization(object):
         if not self.deserializers:
             return data
         for deserializer in self.deserializers:
-            data = deserializer(self, data).output
+            data = deserializer(self.store, data).output
         return data
 
     def fromstring(self, data):

--- a/pootle/apps/pootle_store/store/serialize.py
+++ b/pootle/apps/pootle_store/store/serialize.py
@@ -39,7 +39,7 @@ class StoreSerialization(object):
     @cached_property
     def serializers(self):
         available_serializers = serializers.gather(
-            self.store.__class__, instance=self.store)
+            self.store.translation_project.project.__class__)
         found_serializers = []
         for serializer in self.project_serializers:
             found_serializers.append(available_serializers[serializer])
@@ -59,7 +59,7 @@ class StoreSerialization(object):
         if not self.serializers:
             return data
         for serializer in self.serializers:
-            data = serializer(self, data).output
+            data = serializer(self.store, data).output
         return data
 
     def serialize(self):


### PR DESCRIPTION
This PR contains a cleanup and a couple of fixes

- Config.set_config does not return a Config object
- Config.none().get_config was not working correctly on ModelConfig
- Fix serializers should be called with Store, and gather on Project

and adjusts tests accordingly