### PR TITLE
Editor: avoid event propagation upon ctrl+enter

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -309,7 +309,8 @@ PTL.editor = {
         this.closeSuggestion();
       }
     });
-    hotkeys.bind('ctrl+return', () => {
+    hotkeys.bind('ctrl+return', (e) => {
+      e.preventDefault();
       if (this.isSuggestMode()) {
         this.handleSuggest();
       } else {


### PR DESCRIPTION
Without this, Safari and Chrome propagate the change to the textarea.

Fixes #4874.