### PR TITLE
Add "none" option to Project.treestyle

### DIFF
--- a/pootle/apps/pootle_project/migrations/0005_add_none_treestyle.py
+++ b/pootle/apps/pootle_project/migrations/0005_add_none_treestyle.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_project', '0004_correct_checkerstyle_options_order'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='treestyle',
+            field=models.CharField(default=b'auto', max_length=20, verbose_name='Project Tree Style', choices=[(b'auto', 'Automatic detection of gnu/non-gnu file layouts (slower)'), (b'gnu', 'GNU style: files named by language code'), (b'nongnu', 'Non-GNU: Each language in its own directory'), (b'none', 'Allow pootle_fs to manage filesystems')]),
+        ),
+    ]

--- a/pootle/apps/pootle_translationproject/migrations/0003_realpath_can_be_none.py
+++ b/pootle/apps/pootle_translationproject/migrations/0003_realpath_can_be_none.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_translationproject', '0002_remove_translationproject_disabled'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='translationproject',
+            name='real_path',
+            field=models.FilePathField(null=True, editable=False, blank=True),
+        ),
+    ]

--- a/tests/models/project.py
+++ b/tests/models/project.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import os
+
 import pytest
 
 from pytest_pootle.factories import UserFactory
@@ -188,3 +190,20 @@ def test_root_hide_permissions(nobody, default, admin, hide, view,
     assert items_equal(Project.accessible_by_user(nobody), ALL_PROJECTS)
     assert items_equal(Project.accessible_by_user(foo_user), ALL_PROJECTS)
     assert items_equal(Project.accessible_by_user(bar_user), ALL_PROJECTS)
+
+
+@pytest.mark.django_db
+def test_project_create_with_none_treestyle(english, templates, settings):
+    project = Project.objects.create(
+        code="foo",
+        source_language=english,
+        treestyle="none")
+    assert not os.path.exists(
+        os.path.join(
+            settings.POOTLE_TRANSLATION_DIRECTORY,
+            project.code))
+    project.save()
+    assert not os.path.exists(
+        os.path.join(
+            settings.POOTLE_TRANSLATION_DIRECTORY,
+            project.code))

--- a/tests/models/translationproject.py
+++ b/tests/models/translationproject.py
@@ -143,3 +143,31 @@ def test_tp_checker(tp_checker_tests):
                                    checks.StandardChecker)
     ]
     assert [x.__class__ for x in tp.checker.checkers] == checkerclasses
+
+
+@pytest.mark.django_db
+def test_tp_create_with_none_treestyle(english, templates, settings):
+    from pytest_pootle.factories import ProjectDBFactory
+
+    project = ProjectDBFactory(
+        source_language=english,
+        treestyle="none")
+    language = LanguageDBFactory()
+    TranslationProjectFactory(
+        language=templates, project=project)
+
+    tp = TranslationProject.objects.create(
+        project=project, language=language)
+
+    assert not tp.abs_real_path
+    assert not os.path.exists(
+        os.path.join(
+            settings.POOTLE_TRANSLATION_DIRECTORY,
+            project.code))
+
+    tp.save()
+    assert not tp.abs_real_path
+    assert not os.path.exists(
+        os.path.join(
+            settings.POOTLE_TRANSLATION_DIRECTORY,
+            project.code))


### PR DESCRIPTION
This PR allows a Project to have its treestyle set to "none" to disable scan/mkdir behaviour