### PR TITLE
Browser: hide disabled items and allow showing them to admins

### DIFF
--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -353,7 +353,7 @@ class ProjectsBrowseView(ProjectsMixin, PootleBrowseView):
         'name', 'progress', 'total', 'need-translation',
         'suggestions', 'critical', 'last-updated', 'activity']
 
-    @property
+    @cached_property
     def items(self):
         items = [
             make_project_list_item(project)

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -582,13 +582,19 @@ class PootleBrowseView(PootleDetailView):
             (self.object, ))
 
     @property
+    def disabled_items(self):
+        return filter(lambda item: item['is_disabled'], self.items)
+
+    @property
     def table(self):
         if self.table_id and self.table_fields and self.items:
             return {
                 'id': self.table_id,
                 'fields': self.table_fields,
                 'headings': get_table_headings(self.table_fields),
-                'items': self.items}
+                'items': self.items,
+                'disabled_items': self.disabled_items,
+            }
 
     def get(self, *args, **kwargs):
         response = super(PootleBrowseView, self).get(*args, **kwargs)

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -759,8 +759,18 @@ button.close
 
 /* table row colors, see 'Table Row Colors.psd' */
 
+tr.item
+{
+   display: none;
+}
+
+tr.item.is-visible
+{
+   display: table-row;
+}
+
 tr.view-row:nth-child(odd),
-tr.item:nth-child(odd)
+.item.odd
 {
     background: #f5fbfd;
 }

--- a/pootle/static/js/browser/components/VisibilityToggle.js
+++ b/pootle/static/js/browser/components/VisibilityToggle.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React, { PropTypes } from 'react';
+
+import TextToggle from 'components/TextToggle';
+
+
+const VisibilityToggle = React.createClass({
+
+  propTypes: {
+    // FIXME: read from context when it becomes available
+    uiLocaleDir: PropTypes.string.isRequired,
+  },
+
+  componentDidMount() {
+    this.handleVisibility({ isActive: false });
+  },
+
+  /**
+   * Note this is coupled with the DOM and how the browsing table is rendered.
+   * The implementation must change once the table is rendered as a component.
+   */
+  handleVisibility({ isActive: showDisabled }) {
+    const rows = [...document.querySelectorAll('tr.item')];
+    rows.map(row => row.classList.remove('odd'));
+    rows
+      .filter(row => row.classList.contains('is-disabled'))
+      .forEach(row => row.classList.toggle('is-visible', showDisabled));
+
+    [...document.querySelectorAll('tr.is-visible')].forEach((row, i) => {
+      row.classList.toggle('odd', i % 2 === 0);
+    });
+  },
+
+  render() {
+    const style = {
+      position: 'absolute',
+      [this.props.uiLocaleDir === 'ltr' ? 'right' : 'left']: '2em',
+      top: '1.2em',
+      color: '#c30',
+    };
+
+    return (
+      <TextToggle
+        defaultChecked
+        labelActive={gettext('Show disabled')}
+        labelInactive={gettext('Hide disabled')}
+        onClick={this.handleVisibility}
+        style={style}
+      />
+    );
+  },
+
+});
+
+
+export default VisibilityToggle;

--- a/pootle/static/js/shared/components/TextToggle.js
+++ b/pootle/static/js/shared/components/TextToggle.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import assign from 'object-assign';
+import React, { PropTypes } from 'react';
+
+
+const TextToggle = React.createClass({
+
+  propTypes: {
+    defaultChecked: PropTypes.bool,
+    labelActive: PropTypes.string,
+    labelInactive: PropTypes.string,
+    onClick: PropTypes.func,
+    style: PropTypes.object,
+  },
+
+  getDefaultProps() {
+    return {
+      defaultChecked: false,
+      labelActive: 'Active',
+      labelInactive: 'Inactive',
+    };
+  },
+
+  getInitialState() {
+    return {
+      isActive: this.props.defaultChecked,
+    };
+  },
+
+  handleClick() {
+    this.setState({ isActive: !this.state.isActive });
+    if (this.props.onClick) {
+      this.props.onClick({ isActive: this.state.isActive });
+    }
+  },
+
+  render() {
+    const label = this.state.isActive ?
+      this.props.labelActive : this.props.labelInactive;
+    const style = assign({}, { cursor: 'pointer' }, this.props.style);
+
+    return (
+      <span
+        onClick={this.handleClick}
+        style={style}
+      >
+        {label}
+      </span>
+    );
+  },
+
+});
+
+
+export default TextToggle;

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -21,6 +21,7 @@ import TimeSince from 'components/TimeSince';
 import UserEvent from 'components/UserEvent';
 import cookie from 'utils/cookie';
 
+import VisibilityToggle from './browser/components/VisibilityToggle';
 import msg from './msg';
 
 
@@ -94,6 +95,11 @@ const stats = {
         this.setState({ isExpanded: state.isExpanded });
       }
     });
+
+    if (this.isAdmin && options.hasDisabledItems) {
+      ReactDOM.render(<VisibilityToggle uiLocaleDir={options.uiLocaleDir} />,
+                      document.querySelector('.js-mnt-visibility-toggle'));
+    }
 
     // Retrieve async data if needed
     if (isExpanded) {

--- a/pootle/static/js/vendor/sorttable.js
+++ b/pootle/static/js/vendor/sorttable.js
@@ -40,6 +40,8 @@ sorttable = {
       }
     });
 
+    makeZebra();
+
   },
 
   makeSortable: function(table) {
@@ -195,6 +197,8 @@ sorttable = {
     for (var j=0; j<row_array.length; j++) {
       tb.appendChild(row_array[j][1]);
     }
+
+    makeZebra();
 
     delete row_array;
   },
@@ -552,3 +556,24 @@ var forEach = function(object, block, context) {
   }
 };
 
+
+/**
+ * Manually adds odd row classes. This should be removed in favour of
+ * `nth-child` selectors, but first the table needs to remove any non-visible
+ * items.
+ */
+function makeZebra() {
+  var rows = Array.prototype.slice.call(
+    document.querySelectorAll('table.sortable tbody tr')
+  );
+  rows.forEach(function rmZebra(row, i) {
+    row.classList.remove('odd');
+  });
+
+  var rows = Array.prototype.slice.call(
+    document.querySelectorAll('table.sortable tbody tr.is-visible')
+  );
+  rows.forEach(function addZebra(row, i) {
+    row.classList.toggle('odd', i % 2 === 0);
+  });
+}

--- a/pootle/templates/browser/_table.html
+++ b/pootle/templates/browser/_table.html
@@ -10,12 +10,13 @@
         {{ th.display_name }}
       </th>
       {% endfor %}
+      <span class="js-mnt-visibility-toggle"></span>
     </tr>
   </thead>
-  <tbody class="stats">
+  <tbody class="stats js-browsing-table">
     {% for item in table.items %}
 
-    <tr class="item{% if item.is_disabled %} is-disabled{% endif %}{% if item.is_grayed %} is-grayed{% endif %}">
+    <tr class="item is-visible{% if item.is_disabled %} is-disabled{% endif %}{% if item.is_grayed %} is-grayed{% endif %}">
 
       {% if 'name' in table.fields %}
       <td class="stats-name {{ item.icon }}"{% if item.description %} title="{{ item.description|striptags }}"{% endif %}>

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -3,6 +3,7 @@
 {% load assets cleanhtml i18n locale common_tags profile_tags %}
 
 {% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 
 {% block header_content_block %}
 <div id="top-stats" class="header">
@@ -145,9 +146,11 @@ $(function () {
   PTL.search.init();
   PTL.stats.init({
     pootlePath: "{{ pootle_path }}",
+    hasDisabledItems: {{ table.disabled_items|yesno:"true,false" }},
     isAdmin: {{ has_admin_access|yesno:"true,false" }},
     isInitiallyExpanded: {{ is_store|yesno:"true,false" }},
     initialData: JSON.parse('{{ stats|escapejs }}'),
+    uiLocaleDir: '{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}',
   });
 });
 </script>


### PR DESCRIPTION
When disabled elements add up, these produce too much noise for administrators,
therefore now they are hidden by default. At the same time, a new "Show
disabled" toggle has been added so administrators can have these items displayed
at their own will.

Implementation-wise, since CSS's `nth-child` takes any elements in the DOM
into account regardless of their visibility/display properties, some ugly hacks
are needed, and `nth-child` has been replaced by explicit CSS classes. These are
controlled ad-hoc at the moment; it's ugly but it's a short-term compromise to
have this working without having to rewrite the entire table.

Looking forward, the table would become a component purely powered by data, so
we could decide what to render at any point in time, and rows that shouldn't be
displayed would be away from the DOM, hence allowing us to put back the
`nth-child` rule and removing any ugly code added here.

Fixes #4609.