### PR TITLE
Bump ttk requirement in Pootle 2.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,6 +25,6 @@ rq>=0.5.0,<=0.5.6
 scandir==1.2
 
 # Translate Toolkit
-translate-toolkit==1.13.0
+translate-toolkit==2.0.0b3
 # If you want to use Translate Toolkit 'master'
 #-e git://github.com/translate/translate.git#egg=translate-toolkit


### PR DESCRIPTION
wondering if we should push the newer version, we are likely to break compat v soon anyway with l20n parser im thinking