### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -413,7 +413,7 @@ intersphinx_mapping = {
     'django': ('https://docs.djangoproject.com/en/%s' % django_ver,
                'https://docs.djangoproject.com/en/%s/_objects' % django_ver),
     'toolkit': ('http://docs.translatehouse.org/projects/translate-toolkit/en/latest/', None),
-    'tastypie': ('https://django-tastypie.readthedocs.org/en/latest/', None),
+    'tastypie': ('https://django-tastypie.readthedocs.io/en/latest/', None),
 }
 
 

--- a/docs/developers/testing.rst
+++ b/docs/developers/testing.rst
@@ -10,7 +10,7 @@ Testing
 
 Pootle tests use the full-featured `pytest testing tool
 <http://pytest.org/latest/>`_ and its integration with Django via
-`pytest-django <http://pytest-django.readthedocs.org/en/latest/>`_.
+`pytest-django <https://pytest-django.readthedocs.io/en/latest/>`_.
 
 The entire test suite can be executed from a checkout by running ``make
 test``. This will create a new virtual environment, install the required
@@ -75,7 +75,7 @@ DB access. At the same time, pytest-django encourages you to follow these
 best practices and disables DB access by default. If your test needs DB
 access, you need to explicitly request it by using the
 `@`pytest.mark.django_db marker
-<http://pytest-django.readthedocs.org/en/latest/helpers.html#pytest-mark-django-db-request-database-access>`_.
+<https://pytest-django.readthedocs.io/en/latest/helpers.html#pytest-mark-django-db-request-database-access>`_.
 
 While testing views/integration tests can also help catch regressions,
 they're slower to run and end up in less useful failures, so better to
@@ -102,4 +102,4 @@ Note that these might depend on other fixtures too.
 For now these model fixtures require DB access, but since that's not what
 every single test might need, we might want to combine this with other
 more complete solutions like `factory_boy
-<https://factoryboy.readthedocs.org/en/latest/>`_ in the future.
+<https://factoryboy.readthedocs.io/en/latest/>`_ in the future.

--- a/docs/releases/2.5.0.rst
+++ b/docs/releases/2.5.0.rst
@@ -129,7 +129,7 @@ Other important changes
   previous version, you will need to replace the occurrences of *static* with
   *assets* within your web server configuration.
 - Static files are bundled into assets by using `django-assets
-  <http://django-assets.readthedocs.org/en/latest/>`_.
+  <https://django-assets.readthedocs.io/en/latest/>`_.
 - Several features from translation projects have been merged into the
   *Overview* tab, including quality check failures and directory- and
   file-level actions. As a consequence the *Review* tab has been dropped and

--- a/docs/releases/2.5.1-rc1.rst
+++ b/docs/releases/2.5.1-rc1.rst
@@ -56,7 +56,7 @@ Important server admin changes
   - The `updatedb
     <http://docs.translatehouse.org/projects/pootle/en/stable-2.5.1/server/commands.html#updatedb>`_
     management command has been phased out in favor of South's own
-    `migrate <http://south.readthedocs.org/en/latest/commands.html#migrate>`_
+    `migrate <https://south.readthedocs.io/en/latest/commands.html#migrate>`_
     command.
   - Post schema upgrade actions have been moved to the `upgrade
     <http://docs.translatehouse.org/projects/pootle/en/stable-2.5.1/server/commands.html#upgrade>`_

--- a/docs/releases/2.5.1.rst
+++ b/docs/releases/2.5.1.rst
@@ -65,7 +65,7 @@ Important server admin changes
   - The `updatedb
     <http://docs.translatehouse.org/projects/pootle/en/stable-2.5.1/server/commands.html#updatedb>`_
     management command has been phased out in favor of South's own
-    `migrate <http://south.readthedocs.org/en/latest/commands.html#migrate>`_
+    `migrate <https://south.readthedocs.io/en/latest/commands.html#migrate>`_
     command.
   - Post schema upgrade actions have been moved to the `upgrade
     <http://docs.translatehouse.org/projects/pootle/en/stable-2.5.1/server/commands.html#upgrade>`_

--- a/docs/server/auth.rst
+++ b/docs/server/auth.rst
@@ -4,14 +4,14 @@ User Authentication and Authorization
 =====================================
 
 Pootle's backend for authenticating and authorizing users is provided by
-`django-allauth <http://django-allauth.readthedocs.org/>`_, and it comes
+`django-allauth <https://django-allauth.readthedocs.io/>`_, and it comes
 with a heavily-customized client-side user interface.
 
 Note that while Allauth supports local and social sign-in flows, not all
 of them have been equally-tested on Pootle, so your mileage might vary.
 
 At the same time, Allauth also provides `tons of settings
-<http://django-allauth.readthedocs.org/en/latest/configuration.html>`_
+<https://django-allauth.readthedocs.io/en/latest/configuration.html>`_
 which deployments can configure to their needs, although some of them
 clash directly with how our workflow has been designed. For instance,
 leaving ``UNIQUE_EMAIL = True`` becomes a hard requirement.

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -1046,7 +1046,7 @@ servers that can be reverse proxied to a proper HTTP web server such as nginx
 or lighttpd.
 
 There are many more options such as `uWSGI
-<http://uwsgi-docs.readthedocs.org/en/latest/WSGIquickstart.html>`_, `Gunicorn
+<https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html>`_, `Gunicorn
 <http://gunicorn.org/>`_, etc.
 
 
@@ -1144,6 +1144,6 @@ from a bash script that creates the correct environment for your command to run
 from.  Call this script then from cron. It shouldn't be necessary to specify
 the settings file for Pootle — it should automatically be detected.
 
-.. _django-assets: http://django-assets.readthedocs.org/en/latest/
+.. _django-assets: https://django-assets.readthedocs.io/en/latest/
 
 .. _webassets: http://elsdoerfer.name/docs/webassets/

--- a/docs/server/optimization.rst
+++ b/docs/server/optimization.rst
@@ -51,9 +51,9 @@ Speed-ups and Extras
 `iso-codes <https://packages.debian.org/unstable/source/iso-codes>`_
   Enables translated language and country names.
 
-`raven <http://raven.readthedocs.org/en/latest/>`_
+`raven <https://raven.readthedocs.io/en/latest/>`_
   Enables logging server exceptions to a `Sentry server
-  <http://sentry.readthedocs.org/en/latest/>`_. If installed and configured,
+  <https://sentry.readthedocs.io/en/latest/>`_. If installed and configured,
   Pootle will automatically use the raven client.
 
 

--- a/docs/server/web.rst
+++ b/docs/server/web.rst
@@ -16,7 +16,7 @@ Running Pootle and RQ workers as a Service
 If you plan to run Pootle and/or RQ workers as system services, you can use
 whatever software you are familiar with for that purpose. For example
 `Supervisor <http://supervisord.org/>`_, `Circus
-<http://circus.readthedocs.org/en/latest/>`_ or `daemontools
+<https://circus.readthedocs.io/en/latest/>`_ or `daemontools
 <http://cr.yp.to/daemontools.html>`_ might fit your needs.
 
 

--- a/pootle/locale/da/pootle.po
+++ b/pootle/locale/da/pootle.po
@@ -861,7 +861,7 @@ msgstr "TMX"
 msgid "TBX"
 msgstr "TBX"
 
-# Formatet hedder "catkeys" og skal derfor ikke oversættes (http://translate-toolkit.readthedocs.org/en/latest/formats/catkeys.html)
+# Formatet hedder "catkeys" og skal derfor ikke oversættes (https://translate-toolkit.readthedocs.io/en/latest/formats/catkeys.html)
 #: apps/pootle_store/filetypes.py:48
 msgid "Haiku catkeys"
 msgstr "Haiku catkeys"

--- a/pootle/settings/25-logging.conf
+++ b/pootle/settings/25-logging.conf
@@ -10,8 +10,8 @@ POOTLE_LOG_DIRECTORY = working_path("log")
 # Logging configuration:
 # Django: https://docs.djangoproject.com/en/1.8/topics/logging/#configuring-logging
 # RQ: https://github.com/ui/django-rq#configuring-logging
-# Sentry: http://raven.readthedocs.org/en/latest/integrations/django.html#integration-with-logging
-# Elasticsearch: http://elasticsearch-py.readthedocs.org/en/master/#logging
+# Sentry: https://raven.readthedocs.io/en/latest/integrations/django.html#integration-with-logging
+# Elasticsearch: https://elasticsearch-py.readthedocs.io/en/master/#logging
 #
 # Format attributes: https://docs.python.org/2/library/logging.html#logrecord-attributes
 # Logging levels: https://docs.python.org/2/library/logging.html#logging-levels

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ inherit=false
 # Ignore all preselected error codes
 select=
 # Known error codes
-# http://pep257.readthedocs.org/en/latest/error_codes.html
+# https://pep257.readthedocs.io/en/latest/error_codes.html
 #
 # Descriptions of default ON error codes
 # D201 - No blank lines allowed before function docstring


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.