### PR TITLE
Cleanup: simplify JS object parsing in templates

### DIFF
--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -28,7 +28,6 @@ from allauth.account.models import EmailAddress
 from allauth.account.utils import sync_user_email_addresses
 
 from pootle.core.cache import make_method_key
-from pootle.core.utils.json import jsonify
 from pootle_language.models import Language
 from pootle_statistics.models import Submission, ScoreLog
 from pootle_store.models import Unit
@@ -260,9 +259,9 @@ class User(AbstractBaseUser):
     def get_absolute_url(self):
         return reverse('pootle-user-profile', args=[self.username])
 
-    def as_json(self):
-        """Returns the user's field-values as a JSON-encoded string."""
-        return jsonify(model_to_dict(self, exclude=['password']))
+    def field_values(self):
+        """Returns the user's field-values (can be encoded as e.g. JSON)."""
+        return model_to_dict(self, exclude=['password'])
 
     def is_anonymous(self):
         """Returns `True` if this is an anonymous user."""

--- a/pootle/apps/accounts/social_adapter.py
+++ b/pootle/apps/accounts/social_adapter.py
@@ -14,7 +14,6 @@ from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount import providers
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 
-from pootle.core.utils.json import jsonify
 from pootle.middleware.errorpages import log_exception
 
 from .utils import get_user_by_email
@@ -78,7 +77,7 @@ class PootleSocialAccountAdapter(DefaultSocialAccountAdapter):
         log_exception(request, exception, tb)
 
         ctx = {
-            'social_error': jsonify({
+            'social_error': {
                 'error': error,
                 'exception': {
                     'name': exception.__class__.__name__,
@@ -86,7 +85,7 @@ class PootleSocialAccountAdapter(DefaultSocialAccountAdapter):
                 },
                 'provider': provider.name,
                 'retry_url': retry_url,
-            }),
+            },
         }
         raise ImmediateHttpResponse(
             response=render(request, 'account/social_error.html', ctx)

--- a/pootle/apps/pootle_app/views/admin/projects.py
+++ b/pootle/apps/pootle_app/views/admin/projects.py
@@ -8,7 +8,6 @@
 
 from django.views.generic import TemplateView
 
-from pootle.core.utils.json import jsonify
 from pootle.core.views import APIView, SuperuserRequiredMixin
 from pootle_app.forms import ProjectForm
 from pootle_language.models import Language
@@ -33,7 +32,7 @@ class ProjectAdminView(SuperuserRequiredMixin, TemplateView):
 
         return {
             'page': 'admin-projects',
-            'form_choices': jsonify({
+            'form_choices': {
                 'checkstyle': Project.checker_choices,
                 'localfiletype': filetype_choices,
                 'source_language': language_choices,
@@ -41,7 +40,7 @@ class ProjectAdminView(SuperuserRequiredMixin, TemplateView):
                 'defaults': {
                     'source_language': default_language,
                 },
-            }),
+            },
         }
 
 

--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.utils import translation
 
 from pootle.core.markup import get_markup_filter_name
-from pootle.core.utils.json import jsonify
 from pootle_language.models import Language
 from pootle_project.models import Project
 from staticpages.models import LegalPage
@@ -56,6 +55,6 @@ def pootle_context(request):
         'custom': settings.POOTLE_CUSTOM_TEMPLATE_CONTEXT,
         'ALL_LANGUAGES': Language.live.cached_dict(translation.get_language()),
         'ALL_PROJECTS': Project.objects.cached_dict(request.user),
-        'SOCIAL_AUTH_PROVIDERS': jsonify(_get_social_auth_providers(request)),
+        'SOCIAL_AUTH_PROVIDERS': _get_social_auth_providers(request),
         'display_agreement': _agreement_context(request),
     }

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -17,7 +17,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.log import SCORE_CHANGED, log
 from pootle.core.utils import dateformat
-from pootle.core.utils.json import jsonify
 from pootle_misc.checks import check_names
 from pootle_store.fields import to_python
 from pootle_store.util import FUZZY, TRANSLATED, UNTRANSLATED
@@ -222,10 +221,6 @@ class Submission(models.Model):
             return False
 
         return True
-
-    def as_json(self):
-        """Returns a json describing the submission."""
-        return jsonify(self.get_submission_info())
 
     def get_submission_info(self):
         """Returns a dictionary describing the submission.

--- a/pootle/apps/reports/views.py
+++ b/pootle/apps/reports/views.py
@@ -26,7 +26,6 @@ from pootle.core.decorators import admin_required
 from pootle.core.http import (JsonResponse, JsonResponseBadRequest,
                               JsonResponseNotFound)
 from pootle.core.log import PAID_TASK_ADDED, PAID_TASK_DELETED, log
-from pootle.core.utils.json import jsonify
 from pootle.core.utils.timezone import make_aware, make_naive
 from pootle.core.views import AjaxResponseMixin, UserObjectMixin
 from pootle_misc.util import (ajax_required, get_date_interval,
@@ -128,10 +127,10 @@ def reports(request):
 
     ctx = {
         'page': 'admin-reports',
-        'users': jsonify(map(
+        'users': map(
             lambda x: {'id': x.username, 'text': x.formatted_name},
             User.objects.hide_meta()
-        )),
+        ),
         'user_rates_form': UserRatesForm(),
         'paid_task_form': PaidTaskForm(),
         'now': now.strftime('%Y-%m-%d %H:%M:%S'),

--- a/pootle/core/templatetags/core.py
+++ b/pootle/core/templatetags/core.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django import template
+from django.utils.html import escapejs
+from django.utils.safestring import mark_safe
+
+from ..utils.json import jsonify
+
+
+register = template.Library()
+
+
+@register.filter
+def to_js(value):
+    """Returns a string which leaves the value readily available for JS
+    consumption.
+    """
+    return mark_safe('JSON.parse("%s")' % escapejs(jsonify(value)))

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -44,7 +44,7 @@ from .helpers import (SIDEBAR_COOKIE_NAME,
                       get_filter_name, get_sidebar_announcements_context)
 from .http import JsonResponse, JsonResponseBadRequest
 from .url_helpers import get_path_parts, get_previous_url
-from .utils.json import PootleJSONEncoder, jsonify
+from .utils.json import PootleJSONEncoder
 from .utils.stats import get_translation_states
 
 
@@ -639,7 +639,7 @@ class PootleBrowseView(PootleDetailView):
 
         ctx.update(
             {'page': 'browse',
-             'stats': jsonify(self.stats),
+             'stats': self.stats,
              'translation_states': get_translation_states(self.object),
              'checks': get_qualitycheck_list(self.object),
              'can_translate': can_translate,

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -85,6 +85,7 @@ INSTALLED_APPS = [
     'contact',
     'import_export',  # Put before 'pootle' to ensure overextends works.
     'pootle',
+    'pootle.core',
     'pootle_app',
     'pootle_comment',
     'pootle_config',

--- a/pootle/templates/account/social_error.html
+++ b/pootle/templates/account/social_error.html
@@ -1,11 +1,12 @@
 {% extends 'welcome.html' %}
+{% load core %}
 
 {% block scripts_extra %}
 <script type="text/javascript">
   $(function () {
     PTL.auth.open({
       initialScreen: 'socialAuthError',
-      socialError: JSON.parse('{{ social_error|escapejs }}'),
+      socialError: {{ social_error|to_js }},
     });
   });
 </script>

--- a/pootle/templates/admin/projects.html
+++ b/pootle/templates/admin/projects.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_app.html" %}
-{% load i18n %}
+{% load core i18n %}
 
 {% block title %}{% trans "Projects" %} | {{ block.super }}{% endblock %}
 
@@ -12,7 +12,7 @@
 $(function () {
   PTL.admin.init({itemType: 'project',
                   appRoot: '{% url "pootle-admin-projects" %}',
-                  formChoices: JSON.parse('{{ form_choices|escapejs }}')});
+                  formChoices: {{ form_choices|to_js }}});
 });
 </script>
 {% endblock %}

--- a/pootle/templates/admin/reports.html
+++ b/pootle/templates/admin/reports.html
@@ -1,6 +1,6 @@
 {% extends "admin/base.html" %}
 
-{% load i18n assets store_tags %}
+{% load core i18n assets store_tags %}
 
 {% block css %}
 {{ block.super }}
@@ -28,7 +28,7 @@
 <script type="text/javascript">
   $(function () {
     PTL.reports.init({
-      users: JSON.parse('{{ users|escapejs }}'),
+      users: {{ users|to_js }},
       updateUserRatesUrl: "{% url 'pootle-reports-update-user-rates' %}",
       addPaidTaskUrl: "{% url 'pootle-reports-add-paid-task' %}",
       removePaidTaskUrl: "{% url 'pootle-reports-remove-paid-task' %}",

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -1,6 +1,6 @@
 {% extends browser_extends %}
 
-{% load assets cleanhtml i18n locale common_tags profile_tags %}
+{% load core assets cleanhtml i18n locale common_tags profile_tags %}
 
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
@@ -176,7 +176,7 @@ $(function () {
     hasDisabledItems: {{ table.disabled_items|yesno:"true,false" }},
     isAdmin: {{ has_admin_access|yesno:"true,false" }},
     isInitiallyExpanded: {{ is_store|yesno:"true,false" }},
-    initialData: JSON.parse('{{ stats|escapejs }}'),
+    initialData: {{ stats|to_js }},
     uiLocaleDir: '{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}',
   });
 });

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -1,4 +1,4 @@
-{% load i18n assets locale profile_tags humanize staticfiles %}
+{% load core i18n assets locale profile_tags humanize staticfiles %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}" id="{% block html_id %}pootle-base{% endblock %}" class="{{ settings.POOTLE_INSTANCE_ID }}">
@@ -29,7 +29,7 @@
       CONTACT_ENABLED: {{ settings.POOTLE_CONTACT_ENABLED|yesno:'true, false' }},
       SIGNUP_ENABLED: {{ settings.POOTLE_SIGNUP_ENABLED|yesno:'true, false' }},
       MARKUP_FILTER: '{{ settings.POOTLE_MARKUP_FILTER }}',
-      SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|safe }},
+      SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|to_js }},
     };
     </script>
 

--- a/pootle/templates/user/profile.html
+++ b/pootle/templates/user/profile.html
@@ -1,5 +1,5 @@
 {% extends 'user/base.html'  %}
-{% load humanize i18n profile_tags assets %}
+{% load core humanize i18n profile_tags assets %}
 
 {% block body_id %}profile-page{% endblock %}
 
@@ -120,10 +120,10 @@
 $(function() {
   PTL.user.init({
     {% if user == object %}
-    userData: JSON.parse('{{ user.as_json|escapejs }}'),
+    userData: {{ user.field_values|to_js }},
     appRoot: '{{ user.get_absolute_url }}',
     {% endif %}
-    lastEvent: JSON.parse('{{ object.last_event.as_json|escapejs }}'),
+    lastEvent: {{ object.last_event.get_submission_info|to_js }},
   });
 });
 </script>

--- a/pytest_pootle/suite.py
+++ b/pytest_pootle/suite.py
@@ -6,14 +6,10 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from json import loads
-
 
 def view_context_test(ctx, **assertions):
     for k, v in assertions.items():
-        if k == "stats":
-            assert loads(ctx[k]) == loads(v)
-        elif k == "check_categories":
+        if k == "check_categories":
             for i, cat in enumerate(ctx[k]):
                 assert v[i] == cat
         elif k == "search_form":

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -23,7 +23,6 @@ from pootle.core.helpers import (
     SIDEBAR_COOKIE_NAME,
     get_filter_name, get_sidebar_announcements_context)
 from pootle.core.url_helpers import get_previous_url
-from pootle.core.utils.json import jsonify
 from pootle.core.utils.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
@@ -67,7 +66,8 @@ def _test_browse_view(language, request, response, kwargs):
         table=table,
         translation_states=get_translation_states(language),
         top_scorers=get_user_model().top_scorers(language=language.code, limit=10),
-        stats=jsonify(language.get_stats_for_user(request.user)))
+        stats=language.get_stats_for_user(request.user),
+    )
     sidebar = get_sidebar_announcements_context(
         request, (language, ))
     for k in ["has_sidebar", "is_sidebar_open", "announcements"]:

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -27,7 +27,6 @@ from pootle.core.delegate import search_backend
 from pootle.core.helpers import (
     SIDEBAR_COOKIE_NAME,
     get_filter_name, get_sidebar_announcements_context)
-from pootle.core.utils.json import jsonify
 from pootle.core.url_helpers import get_previous_url, get_path_parts
 from pootle.core.utils.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_list, get_qualitycheck_schema
@@ -149,7 +148,8 @@ def _test_browse_view(project, request, response, kwargs):
         checks=get_qualitycheck_list(ob),
         table=table,
         top_scorers=User.top_scorers(project=project.code, limit=10),
-        stats=jsonify(ob.get_stats()))
+        stats=ob.get_stats(),
+    )
     sidebar = get_sidebar_announcements_context(
         request, (project, ))
     for k in ["has_sidebar", "is_sidebar_open", "announcements"]:
@@ -250,7 +250,7 @@ def test_view_projects_browse(client, request_users):
         object=ob,
         table=table,
         browser_extends="projects/all/base.html",
-        stats=jsonify(ob.get_stats()),
+        stats=ob.get_stats(),
         checks=get_qualitycheck_list(ob),
         top_scorers=User.top_scorers(limit=10),
         translation_states=get_translation_states(ob),

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -25,7 +25,6 @@ from pootle.core.helpers import (
     SIDEBAR_COOKIE_NAME,
     get_filter_name, get_sidebar_announcements_context)
 from pootle.core.url_helpers import get_previous_url, get_path_parts
-from pootle.core.utils.json import jsonify
 from pootle.core.utils.stats import get_translation_states
 from pootle_misc.checks import get_qualitycheck_list, get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
@@ -79,9 +78,8 @@ def _test_browse_view(tp, request, response, kwargs):
             stats.update(ob.get_stats())
         else:
             stats = ob.get_stats()
-        stats = jsonify(stats)
     else:
-        stats = jsonify(ob.get_stats())
+        stats = ob.get_stats()
         vfolders = None
 
     filters = {}


### PR DESCRIPTION
By using the `to_js` filter on any Python object, it'll return all what's needed
to read the value into a native JS object via JSON, e.g.:

  var js_foo = {{ my_python_object|to_js }};

Therefore removing all the error-prone boilerplate needed at the moment.