### PR TITLE
Restrict user stats views to logged in users

### DIFF
--- a/pootle/apps/reports/views.py
+++ b/pootle/apps/reports/views.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response
@@ -59,6 +60,10 @@ INITIAL_STATES = ['new', 'edit']
 class UserStatsView(NoDefaultUserMixin, UserObjectMixin, DetailView):
     template_name = 'user/stats.html'
 
+    @method_decorator(login_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super(UserStatsView, self).dispatch(request, *args, **kwargs)
+
     def get_context_data(self, **kwargs):
         ctx = super(UserStatsView, self).get_context_data(**kwargs)
         now = make_aware(datetime.now())
@@ -76,6 +81,7 @@ class UserStatsView(NoDefaultUserMixin, UserObjectMixin, DetailView):
 
 class UserActivityView(NoDefaultUserMixin, UserObjectMixin, DetailView):
 
+    @method_decorator(login_required)
     @method_decorator(ajax_required)
     def dispatch(self, request, *args, **kwargs):
         self.month = request.GET.get('month', None)
@@ -89,6 +95,7 @@ class UserActivityView(NoDefaultUserMixin, UserObjectMixin, DetailView):
 class UserDetailedStatsView(NoDefaultUserMixin, UserObjectMixin, DetailView):
     template_name = 'user/detailed_stats.html'
 
+    @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
         self.month = request.GET.get('month', None)
         self.user = request.user

--- a/pootle/templates/user/profile.html
+++ b/pootle/templates/user/profile.html
@@ -63,9 +63,11 @@
     {% endif %}
     {% endwith %}
 
+    {% if not user.is_anonymous %}
     <h3 class="user-detailed-stats">
       <a href="{% url 'pootle-user-stats' object.username %}">{% trans 'Statistics' %}</a>
     </h3>
+    {% endif %}
   </div>
 
   {% if object.bio or object.has_contact_details or user == object %}

--- a/tests/views/user.py
+++ b/tests/views/user.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_user_stats_link(client, request_users):
+    user = request_users["user"]
+    if user.username != "nobody":
+        client.login(
+            username=user.username,
+            password=request_users["password"])
+    response = client.get("/user/member/")
+    assert (
+        ("user-detailed-stats" in response.content)
+        == (not user.is_anonymous()))
+
+
+@pytest.mark.django_db
+def test_user_stats_view(client, request_users):
+    user = request_users["user"]
+    if user.username != "nobody":
+        client.login(
+            username=user.username,
+            password=request_users["password"])
+    response = client.get("/user/member/stats/")
+    assert (
+        (response.status_code)
+        == (user.is_anonymous() and 302 or 200))


### PR DESCRIPTION
Restrict user stats views to logged in users.

This resolves issues around bots crawling user stats to infinitiy, and gives better protection to users privacy

still needs

- links to be restricted on view pages leading to the stats pages
- tests to ensure only logged in users can views these pages

fixes #4995 