### PR TITLE
Travis: Use nodejs 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
       -r requirements/base.txt
       -r requirements/travis.txt
       -e .
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 0.12
 script:
   - tox -e $TOXENV
 notifications:


### PR DESCRIPTION
This allows us to get rid of most of the warnings in build process.