### PR TITLE
Align table lines in expanded stats panels

### DIFF
--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1759,7 +1759,7 @@ html[dir="rtl"] .summary-3-col
 }
 
 
-@media screen and (max-width: 1440px)
+@media screen and (max-width: 1600px)
 {
     .path-summary-more .summary-1-col,
     .path-summary-more .summary-2-col
@@ -1819,7 +1819,7 @@ html[dir="rtl"] .summary-3-col
 #top-stats .path-summary-more h3
 {
     border: 0;
-    margin: 2em 0 0;
+    margin: 1.6em 0 0 0;
 }
 
 #top-stats .path-summary-more h3.top

--- a/pootle/static/js/browser/components/Stats.js
+++ b/pootle/static/js/browser/components/Stats.js
@@ -64,7 +64,7 @@ const Stats = React.createClass({
 
     return (
       <div className="summary-2-col">
-        <h3 className="top">{t('Top Contributors for the Last 30 Days')}</h3>
+        <h3 className="top">{t('Contributors, 30 Days')}</h3>
         <div className="bd">
           <TopContributorsTable
             items={this.state.topContributors}


### PR DESCRIPTION
- set "Last 30 days" separately since we are going to have date range selector instead;
- adjust screen width when expanded stats panel switches to 3 columns;

Fixes #4926 