### PR TITLE
Editor: avoid extra loading indicator on page load

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -354,6 +354,10 @@ PTL.editor = {
     /* XHR activity indicator */
     $(document).ajaxStart(() => {
       clearTimeout(this.delayedActivityTimer);
+      if (this.isLoading) {
+        return;
+      }
+
       this.delayedActivityTimer = setTimeout(() => {
         this.showActivity();
       }, 3000);


### PR DESCRIPTION
When the initial loading time goes past a few seconds, the generic indicator
(via jQuery's `ajaxStart()`) will overlap the page load indicator, making the
spinner move its position. This commit avoids the generic indicator from kicking
in on the initial page load, hence avoiding the extra indicator.

Fixes #4950.