### PR TITLE
Cleanup: remove unnecessary pytest django marker

### DIFF
--- a/tests/core/display.py
+++ b/tests/core/display.py
@@ -31,7 +31,6 @@ class DummyDisplayContext(object):
         return self.data[k]
 
 
-@pytest.mark.django
 def test_display_instance():
     context = DummyDisplayContext()
     display = Display(context)
@@ -50,7 +49,6 @@ def test_display_instance():
     assert str(display) == "%s\n" % result
 
 
-@pytest.mark.django
 def test_display_no_results():
 
     class DisplayNoResults(Display):
@@ -61,7 +59,6 @@ def test_display_no_results():
     assert str(display) == "%s\n" % DisplayNoResults.no_results_msg
 
 
-@pytest.mark.django
 def test_display_section_instance():
     context = DummyDisplayContext()
     display = Display(context)
@@ -87,7 +84,6 @@ def test_display_section_instance():
     assert str(section) == "%s\n" % result
 
 
-@pytest.mark.django
 def test_display_section_info():
     context = DummyDisplayContext()
 
@@ -114,7 +110,6 @@ def test_display_section_info():
     assert str(section) == "%s\n" % result
 
 
-@pytest.mark.django
 def test_display_section_no_info():
     context = DummyDisplayContext()
 
@@ -140,7 +135,6 @@ def test_display_section_no_info():
     assert str(section) == "%s\n" % result
 
 
-@pytest.mark.django
 def test_display_section_bad_items_none():
     display = Display(DummyDisplayContext())
     section = SectionDisplay(display, "section2")
@@ -151,7 +145,6 @@ def test_display_section_bad_items_none():
         assert section.items
 
 
-@pytest.mark.django
 def test_display_section_bad_items_str():
     display = Display(dict(section1="FOO"))
     section = SectionDisplay(display, "section1")
@@ -160,7 +153,6 @@ def test_display_section_bad_items_str():
         assert section.items
 
 
-@pytest.mark.django
 def test_display_item_instance():
     display = Display(DummyDisplayContext())
     section = SectionDisplay(display, "section1")

--- a/tests/core/management/subcommands.py
+++ b/tests/core/management/subcommands.py
@@ -37,7 +37,6 @@ def test_command_with_subcommands_instance(capsys, command_caller):
     assert out == u'Did a foo\n'
 
 
-@pytest.mark.django
 def test_command_with_subcommands_help(capsys, command_calls):
 
     class FooCommand(CommandWithSubcommands):
@@ -83,7 +82,6 @@ def test_command_with_subcommands_sub(capsys, command_calls):
     assert "{bar}" in out
 
 
-@pytest.mark.django
 def test_command_with_subcommands_many_subs(capsys, command_calls):
 
     class FooCommand(CommandWithSubcommands):
@@ -183,7 +181,6 @@ def test_command_with_subcommands_sub_args(capsys, command_calls):
     assert out == "Bar called with fooarg: BAR\n"
 
 
-@pytest.mark.django
 def test_command_with_subcommands_bad_args(capsys):
 
     class FooCommand(CommandWithSubcommands):
@@ -197,7 +194,6 @@ def test_command_with_subcommands_bad_args(capsys):
     assert "unrecognized arguments: bad args" in err
 
 
-@pytest.mark.django
 def test_command_with_subcommands_bad_exec(capsys):
 
     class RandomError(Exception):
@@ -213,7 +209,6 @@ def test_command_with_subcommands_bad_exec(capsys):
         foo_command.run_from_argv(["", "foo"])
 
 
-@pytest.mark.django
 def test_command_with_subcommands_bad_syscheck(capsys):
 
     class FooCommand(CommandWithSubcommands):
@@ -228,7 +223,6 @@ def test_command_with_subcommands_bad_syscheck(capsys):
     assert err == "BAD SYSTEM\n"
 
 
-@pytest.mark.django
 def test_command_with_subcommands_bad_commanderror(capsys):
 
     class FooCommand(CommandWithSubcommands):

--- a/tests/core/plugin/getters.py
+++ b/tests/core/plugin/getters.py
@@ -6,13 +6,10 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import pytest
-
 from pootle.core.plugin import getter
 from pootle.core.plugin.delegate import Getter
 
 
-@pytest.mark.django
 def test_getter():
 
     get_test = Getter(providing_args=["foo"])
@@ -24,7 +21,6 @@ def test_getter():
     assert get_test.get() == 2
 
 
-@pytest.mark.django
 def test_no_getter():
 
     get_test = Getter(providing_args=["foo"])
@@ -32,7 +28,6 @@ def test_no_getter():
     assert get_test.get() is None
 
 
-@pytest.mark.django
 def test_getter_with_arg():
 
     get_test = Getter(providing_args=["foo"])
@@ -44,7 +39,6 @@ def test_getter_with_arg():
     assert get_test.get(foo=3) == 3
 
 
-@pytest.mark.django
 def test_getter_with_with_sender():
 
     get_test = Getter(providing_args=["foo"])
@@ -56,7 +50,6 @@ def test_getter_with_with_sender():
     assert get_test.get(str, foo="BOOM") == "BOOM"
 
 
-@pytest.mark.django
 def test_getter_with_with_sender_int():
 
     get_test = Getter(providing_args=["foo"])
@@ -68,7 +61,6 @@ def test_getter_with_with_sender_int():
     assert get_test.get(int, foo=3) == 21
 
 
-@pytest.mark.django
 def test_getter_with_with_sender_multi():
 
     get_test = Getter(providing_args=["foo"])
@@ -83,7 +75,6 @@ def test_getter_with_with_sender_multi():
     assert get_test.get(int, foo=3) == 21
 
 
-@pytest.mark.django
 def test_getter_handle_multi():
 
     get_test = Getter(providing_args=["foo"])
@@ -97,7 +88,6 @@ def test_getter_handle_multi():
     assert get_test_2.get(str, foo="test 2") == "test 2"
 
 
-@pytest.mark.django
 def test_getter_handle_order():
 
     get_test = Getter(providing_args=["foo"])
@@ -113,7 +103,6 @@ def test_getter_handle_order():
     assert get_test.get(str, foo="bar") == 2
 
 
-@pytest.mark.django
 def test_getter_handle_order_2():
 
     get_test = Getter(providing_args=["foo"])
@@ -129,7 +118,6 @@ def test_getter_handle_order_2():
     assert get_test.get(str, foo="bar") == 1
 
 
-@pytest.mark.django
 def test_getter_handle_order_3():
 
     get_test = Getter(providing_args=["foo"])

--- a/tests/core/plugin/providers.py
+++ b/tests/core/plugin/providers.py
@@ -6,15 +6,12 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import pytest
-
 from pootle.core.plugin import provider
 from pootle.core.plugin.delegate import Provider
 from pootle.core.plugin.exceptions import StopProviding
 from pootle.core.plugin.results import GatheredDict, GatheredList
 
 
-@pytest.mark.django
 def test_provider():
 
     provider_test = Provider(providing_args=["foo"])
@@ -28,7 +25,6 @@ def test_provider():
     assert results["result"] == 2
 
 
-@pytest.mark.django
 def test_no_providers():
 
     provider_test = Provider(providing_args=["foo"])
@@ -38,7 +34,6 @@ def test_no_providers():
     assert results.keys() == []
 
 
-@pytest.mark.django
 def test_provider_with_arg():
 
     provider_test = Provider(providing_args=["foo"])
@@ -52,7 +47,6 @@ def test_provider_with_arg():
     assert results["result"] == 3
 
 
-@pytest.mark.django
 def test_provider_with_sender():
 
     provider_test = Provider(providing_args=["foo"])
@@ -66,7 +60,6 @@ def test_provider_with_sender():
     assert results["result"] == "BOOM"
 
 
-@pytest.mark.django
 def test_provider_with_sender_int():
 
     provider_test = Provider(providing_args=["foo"])
@@ -80,7 +73,6 @@ def test_provider_with_sender_int():
     assert results["result"] == 21
 
 
-@pytest.mark.django
 def test_provider_with_sender_multi():
 
     provider_test = Provider(providing_args=["foo"])
@@ -100,7 +92,6 @@ def test_provider_with_sender_multi():
     assert results["result"] == 21
 
 
-@pytest.mark.django
 def test_provider_handle_multi_decorators():
 
     provider_test = Provider(providing_args=["foo"])
@@ -119,7 +110,6 @@ def test_provider_handle_multi_decorators():
     assert results["result"] == "BOOM: 2"
 
 
-@pytest.mark.django
 def test_provider_handle_multi_providers():
 
     provider_test = Provider()
@@ -138,7 +128,6 @@ def test_provider_handle_multi_providers():
     assert results["result2"] == 2
 
 
-@pytest.mark.django
 def test_provider_handle_null_provider():
 
     provider_test = Provider()
@@ -162,7 +151,6 @@ def test_provider_handle_null_provider():
     assert results["result3"] == 3
 
 
-@pytest.mark.django
 def test_provider_handle_bad_providers():
 
     provider_test = Provider()
@@ -191,7 +179,6 @@ def test_provider_handle_bad_providers():
     assert results["result4"] == 4
 
 
-@pytest.mark.django
 def test_provider_handle_stop_providing():
 
     provider_test = Provider()
@@ -215,7 +202,6 @@ def test_provider_handle_stop_providing():
     assert "result3" not in results
 
 
-@pytest.mark.django
 def test_provider_list_results():
 
     provider_test = Provider(result_class=GatheredList)

--- a/tests/core/plugin/results.py
+++ b/tests/core/plugin/results.py
@@ -14,7 +14,6 @@ from pootle.core.plugin.delegate import Provider
 from pootle.core.plugin.results import GatheredDict, GatheredList
 
 
-@pytest.mark.django
 def test_gathered_dict():
 
     provider_test = Provider()
@@ -37,7 +36,6 @@ def test_gathered_dict():
     assert all((k in gd) for k in memberdict.keys())
 
 
-@pytest.mark.django
 def test_gathered_dict_update():
 
     provider_test = Provider()
@@ -58,7 +56,6 @@ def test_gathered_dict_update():
     assert len(newdict) == len(memberdict)
 
 
-@pytest.mark.django
 def test_gathered_list():
 
     provider_test = Provider()

--- a/tests/misc/response.py
+++ b/tests/misc/response.py
@@ -18,7 +18,6 @@ class DummyContext(object):
         return "<DummyContext object>"
 
 
-@pytest.mark.django
 def test_response_instance():
     context = DummyContext()
     resp = Response(context)
@@ -34,7 +33,6 @@ def test_response_instance():
         resp["DOES_NOT_EXIST"]
 
 
-@pytest.mark.django
 def test_response_completed():
     resp = Response(DummyContext())
     resp.add("foo_response", completed=True)
@@ -73,7 +71,6 @@ def test_response_completed():
     assert "FAIL" not in str(resp)
 
 
-@pytest.mark.django
 def test_response_failed():
     resp = Response(DummyContext())
     resp.add("foo_response", complete=False)
@@ -113,7 +110,6 @@ def test_response_failed():
     assert resp.__responses__["other_response"] == []
 
 
-@pytest.mark.django
 def test_response_kwargs():
     resp = Response(DummyContext())
     resp.add("foo_response", foo="foo1", bar="bar1")
@@ -134,7 +130,6 @@ def test_response_kwargs():
     assert "'bar': 'bar1'" in str(resp["foo_response"][0])
 
 
-@pytest.mark.django
 def test_response_msg():
     resp = Response(DummyContext())
     resp.add("foo_response", msg="Response message")

--- a/tests/misc/state.py
+++ b/tests/misc/state.py
@@ -18,7 +18,6 @@ class DummyContext(object):
         return "<DummyContext object>"
 
 
-@pytest.mark.django
 def test_state_instance():
 
     context = DummyContext()
@@ -36,7 +35,6 @@ def test_state_instance():
         "<State(<DummyContext object>): Nothing to report>")
 
 
-@pytest.mark.django
 def test_state_states():
     """By default the State class will automagically find any
     methods that start with `state_` and create a list of states
@@ -91,7 +89,6 @@ def test_state_states():
     assert state["foo"][0].state_type == "foo"
 
 
-@pytest.mark.django
 def test_state_all_states():
 
     class ContextualState(State):
@@ -125,7 +122,6 @@ def test_state_all_states():
     assert len(state["baz"]) == 3
 
 
-@pytest.mark.django
 def test_state_properties():
 
     class ContextualState(State):
@@ -148,7 +144,6 @@ def test_state_properties():
     assert state["bar"][1].kwargs.items() == [("bar2", 2)]
 
 
-@pytest.mark.django
 def test_state_item_kwargs():
 
     class ContextualState(State):
@@ -178,7 +173,6 @@ def test_state_item_kwargs():
     assert not hasattr(state["bar"][1], "bar3")
 
 
-@pytest.mark.django
 def test_state_bad():
     # requires a context
     with pytest.raises(TypeError):
@@ -202,7 +196,6 @@ def test_state_bad():
         ContextualState(DummyContext())
 
 
-@pytest.mark.django
 def test_state_item_instance():
 
     class DummyContext(object):
@@ -220,7 +213,6 @@ def test_state_item_instance():
     assert item == ItemState(state, "foo")
 
 
-@pytest.mark.django
 def test_state_kwargs():
 
     class ContextualState(State):
@@ -236,7 +228,6 @@ def test_state_kwargs():
     state["foo"][0].kwarg2 == "kw2"
 
 
-@pytest.mark.django
 def test_state_item_bad():
 
     class ContextualState(State):
@@ -256,7 +247,6 @@ def test_state_item_bad():
     assert ItemState(ContextualState(DummyContext()), "foo")
 
 
-@pytest.mark.django
 def test_state_reload():
 
     class ContextualState(State):

--- a/tests/pootle_fs/display.py
+++ b/tests/pootle_fs/display.py
@@ -111,7 +111,6 @@ def test_fs_response_display_item_fs_untracked(localfs_fs_untracked):
     assert str(item_display) == result
 
 
-@pytest.mark.django
 def test_fs_response_display_item_existence(fs_responses, fs_states):
 
     class DummyResponseItem(object):
@@ -220,7 +219,6 @@ def test_fs_display_state_item_instance_fs_untracked(localfs_fs_untracked):
     assert item_display.tracked is False
 
 
-@pytest.mark.django
 def test_fs_display_state_item_existence(fs_states):
 
     class DummyStateItem(object):

--- a/tests/views/core.py
+++ b/tests/views/core.py
@@ -6,12 +6,9 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import pytest
-
 from pootle.core.views import PootleJSON
 
 
-@pytest.mark.django
 def test_view_pootle_json():
     json_test = PootleJSON()
     ctx = dict(foo="bar")


### PR DESCRIPTION
This PR removes unnecessary `pytest.mark.django` added in #4809.