### PR TITLE
Use "last 30 days" instead of "last/this month"

### DIFF
--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -74,7 +74,7 @@
       </div>
       {% if top_scorers %}
         <div class="summary-2-col">
-          <h3 class="top">{% trans "Top contributors Last 30 days" %}</h3>
+          <h3 class="top">{% trans "Top Contributors for the Last 30 Days" %}</h3>
           <div class="bd">
             {% include 'core/_top_scorers_as_table.html' %}
           </div>

--- a/pootle/templates/user/profile.html
+++ b/pootle/templates/user/profile.html
@@ -37,17 +37,17 @@
     <h3 class="user-position">
     {% with pos=object.top_language.0 lang=object.top_language.1 %}
     {% if pos == -1 %}
-      {% trans 'No contributions in the last month' %}
+      {% trans 'No contributions in the last 30 days' %}
     {% else %}
       {% if user == object %}
-        <a class="js-popup-tweet" href="https://twitter.com/share?text={% filter urlencode %}{% blocktrans with server_title=settings.POOTLE_TITLE lang_name=lang.name url=lang.get_absolute_url %}I am #{{ pos }} contributor in {{ lang_name }} for this month at {{ server_title }}! {% endblocktrans %}{% endfilter %}" title="{% blocktrans %}Tweet this!{% endblocktrans %}">
+        <a class="js-popup-tweet" href="https://twitter.com/share?text={% filter urlencode %}{% blocktrans with server_title=settings.POOTLE_TITLE lang_name=lang.name url=lang.get_absolute_url %}I am #{{ pos }} contributor in {{ lang_name }} in the last 30 days at {{ server_title }}! {% endblocktrans %}{% endfilter %}" title="{% blocktrans %}Tweet this!{% endblocktrans %}">
           {% blocktrans with lang_name=lang.name trimmed %}
-          #{{ pos }} contributor in {{ lang_name }} for this month
+          #{{ pos }} contributor in {{ lang_name }} in the last 30 days
           {% endblocktrans %}
         </a>
       {% else %}
         {% blocktrans with lang_name=lang.name url=lang.get_absolute_url trimmed %}
-        #{{ pos }} contributor in <a href="{{ url }}">{{ lang_name }}</a> for this month
+        #{{ pos }} contributor in <a href="{{ url }}">{{ lang_name }}</a> in the last 30 days
         {% endblocktrans %}
       {% endif %}
     {% endif %}

--- a/pootle/templates/welcome.html
+++ b/pootle/templates/welcome.html
@@ -29,7 +29,7 @@
     <div class="column center">
 
       <div class="section">
-        <h1>{% trans 'Top Contributors This Month' %}</h1>
+        <h1>{% trans 'Top Contributors for the Last 30 Days' %}</h1>
         {% top_scorers %}
       </div>
 


### PR DESCRIPTION
We calculate stats for last 30 days. So all labels were phrased better and how we say it elsewhere “in the last 30 days”.