### PR TITLE
User.top_language: fix condition

### DIFF
--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -424,8 +424,8 @@ class User(AbstractBaseUser):
         if language is not None:
             language_scorers = self.top_scorers(language=language.code,
                                                 days=days, limit=None)
-            for index, user in enumerate(language_scorers, start=1):
-                if user == self:
+            for index, user_score in enumerate(language_scorers, start=1):
+                if user_score['user'] == self:
                     position = index
                     break
 


### PR DESCRIPTION
Since ffe4deb5 `User.top_scorers()` doesn't return a list of users anymore, but
a list of annotated dictionaries. Therefore, the actual user is now under the
'user' key of these dictionaries.

Fixes #4889.