### PR TITLE
Fixing compatibility with .lang files

### DIFF
--- a/pootle/apps/pootle_store/store/deserialize.py
+++ b/pootle/apps/pootle_store/store/deserialize.py
@@ -47,8 +47,14 @@ class StoreDeserialization(object):
             data = deserializer(self.store, data).output
         return data
 
+    def dataio(self, data):
+        data = io.BytesIO(data)
+        data.name = self.store.name
+        return data
+
     def fromstring(self, data):
-        return getclass(io.BytesIO(data))(data)
+        data = self.dataio(data)
+        return getclass(data)(data)
 
     def deserialize(self, data):
         return self.fromstring(self.pipeline(data))


### PR DESCRIPTION
Add store.name to BytesIO data before attempting translate.storage.factory

If you use translate.storage.factory.getclass on a BytesIO it doesnt work unless you fake the name in the way that an open file would have