### PR TITLE
Prevent resource dropdown disappearance

### DIFF
--- a/pootle/static/js/utils.js
+++ b/pootle/static/js/utils.js
@@ -190,7 +190,7 @@ export function relativeDate(date) {
  *
  * `onChange` function will be fired when the select choice changes.
  */
-export function makeSelectableInput(selector, options, onChange) {
+export function makeSelectableInput(selector, options, onChange, onSelecting) {
   // XXX: Check if this works with multiple selects per page
   const $el = $(selector);
 
@@ -201,6 +201,7 @@ export function makeSelectableInput(selector, options, onChange) {
   $el.select2(options);
 
   $el.on('change', onChange);
+  $el.on('select2-selecting', onSelecting);
 }
 
 


### PR DESCRIPTION
This is an attempt to fix #4835. Click on '/' is ignored if we already have selected entire project. I couldn't clear select2 after empty value is selected.
And getting rid of '/' at all seems to be better solution still because we always are able to select `Entire project` by clicking on `x` (close).
