### PR TITLE
Cleanup: rename views' `is_admin` to `has_admin_access`

### DIFF
--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -339,7 +339,7 @@ class ProjectsMixin(object):
         return self.get_object().directory
 
     @property
-    def is_admin(self):
+    def has_admin_access(self):
         return self.request.user.is_superuser
 
     @property

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -450,9 +450,9 @@ class UnitEditJSON(PootleUnitJSON):
             'canreview': check_user_permission(self.request.user,
                                                "review",
                                                self.directory),
-            'is_admin': check_user_permission(self.request.user,
-                                              'administrate',
-                                              self.directory),
+            'has_admin_access': check_user_permission(self.request.user,
+                                                      'administrate',
+                                                      self.directory),
             'altsrcs': self.get_alt_srcs()}
 
     def get_response_data(self, context):

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -292,13 +292,13 @@ class TPBrowseView(TPDirectoryMixin, TPBrowseBaseView):
     @cached_property
     def vfolders(self):
         vftis = self.object.vf_treeitems
-        if not self.is_admin:
+        if not self.has_admin_access:
             vftis = vftis.filter(vfolder__is_public=True)
         return [
             make_vfolder_treeitem_dict(vfolder_treeitem)
             for vfolder_treeitem
             in vftis.order_by('-vfolder__priority').select_related("vfolder")
-            if (self.is_admin
+            if (self.has_admin_access
                 or vfolder_treeitem.is_visible)]
 
     @cached_property

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -472,7 +472,7 @@ class PootleDetailView(DetailView):
             kwargs=self.url_kwargs)
 
     @cached_property
-    def is_admin(self):
+    def has_admin_access(self):
         return check_permission('administrate', self.request)
 
     @property
@@ -516,7 +516,7 @@ class PootleDetailView(DetailView):
             'project': self.project,
             'language': self.language,
             'translation_project': self.tp,
-            'is_admin': self.is_admin,
+            'has_admin_access': self.has_admin_access,
             'resource_path': self.resource_path,
             'resource_path_parts': get_path_parts(self.resource_path),
             'translate_url': self.translate_url,

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -145,7 +145,7 @@ $(function () {
   PTL.search.init();
   PTL.stats.init({
     pootlePath: "{{ pootle_path }}",
-    isAdmin: {{ is_admin|yesno:"true,false" }},
+    isAdmin: {{ has_admin_access|yesno:"true,false" }},
     isInitiallyExpanded: {{ is_store|yesno:"true,false" }},
     initialData: JSON.parse('{{ stats|escapejs }}'),
   });

--- a/pootle/templates/core/_breadcrumbs.html
+++ b/pootle/templates/core/_breadcrumbs.html
@@ -10,7 +10,7 @@
 <li>
   <select id="js-select-language" data-initial-code="{{ language.code }}"
     style="visibility: hidden;">
-    {% if is_admin or page != "translate" %}
+    {% if has_admin_access or page != "translate" %}
     <option value=""></option>
     {% endif %}
     {% for lang_code, lang_name in ALL_LANGUAGES.items %}

--- a/pootle/templates/editor/_scripts.html
+++ b/pootle/templates/editor/_scripts.html
@@ -24,7 +24,7 @@ $(function() {
     resourcePath: '{{ resource_path }}',
     chunkSize: {{ request.user.get_unit_rows }},
     displayPriority: {{ display_priority|yesno:"true,false" }},
-    isAdmin: {{ is_admin|yesno:"true,false" }},
+    isAdmin: {{ has_admin_access|yesno:"true,false" }},
     isAnonymous: {{ request.user.is_anonymous|yesno:"true,false" }},
     userId: {{ request.user.id }},
     localeDir: '{{ language.direction }}',

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -173,7 +173,7 @@
               <div class="submit"><a href="#" title="{% trans 'Switch to suggestion mode (Ctrl+Shift+Space)' %}">&harr; {% trans "Suggest" %}</a></div>
             </div>
             {% endif %}
-            <div class="translate-fuzzy-block js-fuzzy-block{% if not is_admin and not unit.isfuzzy %} hide{% endif %}"
+            <div class="translate-fuzzy-block js-fuzzy-block{% if not has_admin_access and not unit.isfuzzy %} hide{% endif %}"
               lang="{{ LANGUAGE_CODE }}"
               title="{% trans 'Mark this string as needing further work (Ctrl+Space)' %}">
               {{ form.state }} {{ form.state|label_tag:'' }}

--- a/pootle/templates/projects/_nav.html
+++ b/pootle/templates/projects/_nav.html
@@ -4,7 +4,7 @@
   data-href="{{ browse_url }}">
   {% trans "Browse" %}
 </option>
-{% if is_admin or language %}
+{% if has_admin_access or language %}
 <option
   value="translate"
   data-href="{{ translate_url }}">

--- a/pootle/templates/projects/all/_nav.html
+++ b/pootle/templates/projects/all/_nav.html
@@ -4,7 +4,7 @@
   data-href="{{ browse_url }}">
   {% trans "Browse" %}
 </option>
-{% if is_admin %}
+{% if has_admin_access %}
 <option
   value="translate"
   data-href="{{ translate_url }}">

--- a/tests/views/get_edit_unit.py
+++ b/tests/views/get_edit_unit.py
@@ -60,5 +60,5 @@ def test_get_edit_unit(client, request_users, settings):
         user, "suggest", directory)
     assert response.context["canreview"] == check_user_permission(
         user, "review", directory)
-    assert response.context["is_admin"] == check_user_permission(
+    assert response.context["has_admin_access"] == check_user_permission(
         user, "administrate", directory)

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -88,7 +88,7 @@ def _test_translate_view(language, request, response, kwargs, settings):
             check_categories=get_qualitycheck_schema(),
             previous_url=get_previous_url(request),
             display_priority=False,
-            is_admin=check_permission('administrate', request),
+            has_admin_access=check_permission('administrate', request),
             cantranslate=check_permission("translate", request),
             cansuggest=check_permission("suggest", request),
             canreview=check_permission("review", request),

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -54,7 +54,7 @@ def _test_translate_view(project, request, response, kwargs, settings):
         ctx,
         **dict(
             page="translate",
-            is_admin=request.user.is_superuser,
+            has_admin_access=request.user.is_superuser,
             language=None,
             project=project,
             pootle_path=pootle_path,
@@ -272,7 +272,7 @@ def test_view_projects_translate(client, settings, request_users):
     request = response.wsgi_request
     assertions = dict(
         page="translate",
-        is_admin=user.is_superuser,
+        has_admin_access=user.is_superuser,
         language=None,
         project=None,
         pootle_path="/projects/",

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -60,13 +60,13 @@ def _test_browse_view(tp, request, response, kwargs):
             pootle_path=pootle_path)
     if not kwargs.get("filename"):
         vftis = ob.vf_treeitems.select_related("vfolder")
-        if not ctx["is_admin"]:
+        if not ctx["has_admin_access"]:
             vftis = vftis.filter(vfolder__is_public=True)
         vfolders = [
             make_vfolder_treeitem_dict(vfolder_treeitem)
             for vfolder_treeitem
             in vftis.order_by('-vfolder__priority')
-            if (ctx["is_admin"]
+            if (ctx["has_admin_access"]
                 or vfolder_treeitem.is_visible)]
         stats = {"vfolders": {}}
         for vfolder_treeitem in vfolders or []:
@@ -119,7 +119,7 @@ def _test_browse_view(tp, request, response, kwargs):
         translation_project=tp,
         language=tp.language,
         project=tp.project,
-        is_admin=check_permission('administrate', request),
+        has_admin_access=check_permission('administrate', request),
         is_store=(kwargs.get("filename") and True or False),
         browser_extends="translation_projects/base.html",
         pootle_path=pootle_path,
@@ -144,7 +144,7 @@ def _test_browse_view(tp, request, response, kwargs):
     view_context_test(ctx, **assertions)
     if vfolders:
         for vfolder in ctx["vfolders"]["items"]:
-            assert (vfolder["is_grayed"] and not ctx["is_admin"]) is False
+            assert (vfolder["is_grayed"] and not ctx["has_admin_access"]) is False
         assert (
             ctx["vfolders"]["items"]
             == vfolders)
@@ -173,7 +173,7 @@ def _test_translate_view(tp, request, response, kwargs, settings):
         translation_project=tp,
         language=tp.language,
         project=tp.project,
-        is_admin=check_permission('administrate', request),
+        has_admin_access=check_permission('administrate', request),
         ctx_path=tp.pootle_path,
         pootle_path=request_path,
         resource_path=resource_path,


### PR DESCRIPTION
Renames views' `is_admin` property to a more natural `has_admin_access` (also in the template context).