### PR TITLE
Set versions dynamically in install docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,9 @@
 import sys
 import os
 
+from django import VERSION as dj_version_actual
+from translate.__version__ import ver as ttk_version_actual
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -425,3 +428,9 @@ extlinks = {
     'wiki': ('http://translate.sourceforge.net/wiki/%s', ''),
     'wp': ('https://en.wikipedia.org/wiki/%s', ''),
 }
+
+
+# -- Dependency versions ----
+
+django = str(dj_version_actual)
+ttk = str(ttk_version_actual)

--- a/docs/server/installation.rst
+++ b/docs/server/installation.rst
@@ -104,10 +104,12 @@ This will also fetch and install Pootle's dependencies.
 To verify that everything installed correctly, you should be able to access the
 :command:`pootle` command line tool within your environment.
 
-.. code-block:: console
+
+.. highlight:: console
+.. parsed-literal::
 
   (env) $ pootle --version
-  Pootle 2.8.0b1 (Django 1.8.13, Translate Toolkit 1.13.0)
+  Pootle |release| (Django |django|, Translate Toolkit |ttk|)
 
 
 .. _installation#initializing-the-configuration:


### PR DESCRIPTION
uses parsed-literal in the affected code blocks which unfortunately means no syntax highlighting