### PR TITLE
Allow accepting suggestions without "can review" permission

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -318,6 +318,11 @@ def unit_form_factory(language, snplurals=None, request=None):
             if self.cleaned_data['suggestion']:
                 old_state = TRANSLATED
 
+                # Skip `TARGET` field submission if suggestion value is equal
+                # to submitted translation
+                if new_target == self.cleaned_data['suggestion'].target_f:
+                    self._updated_fields = []
+
             if (self.request is not None and
                 not check_permission('administrate', self.request) and
                 is_fuzzy):

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1575,8 +1575,13 @@ PTL.editor = {
     const suggestionIndex = suggestionTexts.indexOf(newTranslation);
 
     if (suggestionIndex !== -1 && !this.isFuzzy()) {
-      this.acceptSuggestion(suggestionIds[suggestionIndex], { skipToNext: true });
-      return;
+      if (this.settings.canReview) {
+        this.acceptSuggestion(suggestionIds[suggestionIndex], { skipToNext: true });
+        return;
+      }
+      // Exact match suggestions are still accepted this way for users
+      // with no review right
+      this.selectedSuggestionId = suggestionIds[suggestionIndex];
     }
 
     // If similarities were in the process of being calculated by the time


### PR DESCRIPTION
This PR allows to accept 100% match suggestions without `can review` permission.