### PR TITLE
Fix autorefresh notice styles

### DIFF
--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -730,6 +730,7 @@ button.close
     right: 0;
     z-index: 1;
     text-align: center;
+    pointer-events: none;
 }
 
 #autorefresh-notice span
@@ -749,6 +750,11 @@ button.close
     position: absolute;
     top: -0.2em;
     color: rgba(0, 0, 0, 0.4);
+}
+
+#autorefresh-notice.dirty span
+{
+    pointer-events: auto;
 }
 
 /*

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -732,7 +732,8 @@ button.close
     text-align: center;
 }
 
-#autorefresh-notice span {
+#autorefresh-notice span
+{
     background: #fe9;
     padding: 0.9em 1.5em;
     border: 1px solid rgba(0, 0, 0, 0.1);
@@ -741,7 +742,8 @@ button.close
     padding-right: 3.7em;
 }
 
-#autorefresh-notice .x {
+#autorefresh-notice .x
+{
     margin-left: 1em;
     font-size: 1.5em;
     position: absolute;


### PR DESCRIPTION
https://github.com/translate/pootle/pull/4879 introduced a bug:
stats table headers in browse mode are not clickable they are overlapped by invisible auto refresh notice when there are no dirty stats.
This PR should fix it.