### PR TITLE
virtualfolder: get rid of import warnings

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -30,8 +30,6 @@ from pootle_misc.util import get_date_interval
 from pootle_project.models import Project
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
-from virtualfolder.helpers import extract_vfolder_from_path
-from virtualfolder.models import VirtualFolderTreeItem
 
 from .fields import to_db
 from .form_fields import (
@@ -514,6 +512,8 @@ class UnitSearchForm(forms.Form):
         self.cleaned_data["vfolder"] = None
         pootle_path = self.cleaned_data.get("path")
         if 'virtualfolder' in settings.INSTALLED_APPS:
+            from virtualfolder.helpers import extract_vfolder_from_path
+            from virtualfolder.models import VirtualFolderTreeItem
             vfolder, pootle_path = extract_vfolder_from_path(
                 pootle_path,
                 vfti=VirtualFolderTreeItem.objects.select_related(

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -8,6 +8,7 @@
 
 from functools import wraps
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.db import connection
@@ -22,7 +23,6 @@ from pootle_language.models import Language
 from pootle_project.models import Project, ProjectResource, ProjectSet
 from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
-from virtualfolder.helpers import extract_vfolder_from_path
 
 from .exceptions import Http400
 from .url_helpers import split_pootle_path
@@ -132,11 +132,15 @@ def set_resource(request, path_obj, dir_path, filename):
 
     is_404 = False
 
-    # Get a clean pootle path for retrieving the directory or store.
-    # A clean pootle path is a pootle path without any virtual folder name on
-    # it. For example /af/test_vfolders/browser/chrome/ is the corresponding
-    # clean pootle path for /af/test_vfolders/browser/vfolder8/chrome/
-    vfolder, clean_pootle_path = extract_vfolder_from_path(pootle_path)
+    vfolder = None
+    clean_pootle_path = pootle_path
+    if 'virtualfolder' in settings.INSTALLED_APPS:
+        from virtualfolder.helpers import extract_vfolder_from_path
+        # Get a clean pootle path for retrieving the directory or store.
+        # A clean pootle path is a pootle path without any virtual folder name on
+        # it. For example /af/test_vfolders/browser/chrome/ is the corresponding
+        # clean pootle path for /af/test_vfolders/browser/vfolder8/chrome/
+        vfolder, clean_pootle_path = extract_vfolder_from_path(pootle_path)
 
     if filename:
         pootle_path = pootle_path + filename


### PR DESCRIPTION
By delaying the model imports from the virtualfolder app only to where they are
needed, we avoid getting warnings when the virtualfolder app is not in Django's
`INSTALLED_APPS`.

Fixes #4442.