### PR TITLE
Fix: timeline doesnt try to parse non-existent datetime

### DIFF
--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -285,8 +285,7 @@ class Timeline(object):
             created = {
                 'created': True,
                 'submitter': User.objects.get_system_user()}
-            if self.object.creation_time:
-                created['datetime'] = self.object.creation_time
+            created['datetime'] = self.object.creation_time
             grouped_entries[:0] = [created]
         return grouped_entries
 

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -380,11 +380,16 @@ class UnitTimelineJSON(PootleUnitJSON):
     def get_entries_group_data(self, context):
         result = []
         for entry_group in context['entries_group']:
+            display_dt = entry_group['datetime']
+            if display_dt is not None:
+                display_dt = dateformat.format(display_dt)
+                iso_dt = entry_group['datetime'].isoformat()
+            else:
+                iso_dt = None
             result.append({
-                "display_datetime": dateformat.format(entry_group['datetime']),
-                "iso_datetime": entry_group['datetime'].isoformat(),
-                "via_upload": entry_group.get('via_upload', False),
-            })
+                "display_datetime": display_dt,
+                "iso_datetime": iso_dt,
+                "via_upload": entry_group.get('via_upload', False)})
         return result
 
 


### PR DESCRIPTION
This is a fix for #4805, altho i think this code needs to be
refactored, and tests obviously need some improvement.