### PR TITLE
Editor: use wrapper for textarea

### DIFF
--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -593,8 +593,7 @@ td.translate-full div.translate-original
 td.translate-full textarea.translation
 {
     width: 100%;
-    margin: 0 auto 0.5em;
-    padding: 0;
+    margin: 0;
     min-height: 2.7em; 
 }
 
@@ -977,6 +976,44 @@ html[dir="rtl"] .extra-item-block .suggestion-feedback .buttons button
     color: #130f30;
     padding-right: 1em;
     float: left;
+}
+
+.editor-area-wrapper
+{
+    background-color: #fff;
+    border: 1px solid #d9d9d9;
+    border-radius: 3px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.075) inset;
+    margin: 0 auto 0.5em;
+    overflow: hidden;
+}
+
+.editor-area-wrapper.is-disabled,
+.editor-area-wrapper.is-disabled textarea
+{
+    box-shadow: none;
+    outline: none;
+    background-color: #eee;
+    color: #999;
+}
+
+.editor-area-wrapper.is-focused
+{
+    box-shadow: 0 0 2px #d9d9d9;
+    outline: -webkit-focus-ring-color auto 5px;
+}
+
+.editor-area-wrapper textarea
+{
+    box-sizing: border-box;
+    border: 0;
+    margin: 0;
+    padding: 0.3em;
+}
+
+.editor-area-wrapper textarea:focus
+{
+    outline: none;
 }
 
 #target-item-gravatar a
@@ -1498,14 +1535,8 @@ table.suggest-mode tr.edit-row.fuzzy-unit textarea.translation
 
 textarea.translation
 {
-    resize: vertical;
+    resize: none;
     font-size: 115%;
-}
-
-textarea.translation:disabled
-{
-    background: none;
-    border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 /* TERMINOLOGY MANAGEMENT */

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -193,6 +193,12 @@ PTL.editor = {
     $(document).on('focus', '.focusthis', (e) => {
       PTL.editor.focused = e.target;
     });
+    $(document).on('focus', '.js-translation-area', (e) => {
+      $(e.target).closest('.js-editor-area-wrapper').addClass('is-focused');
+    });
+    $(document).on('blur', '.js-translation-area', (e) => {
+      $(e.target).closest('.js-editor-area-wrapper').removeClass('is-focused');
+    });
 
     /* General */
     $(document).on('click', '.js-editor-reload', (e) => {

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -188,7 +188,12 @@
             {% endif %}
 
             {% block target_field %}
-            {{ form.target_f }}
+            <div
+              class="editor-area-wrapper js-editor-area-wrapper
+              {% if form.target_f.field.widget.attrs.disabled %} is-disabled{% endif %}"
+            >
+              {{ form.target_f }}
+            </div>
             {% endblock %}
 
             <div class="extras-bar">


### PR DESCRIPTION
Since in the near-future more elements will need to be combined with the
textarea (live previews etc.), the wrapper provides a convenient way to host all
of these while providing a way to nicely style everything.

Implementation-wise, reacting to focus/blur events is needed because there's no
way to target parent elements in pure CSS (note this is the same solution we use
for the search box).