### PR TITLE
Fix: call pootle init before make travis-assets in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands=
     postgres: psql -c 'create database pootle;' -U postgres
     mysql: mysql -e 'create database pootle CHARACTER SET utf8 COLLATE utf8_general_ci;'
     mysql: mysql -e "SET GLOBAL wait_timeout = 36000;"
-
+    pootle init
     make travis-assets
     py.test --cov-report=term --cov=. -v --duration=10
     python {toxinidir}/run_coveralls.py
@@ -46,7 +46,7 @@ commands=
     flake8 --config=setup.cfg
     pep257
     isort --check-only --diff
-    # Setup databases
+        # Setup databases
     psql -c 'create database pootle;' -U postgres
     mysql -e 'create database pootle CHARACTER SET utf8 COLLATE utf8_general_ci;'
     mysql -e "SET GLOBAL wait_timeout = 36000;"
@@ -60,6 +60,7 @@ commands=
     bash -c "DATABASE_BACKEND=sqlite python manage.py migrate --noinput | egrep 'Your models have changes that are not yet reflected in a migration'; test $? -eq 1"
     bash -c "DATABASE_BACKEND=sqlite python manage.py initdb --no-projects"
     # Other linting
+    pootle init
     make travis-assets
     python setup.py sdist
     make docs


### PR DESCRIPTION
fixes a bug introduced by using `${POOTLE_CMD}` in `make travis-assets`