### PR TITLE
Cleanups on utils/i18n

### DIFF
--- a/pootle/static/js/shared/utils/i18n.js
+++ b/pootle/static/js/shared/utils/i18n.js
@@ -46,12 +46,13 @@ function formatComponent(str, ctx) {
 
 
 /**
- * Mark a string for localization and replace placeholders with the components
- * provided in the context argument. This is intended to use in the context of
- * JSX and React components.
+ * Mark a string for localization and optionally replace placeholders with the
+ * components provided in the context argument. This is intended to use in the
+ * context of JSX and React components.
  *
- * @param {String} string - The string to internationalize. It accepts
- * printf-style named placeholders.
+ * @param {String} string - The string to internationalize. It accepts a
+ * simplified form of printf-style placeholders, however note these must be
+ * named, so they need to take the explicit `%(key)s` form, not `%s`.
  * @param {Object} ctx - Components to be injected in the placeholders specified
  * by the keys.
  * @return {Array} - An array with the original `string`, and placeholders

--- a/pootle/static/js/shared/utils/i18n.js
+++ b/pootle/static/js/shared/utils/i18n.js
@@ -54,11 +54,12 @@ function formatComponent(str, ctx) {
  * printf-style named placeholders.
  * @param {Object} ctx - Components to be injected in the placeholders specified
  * by the keys.
- * @return {Array|String} - The original `string` with replaced placeholders.
+ * @return {Array} - An array with the original `string`, and placeholders
+ * replaced by the given components.
  */
 export function tct(string, ctx = null) {
   if (!ctx) {
-    return gettext(string);
+    return [gettext(string)];
   }
   return formatComponent(gettext(string), ctx);
 }

--- a/pootle/static/js/shared/utils/i18n.js
+++ b/pootle/static/js/shared/utils/i18n.js
@@ -66,6 +66,21 @@ export function tct(string, ctx = null) {
 }
 
 
-export function t(string, args) {
-  return interpolate(gettext(string), args, true);
+/**
+ * Mark a string for localization and optionally replace placeholders with the
+ * values provided in the context argument.
+ *
+ * @param {String} string - The string to internationalize. It accepts a
+ * simplified form of printf-style placeholders, however note these must be
+ * named, so they need to take the explicit `%(key)s` form, not `%s`.
+ * @param {Object} ctx - Values to be injected in the placeholders specified by
+ * the keys. Note these will be coerced to strings.
+ * @return {String} - The original `string` with placeholders replaced by the
+ * given context values.
+ */
+export function t(string, ctx = null) {
+  if (!ctx) {
+    return gettext(string);
+  }
+  return interpolate(gettext(string), ctx, true);
 }


### PR DESCRIPTION
A few related code changes to complete and make consistent the `t()`/`tct()` functions.