### PR TITLE
Remove external link icon in about page

### DIFF
--- a/pootle/templates/about.html
+++ b/pootle/templates/about.html
@@ -18,8 +18,7 @@
     teams to do translation and translation management. This community
     tool is Free Software, and any team can use it and contribute to the
     Pootle community. Read more on the
-    <a href="http://pootle.translatehouse.org/"><i class="icon-external-link"></i>
-    project website</a>.
+    <a href="http://pootle.translatehouse.org/">project website</a>.
     {% endblocktrans %}
   </p>
   <p>


### PR DESCRIPTION
This is to fix the icon for the external link in the About page. Maybe it is better to just remove the icon since it is only used there.

@iafan Please review.