### PR TITLE
Mousetrap: always prevent default browser behavior

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -313,7 +313,8 @@ PTL.editor = {
     const hotkeys = mousetrap(document.body);
 
     // FIXME: move binding to `SuggestionFeedbackForm` component
-    hotkeys.bind('esc', () => {
+    hotkeys.bind('esc', (e) => {
+      e.preventDefault();
       if (this.selectedSuggestionId !== undefined) {
         this.closeSuggestion();
       }
@@ -326,14 +327,32 @@ PTL.editor = {
         this.handleSubmit();
       }
     });
-    hotkeys.bind('ctrl+space', () => this.toggleState());
-    hotkeys.bind('ctrl+shift+space', (e) => this.toggleSuggestMode(e));
+    hotkeys.bind('ctrl+space', (e) => {
+      e.preventDefault();
+      this.toggleState();
+    });
+    hotkeys.bind('ctrl+shift+space', (e) => {
+      e.preventDefault();
+      this.toggleSuggestMode(e);
+    });
 
-    hotkeys.bind('ctrl+up', () => this.gotoPrev());
-    hotkeys.bind('ctrl+,', () => this.gotoPrev());
+    hotkeys.bind('ctrl+up', (e) => {
+      e.preventDefault();
+      this.gotoPrev();
+    });
+    hotkeys.bind('ctrl+,', (e) => {
+      e.preventDefault();
+      this.gotoPrev();
+    });
 
-    hotkeys.bind('ctrl+down', () => this.gotoNext({ isSubmission: false }));
-    hotkeys.bind('ctrl+.', () => this.gotoNext({ isSubmission: false }));
+    hotkeys.bind('ctrl+down', (e) => {
+      e.preventDefault();
+      this.gotoNext({ isSubmission: false });
+    });
+    hotkeys.bind('ctrl+.', (e) => {
+      e.preventDefault();
+      this.gotoNext({ isSubmission: false });
+    });
 
     if (navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
       // Optimize string join with '<br/>' as separator
@@ -351,7 +370,10 @@ PTL.editor = {
       );
     }
 
-    hotkeys.bind('ctrl+shift+n', (e) => this.unitIndex(e));
+    hotkeys.bind('ctrl+shift+n', (e) => {
+      e.preventDefault();
+      this.unitIndex(e);
+    });
 
     /* XHR activity indicator */
     $(document).ajaxStart(() => {

--- a/pootle/static/js/search.js
+++ b/pootle/static/js/search.js
@@ -40,10 +40,12 @@ const search = {
 
     /* Shortcuts */
 
-    mousetrap(document.body).bind('mod+shift+s', () => {
+    mousetrap(document.body).bind('mod+shift+s', (e) => {
+      e.preventDefault();
       this.$input.focus();
     });
     mousetrap(this.$form[0]).bind('esc', (e) => {
+      e.preventDefault();
       if (this.$form.hasClass('focused')) {
         this.$input.blur();
         this.toggleFields(e);


### PR DESCRIPTION
Mousetrap doesn't offer a default behavior or global hook to disallow events
from propagating, therefore this is left for callbacks to do it explicitly.
That's the case for Pootle: we want to hijack shortcuts entirely, and not bubble
up the event, hence avoiding potential side-effects.

As an example, on Windows machines, pressing Ctrl+Up/Down in the editor would
trigger Pootle's logic AND the native behavior, resulting in potential scrolls
as the event could be handled after the editor changed its layout.