### PR TITLE
Allow translators to auto-accept exact suggestions

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -680,7 +680,7 @@ def reject_suggestion(request, unit, suggid):
     return JsonResponse(json)
 
 
-@get_unit_context('review')
+@get_unit_context(['review', 'translate'])
 def accept_suggestion(request, unit, suggid):
     json = {
         'udbid': unit.id,


### PR DESCRIPTION
Instead of sending a new translation, suggestions that
match 100% are accepted instead. This helps reducing the
number of suggestions and also credit the involved people.

This was failing because user could have "translate" right
but not "review" right as previously required by the view.

Fixes #5025.