### PR TITLE
Webpack: rewrite how manifest entry points are merged

### DIFF
--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -19,7 +19,6 @@
     "eslint": "^2.5.0",
     "eslint-config-airbnb": "~6.2.0",
     "eslint-plugin-react": "^4.2.0",
-    "lodash": "^2.4.1",
     "style-loader": "^0.8.0",
     "webpack": "^1.9.8"
   },


### PR DESCRIPTION
The new code is simple enough and it doesn't rely on lodash, which allows us to
drop it from the `devDevpendencies` section of npm's package.json.