### PR TITLE
Error when building PO files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ SPRITE_DIR = ${IMAGES_DIR}/sprite
 FORMATS=--formats=bztar
 TEST_ENV_NAME = pootle_test_env
 
-.PHONY: all build clean sprite test pot mo mo-all help docs assets
+.PHONY: all build clean sprite test pot help docs assets
 
 all: help
 
-build: docs mo assets
+build: docs assets
 	python setup.py sdist ${FORMATS} ${TAIL}
 
 assets:
@@ -84,12 +84,6 @@ put-translations:
 linguas:
 	@${SRC_DIR}/tools/make-LINGUAS.sh 80 > ${SRC_DIR}/locale/LINGUAS
 
-mo:
-	python setup.py build_mo ${TAIL}
-
-mo-all:
-	python setup.py build_mo --all
-
 jslint:
 	cd ${JS_DIR} \
 	&& npm run lint
@@ -111,6 +105,4 @@ help:
 	@echo "  pot - update the POT translations templates"
 	@echo "  get-translations - retrieve Pootle translations from server (requires ssh config for pootletranslations)"
 	@echo "  linguas - update the LINGUAS file with languages over 80% complete"
-	@echo "  mo - build MO files for languages listed in 'pootle/locale/LINGUAS'"
-	@echo "  mo-all - build MO files for all languages (only use for testing)"
 	@echo "  publish-pypi - publish on PyPI"

--- a/docs/developers/releasing.rst
+++ b/docs/developers/releasing.rst
@@ -180,7 +180,8 @@ Update the translations from the `Pootle server
 
    .. code-block:: console
 
-       $ make mo  # Build all LINGUAS enabled languages
+       $ ./setup.py build_mo          # Build all LINGUAS enabled languages
+       $ ./setup.py build_mo --check  # Not all of these are errors
 
 
 Create release notes
@@ -280,7 +281,7 @@ checkout run:
     (build-pootle-release)$ pip install -r requirements/build.txt
     (build-pootle-release)$ export PYTHONPATH="${PYTHONPATH}:`pwd`"
     (build-pootle-release)$ export POOTLE_SETTINGS=~/.pootle/pootle_build.conf
-    (build-pootle-release)$ make mo-all  # If we are shipping an RC
+    (build-pootle-release)$ ./setup.py build_mo --all  # If we are shipping an RC
     (build-pootle-release)$ make clean
     (build-pootle-release)$ make build
     (build-pootle-release)$ deactivate

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ class PootleBuildMo(DistutilsBuild):
          "compile all language (don't use LINGUAS file)"),
         ('lang=', 'l',
          "specify a language to compile"),
+        ('check', None,
+         "check for errors"),
     ]
     boolean_options = ['all']
 
@@ -75,6 +77,7 @@ class PootleBuildMo(DistutilsBuild):
     def initialize_options(self):
         self.all = False
         self.lang = None
+        self.check = False
 
     def finalize_options(self):
         if self.all and self.lang is not None:
@@ -122,10 +125,14 @@ class PootleBuildMo(DistutilsBuild):
                     os.makedirs(mo_path)
 
                 log.info("compiling %s", lang)
+                if self.check:
+                    command = ['msgfmt', '-c', '--strict',
+                               '-o', mo_filename, po_filename]
+                else:
+                    command = ['msgfmt', '--strict',
+                               '-o', mo_filename, po_filename]
                 try:
-                    subprocess.check_call([
-                        'msgfmt', '--strict', '-o', mo_filename, po_filename],
-                        stderr=subprocess.STDOUT)
+                    subprocess.check_call(command, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError as e:
                     error_occured = True
                 except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,8 @@ class PootleBuildMo(DistutilsBuild):
         import gettext
         from translate.storage import factory
 
+        error_occured = False
+
         for lang in self._langs:
             lang = lang.rstrip()
 
@@ -121,9 +123,11 @@ class PootleBuildMo(DistutilsBuild):
 
                 log.info("compiling %s", lang)
                 try:
-                    subprocess.call([
+                    subprocess.check_call([
                         'msgfmt', '--strict', '-o', mo_filename, po_filename],
                         stderr=subprocess.STDOUT)
+                except subprocess.CalledProcessError as e:
+                    error_occured = True
                 except Exception as e:
                     log.warn("%s: skipping, running msgfmt failed: %s",
                              lang, e)
@@ -134,6 +138,9 @@ class PootleBuildMo(DistutilsBuild):
                 except Exception:
                     log.warn("%s: invalid plural header in %s",
                              lang, po_filename)
+
+        if error_occured:
+            sys.exit(1)
 
     def run(self):
         self.build_mo()

--- a/tox.ini
+++ b/tox.ini
@@ -63,5 +63,5 @@ commands=
     make travis-assets
     python setup.py sdist
     make docs
-    make mo-all
+    python setup.py build_mo
     make jslint


### PR DESCRIPTION
* We now passthrough errors from `msgfmt` when using `build_mo`
* We're only building release languages (non-release langs have some errors)
* We add `--check` to `build_mo` to allow more thorough checks.  Unfortunately some are false positives and this can't be relied on for Travis testing.