### PR TITLE
Remove language sorting on select nodes

### DIFF
--- a/pootle/static/js/common.js
+++ b/pootle/static/js/common.js
@@ -159,36 +159,5 @@ PTL.common = {
       const target = $(this).attr('href') || $(this).data('target');
       $(target).toggle();
     });
-
-    /* Sorts language names within select elements */
-    const ids = ['id_languages', 'id_alt_src_langs', '-language',
-                 '-source_language'];
-
-    $.each(ids, (i, id) => {
-      const $selects = $(`select[id$="${id}"]`);
-
-      $.each($selects, (j, select) => {
-        const $select = $(select);
-        const options = $('option', $select);
-        let selected;
-
-        if (options.length) {
-          if (!$select.is('[multiple]')) {
-            selected = $(':selected', $select);
-          }
-
-          const opsArray = $.makeArray(options);
-          opsArray.sort((a, b) => utils.strCmp($(a).text(), $(b).text()));
-
-          options.remove();
-          $select.append($(opsArray));
-
-          if (!$select.is('[multiple]')) {
-            $select.get(0).selectedIndex = $(opsArray).index(selected);
-          }
-        }
-      });
-    });
   },
-
 };


### PR DESCRIPTION
Im not sure if removing this altogether breaks any expectations, but based on comment from @julen 

>  I'd prefer to only sort the data when rendering (and not some DOM structure)

which i agree with - ive PRed to remove this
