### PR TITLE
Cleanup: dont add vfolders in test setup

### DIFF
--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -38,7 +38,7 @@ class PootleTestEnv(object):
     methods = (
         "redis", "case_sensitive_schema", "content_type", "site_root",
         "languages", "site_matrix", "system_users", "permissions",
-        "site_permissions", "tps", "disabled_project", "vfolders",
+        "site_permissions", "tps", "disabled_project",
         "subdirs", "submissions", "announcements", "terminology")
 
     def __init__(self, request):
@@ -148,31 +148,6 @@ class PootleTestEnv(object):
             cursor,
             "pootle_store.Store",
             "name",
-            "utf8_bin",
-            "varchar(255)")
-
-        # VirtualFolderTreeItem
-        set_mysql_collation_for_column(
-            apps,
-            cursor,
-            "virtualfolder.VirtualFolderTreeItem",
-            "pootle_path",
-            "utf8_bin",
-            "varchar(255)")
-
-        # VirtualFolder
-        set_mysql_collation_for_column(
-            apps,
-            cursor,
-            "virtualfolder.VirtualFolder",
-            "name",
-            "utf8_bin",
-            "varchar(70)")
-        set_mysql_collation_for_column(
-            apps,
-            cursor,
-            "virtualfolder.VirtualFolder",
-            "location",
             "utf8_bin",
             "varchar(255)")
 
@@ -360,23 +335,6 @@ class PootleTestEnv(object):
                 tp_dir.obsolete = False
                 tp_dir.save()
                 self._add_stores(tp)
-
-    def setup_vfolders(self):
-        from pytest_pootle.factories import VirtualFolderDBFactory
-
-        VirtualFolderDBFactory(filter_rules="store0.po")
-        VirtualFolderDBFactory(filter_rules="store1.po")
-        VirtualFolderDBFactory(
-            location='/{LANG}/project0/',
-            is_public=False,
-            filter_rules="store0.po")
-        VirtualFolderDBFactory(
-            location='/{LANG}/project0/',
-            is_public=False,
-            filter_rules="store1.po")
-        VirtualFolderDBFactory(
-            location='/language0/project0/',
-            filter_rules="subdir0/store4.po")
 
     def _add_stores(self, tp, n=(3, 2), parent=None):
         from pytest_pootle.factories import StoreDBFactory, UnitDBFactory

--- a/pytest_pootle/fixtures/models/vfolders.py
+++ b/pytest_pootle/fixtures/models/vfolders.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+
+@pytest.fixture
+def vfolders():
+    from pytest_pootle.factories import VirtualFolderDBFactory
+
+    from django.db import connection
+    from django.apps import apps
+
+    from pootle.core.utils.db import set_mysql_collation_for_column
+
+    cursor = connection.cursor()
+
+    # VirtualFolderTreeItem
+    set_mysql_collation_for_column(
+        apps,
+        cursor,
+        "virtualfolder.VirtualFolderTreeItem",
+        "pootle_path",
+        "utf8_bin",
+        "varchar(255)")
+
+    # VirtualFolder
+    set_mysql_collation_for_column(
+        apps,
+        cursor,
+        "virtualfolder.VirtualFolder",
+        "name",
+        "utf8_bin",
+        "varchar(70)")
+    set_mysql_collation_for_column(
+        apps,
+        cursor,
+        "virtualfolder.VirtualFolder",
+        "location",
+        "utf8_bin",
+        "varchar(255)")
+
+    VirtualFolderDBFactory(filter_rules="store0.po")
+    VirtualFolderDBFactory(filter_rules="store1.po")
+    VirtualFolderDBFactory(
+        location='/{LANG}/project0/',
+        is_public=False,
+        filter_rules="store0.po")
+    VirtualFolderDBFactory(
+        location='/{LANG}/project0/',
+        is_public=False,
+        filter_rules="store1.po")
+    VirtualFolderDBFactory(
+        location='/language0/project0/',
+        filter_rules="subdir0/store4.po")

--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -308,7 +308,7 @@ def project_views(request, client, request_users, settings):
 
 
 @pytest.fixture(params=TP_VIEW_TESTS.keys())
-def tp_views(request, client, request_users, settings):
+def tp_views(request, client, request_users, vfolders, settings):
     from pootle.core.helpers import SIDEBAR_COOKIE_NAME
     from pootle_translationproject.models import TranslationProject
 

--- a/tests/models/virtualfolder.py
+++ b/tests/models/virtualfolder.py
@@ -265,14 +265,14 @@ def test_vfolder_unit_priorities():
 
 @pytest.mark.django_db
 def test_virtualfolder_repr():
-    vf = VirtualFolder.objects.first()
+    vf = VirtualFolderDBFactory(filter_rules="store0.po")
     assert (
         "<VirtualFolder: %s: %s>" % (vf.name, vf.location)
         == repr(vf))
 
 
 @pytest.mark.django_db
-def test_virtualfoldertreeitem_repr():
+def test_virtualfoldertreeitem_repr(vfolders):
     vfti = VirtualFolderTreeItem.objects.first()
     assert (
         "<VirtualFolderTreeItem: %s>" % vfti.pootle_path


### PR DESCRIPTION
this doesnt speed things up as much as i had hoped, but does seem to make test runs a little  faster.

this PR also has the benefit that it speeds up setup time significantly, making it quicker when running tests locally, repeatedly