### PR TITLE
A fix and a cleanup

### DIFF
--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -16,8 +16,6 @@ from django.core import management
 
 import syspath_override  # noqa
 
-from .core.utils.redis_rq import rq_workers_are_running
-
 
 #: Length for the generated :setting:`SECRET_KEY`
 KEY_LENGTH = 50
@@ -159,6 +157,8 @@ def init_command(parser, settings_template, args):
 def set_sync_mode(noinput=False):
     """Sets ASYNC = False on all redis worker queues
     """
+    from .core.utils.redis_rq import rq_workers_are_running
+
     if rq_workers_are_running():
         redis_warning = ("\nYou currently have RQ workers running.\n\n"
                          "Running in synchronous mode may conflict with jobs "

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -13,17 +13,18 @@ import factory
 from django.utils import timezone
 
 import pootle_store
+from pootle.core.utils.timezone import make_aware
 
 
 class ScoreLogFactory(factory.django.DjangoModelFactory):
-    creation_time = timezone.now()
+    creation_time = make_aware(timezone.now())
 
     class Meta(object):
         model = 'pootle_statistics.ScoreLog'
 
 
 class SubmissionFactory(factory.django.DjangoModelFactory):
-    creation_time = timezone.now()
+    creation_time = make_aware(timezone.now())
 
     class Meta(object):
         model = 'pootle_statistics.Submission'


### PR DESCRIPTION
Allows compatibility with django-rq > 0.9

- move django rq import in pootle.runner - Fixes: #4737
- make factories tz aware
