### PR TITLE
Use stats_refresh_attempts_count to disable dirty stats auto refresh

### DIFF
--- a/pootle/core/templatetags/core.py
+++ b/pootle/core/templatetags/core.py
@@ -11,6 +11,7 @@ from django import template
 from django.utils.html import escapejs
 from django.utils.safestring import mark_safe
 
+from ..utils.docs import get_docs_url
 from ..utils.json import jsonify
 
 
@@ -23,3 +24,9 @@ def to_js(value):
     consumption.
     """
     return mark_safe('JSON.parse("%s")' % escapejs(jsonify(value)))
+
+
+@register.filter
+def docs_url(path_name):
+    """Returns the absolute URL to `path_name` in the RTD docs."""
+    return get_docs_url(path_name)

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -656,6 +656,8 @@ class PootleBrowseView(PootleDetailView):
 
         ctx.update(
             {'page': 'browse',
+             'stats_refresh_attempts_count':
+                 settings.POOTLE_STATS_REFRESH_ATTEMPTS_COUNT,
              'stats': self.stats,
              'translation_states': get_translation_states(self.object),
              'checks': get_qualitycheck_list(self.object),

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -121,3 +121,9 @@ AUTH_USER_MODEL = 'accounts.User'
 COMMENTS_APP = "pootle_comment"
 
 POOTLE_EXPORT_VIEW_LIMIT = 10000
+
+# Number of silent attempts to refresh stale statistics data before a banner
+# pops up telling you that the statistics is outdated.
+# The banner will appear immediately if you set it to 0 and open browse page
+# with stale statistics data.
+POOTLE_STATS_REFRESH_ATTEMPTS_COUNT = 2

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -310,7 +310,7 @@ const stats = {
     if (!!data.is_dirty) {
       if (dirtyStatsRefreshEnabled) {
         this.dirtyBackoff = Math.pow(2, this.retries);
-        this.dirtyBackoffId = setInterval(() => this.updateDirty(), 1000);
+        this.dirtyBackoffId = setInterval(() => this.updateDirty({ hideSpin: true }), 1000);
       } else {
         $('.js-stats-refresh').show();
       }
@@ -397,7 +397,7 @@ const stats = {
     }
   },
 
-  updateDirty() {
+  updateDirty({ hideSpin = false } = {}) {
     if (--this.dirtyBackoff === 0) {
       $('.js-stats-refresh').hide();
       clearInterval(this.dirtyBackoffId);
@@ -405,19 +405,21 @@ const stats = {
         if (this.retries < 5) {
           this.retries++;
         }
-        this.loadStats();
+        this.loadStats({ hideSpin });
       }, 250);
     }
   },
 
-  load(methodName) {
-    $('body').spin();
+  load(methodName, { hideSpin = false } = {}) {
+    if (!hideSpin) {
+      $('body').spin();
+    }
     return StatsAPI[methodName](this.pootlePath)
       .always(() => $('body').spin(false));
   },
 
-  loadStats() {
-    return this.load('getStats')
+  loadStats({ hideSpin = false } = {}) {
+    return this.load('getStats', { hideSpin })
       .done((data) => this.setState({ data }));
   },
 

--- a/pootle/templates/browser/index.html
+++ b/pootle/templates/browser/index.html
@@ -143,10 +143,15 @@
 {% endif %}
 
 <div id="autorefresh-notice">
-  {% blocktrans trimmed %}
-  Some data on this page is currently being calculated, and the page will be
-  refreshed automatically in <strong>30 seconds</strong>.
-  {% endblocktrans %}
+  {% if user.is_superuser %}
+    {% blocktrans trimmed with docs_url="server/rq.html"|docs_url %}
+    Stats are out of date.
+    See <a href="{{ docs_url }}">documentation</a>
+    for dealing with stats issues.
+    {% endblocktrans %}
+  {% else %}
+    {% trans "The stats on this page may be out of date." %}
+  {% endif %}
   <a href="#" class="js-stats-refresh">{% trans "Refresh now" %}</a>
 </div>
 
@@ -181,6 +186,7 @@ $(function () {
     isAdmin: {{ has_admin_access|yesno:"true,false" }},
     isInitiallyExpanded: {{ is_store|yesno:"true,false" }},
     initialData: {{ stats|to_js }},
+    statsRefreshAttemptsCount: {{ stats_refresh_attempts_count }},
     uiLocaleDir: '{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}',
   });
 });


### PR DESCRIPTION
This PR hides dirty stats banner for `stats_refresh_attempts_count` refresh attempts.
if `stats_refresh_attempts_count` is `0` then it's similar to PR #4862 where `POOTLE_STATS_BANNER_AUTO_REFRESH_ENABLED` is used.