### PR TITLE
Do not send CSRF token to external sites

### DIFF
--- a/pootle/static/js/common.js
+++ b/pootle/static/js/common.js
@@ -113,7 +113,9 @@ PTL.common = {
       traditional: true,
       crossDomain: false,
       beforeSend(xhr, settings) {
-        if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
+        // Set CSRF token only for local requests.
+        if (!this.crossDomain &&
+            !/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
           xhr.setRequestHeader('X-CSRFToken', cookie('csrftoken'));
         }
       },


### PR DESCRIPTION
As a side effect this now allows Caighdeán MT queries to work again.

Fixes #4808.