### PR TITLE
JS cleanups 2

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -378,9 +378,6 @@ PTL.editor = {
       });
     });
 
-    // Update relative dates every minute
-    setInterval(helpers.updateRelativeDates, 6e4);
-
     /* History support */
     $.history.init((hash) => {
       const params = utils.getParsedHash(hash);


### PR DESCRIPTION
Cleanup: dont fire updateRelativeDates in editor as this is already done in PTL.init