### PR TITLE
Truncate names on browse view

### DIFF
--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1139,6 +1139,21 @@ td.stats-name
 {
     white-space: nowrap;
     line-height: 20px;
+    width: 100%;
+    min-width: 10em;
+}
+
+.truncate-ellipsis {
+    display: table;
+    table-layout: fixed;
+    width: 100%;
+    white-space: nowrap;
+}
+ 
+.truncate-ellipsis > * {
+    display: table-cell;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 td.stats-number

--- a/pootle/templates/browser/_table.html
+++ b/pootle/templates/browser/_table.html
@@ -20,9 +20,13 @@
 
       {% if 'name' in table.fields %}
       <td class="stats-name {{ item.icon }}"{% if item.description %} title="{{ item.description|striptags }}"{% endif %}>
-        {% if item.href %}<a href="{{ item.href }}">{% endif %}
-          <i class="icon-{{ item.icon }}"></i> <span>{{ item.title }}</span>
-        {% if item.href %}</a>{% endif %}
+        {% if item.href %}
+        <div class="truncate-ellipsis">
+          <a href="{{ item.href }}" title="{{ item.title }}">{% endif %}
+            <i class="icon-{{ item.icon }}"></i> <span>{{ item.title }}</span>
+        {% if item.href %}
+          </a>
+        </div>{% endif %}
       </td>
       {% endif %}
 


### PR DESCRIPTION
A tooltip is used to display the full name if truncated.

Part of #4817.