### PR TITLE
[RFC] Cleanup/pylint

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -3,3 +3,7 @@ uses:
 
 ignore-paths:
     - migrations
+
+pylint:
+    options:
+        dummy-variables-rgx: __|^.*[^_]_$

--- a/.pylint-travisrc
+++ b/.pylint-travisrc
@@ -9,6 +9,9 @@
 # 3. Prefer a checker over and individual check
 # 4. We don't include anything that the devs can't agree on in terms of linting
 
+[MASTER]
+ignore=migrations
+
 [MESSAGES CONTROL]
 disable=all
 # For checkers and individual checks see

--- a/.pylint-travisrc
+++ b/.pylint-travisrc
@@ -17,6 +17,7 @@ disable=all
 # For checkers and individual checks see
 # https://pylint.readthedocs.io/en/latest/features.html
 enable=reimported,logging,stdlib,string,unneeded-not
+dummy-variables-rgx=__|^.*[^_]_$
 
 [REPORTS]
 msg-template="{path}:{line}: {msg_id} {msg} ({symbol})"

--- a/pootle/apps/import_export/utils.py
+++ b/pootle/apps/import_export/utils.py
@@ -43,7 +43,7 @@ def import_file(file, user=None):
     rev = int(rev)
 
     try:
-        store, __ = Store.objects.get_or_create(pootle_path=pootle_path)
+        store = Store.objects.get_or_create(pootle_path=pootle_path)[0]
     except Exception as e:
         raise FileImportError(_("Could not create '%s'. Missing "
                                 "Project/Language? (%s)", (file.name, e)))

--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -68,7 +68,7 @@ class Command(BaseCommand):
             user_score = 0
             for scorelog in scorelog_qs.iterator():
                 score_delta = scorelog.get_score_delta()
-                translated, reviewed = scorelog.get_paid_wordcounts()
+                translated = scorelog.get_paid_wordcounts()[0]
                 user_score += score_delta
                 ScoreLog.objects.filter(id=scorelog.id).update(
                     score_delta=score_delta,

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -122,7 +122,7 @@ class FileParser(object):
                 continue
 
             if os.path.isdir(filename):
-                for dirpath, dirs, fnames in os.walk(filename):
+                for dirpath, dirs_, fnames in os.walk(filename):
                     if (os.path.basename(dirpath) in
                         ["CVS", ".svn", "_darcs", ".git", ".hg", ".bzr"]):
 

--- a/pootle/apps/pootle_app/management/commands/update_tmserver.py
+++ b/pootle/apps/pootle_app/management/commands/update_tmserver.py
@@ -352,5 +352,4 @@ class Command(BaseCommand):
         if self.is_local_tm:
             self._set_latest_indexed_revision(**options)
 
-        success, _ = helpers.bulk(self.es,
-                                  self._parse_translations(**options))
+        helpers.bulk(self.es, self._parse_translations(**options))

--- a/pootle/apps/pootle_app/migrations/0002_mark_empty_dirs_as_obsolete.py
+++ b/pootle/apps/pootle_app/migrations/0002_mark_empty_dirs_as_obsolete.py
@@ -22,7 +22,7 @@ def make_empty_directories_obsolete(apps, schema_editor):
     for d in Directory.objects.filter(child_stores__isnull=True,
                                       child_dirs__isnull=True,
                                       obsolete=False):
-        lang_code, prj_code, dir_path, fname = split_pootle_path(d.pootle_path)
+        lang_code, prj_code, dir_path = split_pootle_path(d.pootle_path)[:3]
 
         # makeobsolete translation project directories and lower
         # and do not touch language and project directories

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -212,8 +212,8 @@ class Directory(models.Model, CachedTreeItem):
             return self
 
     def get_or_make_subdir(self, child_name):
-        child_dir, created = Directory.objects.get_or_create(name=child_name,
-                                                             parent=self)
+        child_dir = Directory.objects.get_or_create(name=child_name,
+                                                    parent=self)[0]
         return child_dir
 
     def trail(self, only_dirs=True):

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -131,7 +131,7 @@ class Directory(models.Model, CachedTreeItem):
         return l(self.pootle_path)
 
     def get_translate_url(self, **kwargs):
-        lang, proj, dir, fn = split_pootle_path(self.pootle_path)
+        lang, proj, dir = split_pootle_path(self.pootle_path)[:3]
 
         if lang and proj:
             pattern_name = 'pootle-tp-translate'

--- a/pootle/apps/pootle_app/project_tree.py
+++ b/pootle/apps/pootle_app/project_tree.py
@@ -31,7 +31,7 @@ LANGCODE_POSTFIX_RE = re.compile(
 
 
 def direct_language_match_filename(language_code, path_name):
-    name, ext = os.path.splitext(os.path.basename(path_name))
+    name = os.path.splitext(os.path.basename(path_name))[0]
     if name == language_code or name.lower() == language_code.lower():
         return True
 
@@ -439,7 +439,7 @@ def get_translated_name_gnu(translation_project, store):
 
 
 def get_translated_name(translation_project, store):
-    name, ext = os.path.splitext(store.name)
+    name = os.path.splitext(store.name)[0]
 
     if store.file:
         path_parts = store.file.name.split(os.sep)

--- a/pootle/apps/pootle_app/project_tree.py
+++ b/pootle/apps/pootle_app/project_tree.py
@@ -242,7 +242,7 @@ def add_files(translation_project, ignored_files, exts, relative_dir, db_dir,
         db_dir,
     )
 
-    db_subdirs, new_db_subdirs = add_items(
+    db_subdirs, new_db_subdirs_ = add_items(
         dir_set,
         existing_dirs,
         lambda name: create_or_resurrect_dir(name=name, parent=db_dir),
@@ -301,7 +301,7 @@ def translation_project_dir_exists(language, project):
 
         if language.code == 'templates':
             # Language is template look for template files
-            for dirpath, dirnames, filenames in os.walk(
+            for dirpath_, dirnames, filenames in os.walk(
                     project.get_real_path()):
                 for filename in filenames:
                     if (project.file_belongs_to_project(filename,
@@ -310,7 +310,7 @@ def translation_project_dir_exists(language, project):
                         return True
         else:
             # find files with the language name in the project dir
-            for dirpath, dirnames, filenames in os.walk(
+            for dirpath_, dirnames, filenames in os.walk(
                     project.get_real_path()):
                 for filename in filenames:
                     # FIXME: don't reuse already used file
@@ -322,7 +322,7 @@ def translation_project_dir_exists(language, project):
     else:
         # find directory with the language name in the project dir
         try:
-            dirpath, dirnames, filename = os.walk(
+            dirpath_, dirnames, filename = os.walk(
                 project.get_real_path()).next()
             if language.code in dirnames:
                 return True
@@ -336,10 +336,10 @@ def init_store_from_template(translation_project, template_store):
     """Initialize a new file for `translation_project` using `template_store`.
     """
     if translation_project.file_style == 'gnu':
-        target_pootle_path, target_path = get_translated_name_gnu(
+        target_pootle_path_, target_path = get_translated_name_gnu(
             translation_project, template_store)
     else:
-        target_pootle_path, target_path = get_translated_name(
+        target_pootle_path_, target_path = get_translated_name(
             translation_project, template_store)
 
     # Create the missing directories for the new TP.

--- a/pootle/apps/pootle_app/views/admin/util.py
+++ b/pootle/apps/pootle_app/views/admin/util.py
@@ -114,7 +114,7 @@ def form_set_as_table(formset, link=None, linkfield='code'):
         # Do not display the delete checkbox for the 'add a new entry' form.
         formset.forms[-1].fields['DELETE'].widget = forms.HiddenInput()
 
-        for i, form in enumerate(formset.forms):
+        for form in formset.forms:
             add_errors(result, fields, form)
             add_widgets(result, fields, form, link)
 

--- a/pootle/apps/pootle_fs/finder.py
+++ b/pootle/apps/pootle_fs/finder.py
@@ -69,7 +69,7 @@ class TranslationFileFinder(object):
 
     def walk(self):
         """Walk a filesystem"""
-        for root, dirs, files in scandir.walk(self.file_root):
+        for root, dirs_, files in scandir.walk(self.file_root):
             for filename in files:
                 yield os.path.join(root, filename)
 

--- a/pootle/apps/pootle_fs/resources.py
+++ b/pootle/apps/pootle_fs/resources.py
@@ -163,7 +163,7 @@ class FSProjectStateResources(object):
 
     def reload(self):
         """Uncache cached_properties"""
-        for k, v in self.__dict__.items():
+        for k, v_ in self.__dict__.items():
             if k in ["context", "pootle_path", "fs_path"]:
                 continue
             del self.__dict__[k]

--- a/pootle/apps/pootle_fs/state.py
+++ b/pootle/apps/pootle_fs/state.py
@@ -188,7 +188,7 @@ class ProjectFSState(State):
     def state_unchanged(self):
         has_changes = []
         [has_changes.extend([p.pootle_path for p in v])
-         for k, v in self.__state__.items()
+         for v in self.__state__.values()
          if v]
         return self.resources.synced.exclude(pootle_path__in=has_changes)
 

--- a/pootle/apps/pootle_fs/state.py
+++ b/pootle/apps/pootle_fs/state.py
@@ -145,7 +145,7 @@ class ProjectFSState(State):
             resolve_conflict__gt=0)
         for store_fs in conflict.iterator():
             store_fs.project = self.project
-            pootle_changed, fs_changed = self._get_changes(store_fs.file)
+            pootle_changed_, fs_changed = self._get_changes(store_fs.file)
             if fs_changed:
                 yield dict(store_fs=store_fs)
 
@@ -256,7 +256,7 @@ class ProjectFSState(State):
     def state_pootle_ahead(self):
         for store_fs in self.resources.pootle_changed.iterator():
             store_fs.project = self.project
-            pootle_changed, fs_changed = self._get_changes(store_fs.file)
+            pootle_changed_, fs_changed = self._get_changes(store_fs.file)
             pootle_ahead = (
                 not fs_changed
                 or store_fs.resolve_conflict == POOTLE_WINS)

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -869,7 +869,7 @@ class ENChecker(checks.UnitChecker):
             translate = False
             fingerprint = 0
 
-            for chunk in chunks:
+            for chunk_ in chunks:
                 translate = not translate
                 if translate:
                     # ordinary text (safe to translate)
@@ -901,7 +901,7 @@ class ENChecker(checks.UnitChecker):
             translate = False
             double_quote_count = 0
 
-            for chunk in chunks:
+            for chunk_ in chunks:
                 translate = not translate
                 if translate:
                     # ordinary text (safe to translate)

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -1145,7 +1145,7 @@ def get_qualitycheck_schema(path_obj=None):
             'url': path_obj.get_translate_url(check=check) if path_obj else ''
         })
 
-    result = sorted([item for code, item in d.items()],
+    result = sorted([item for item in d.values()],
                     key=lambda x: x['code'],
                     reverse=True)
 

--- a/pootle/apps/pootle_misc/match.py
+++ b/pootle/apps/pootle_misc/match.py
@@ -45,7 +45,7 @@ class TerminologyComparer(terminology.TerminologyComparer):
         term_count = len(term_list)
         matched_index = 0
 
-        for i, term_word in enumerate(term_list):
+        for term_word in term_list:
             for j, text_word in enumerate(text_list[matched_index:],
                                           start=matched_index):
                 text_word_len = len(text_word)

--- a/pootle/apps/pootle_misc/templatetags/cleanhtml.py
+++ b/pootle/apps/pootle_misc/templatetags/cleanhtml.py
@@ -56,7 +56,7 @@ def trim_url(link):
 def url_trim(html):
     """Trims anchor texts that are longer than 70 chars."""
     fragment = fromstring(html)
-    for el, attrib, link, pos in fragment.iterlinks():
+    for el, attrib_, link_, pos_ in fragment.iterlinks():
         new_link_text = trim_url(el.text_content())
         el.text = new_link_text
 

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -142,7 +142,7 @@ class ProjectURLMixin(object):
     """
 
     def get_absolute_url(self):
-        lang, proj, dir, fn = split_pootle_path(self.pootle_path)
+        proj = split_pootle_path(self.pootle_path)[1]
 
         if proj is not None:
             pattern_name = 'pootle-project-browse'
@@ -154,7 +154,7 @@ class ProjectURLMixin(object):
         return reverse(pattern_name, args=pattern_args)
 
     def get_translate_url(self, **kwargs):
-        lang, proj, dir, fn = split_pootle_path(self.pootle_path)
+        proj, dir, fn = split_pootle_path(self.pootle_path)[1:]
 
         if proj is not None:
             pattern_name = 'pootle-project-translate'
@@ -577,7 +577,7 @@ def invalidate_resources_cache(sender, instance, **kwargs):
         (not kwargs['created'] or kwargs['raw'])):
         return
 
-    lang, proj, dir, fn = split_pootle_path(instance.pootle_path)
+    proj = split_pootle_path(instance.pootle_path)[1]
     if proj is not None:
         cache.delete(make_method_key(Project, 'resources', proj))
 

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -464,7 +464,7 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
     def _detect_treestyle(self):
         try:
             dirlisting = os.walk(self.get_real_path())
-            dirpath, dirnames, filenames = dirlisting.next()
+            dirpath_, dirnames, filenames = dirlisting.next()
 
             if not dirnames:
                 # No subdirectories
@@ -479,7 +479,7 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
                 return "nongnu"
 
             # No language subdirs found, look for any translation file
-            for dirpath, dirnames, filenames in os.walk(self.get_real_path()):
+            for dirpath_, dirnames, filenames in os.walk(self.get_real_path()):
                 if filter(self.file_belongs_to_project, filenames):
                     return "gnu"
         except:

--- a/pootle/apps/pootle_statistics/migrations/0004_fill_translated_wordcount.py
+++ b/pootle/apps/pootle_statistics/migrations/0004_fill_translated_wordcount.py
@@ -20,7 +20,7 @@ def set_translated_wordcount(apps, schema_editor):
         ]
     )
     for scorelog in scorelog_qs.iterator():
-        translated, reviewed = scorelog.get_paid_wordcounts()
+        translated = scorelog.get_paid_wordcounts()[0]
         ScoreLog.objects.filter(id=scorelog.id).update(
             translated_wordcount=translated
         )

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -491,7 +491,7 @@ class ScoreLog(models.Model):
         self.rate = self.user.rate
         self.review_rate = self.user.review_rate
         self.score_delta = self.get_score_delta()
-        translated, reviewed = self.get_paid_wordcounts()
+        translated = self.get_paid_wordcounts()[0]
         self.translated_wordcount = translated
 
         super(ScoreLog, self).save(*args, **kwargs)

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -191,7 +191,7 @@ class StoreDiff(object):
     def get_indexes_to_update(self):
         offset = 0
         index_updates = []
-        for (insert_at, uids_add, next_index, delta) in self.insert_points:
+        for (insert_at_, uids_add_, next_index, delta) in self.insert_points:
             if delta > 0:
                 index_updates += [(next_index + offset, delta)]
                 offset += delta
@@ -200,7 +200,7 @@ class StoreDiff(object):
     def get_units_to_add(self):
         offset = 0
         to_add = []
-        for (insert_at, uids_add, next_index, delta) in self.insert_points:
+        for (insert_at, uids_add, next_index_, delta) in self.insert_points:
             for index, uid in enumerate(uids_add):
                 file_unit = self.file_store.findid(uid)
                 if file_unit and file_unit.getid() not in self.db_units:
@@ -220,7 +220,7 @@ class StoreDiff(object):
         uid_index_map = {}
         offset = 0
 
-        for (insert_at, uids_add, next_index, delta) in self.insert_points:
+        for (insert_at, uids_add, next_index_, delta) in self.insert_points:
             for index, uid in enumerate(uids_add):
                 new_unit_index = insert_at + index + 1 + offset
                 if uid in self.db_units:
@@ -238,7 +238,7 @@ class StoreDiff(object):
         """
         update_dbids = set()
 
-        for (tag, i1, i2, j1, j2) in self.opcodes:
+        for (tag, i1, i2, j1_, j2_) in self.opcodes:
             if tag == 'equal':
                 update_dbids.update(
                     set(self.db_units[uid]['id']

--- a/pootle/apps/pootle_store/fields.py
+++ b/pootle/apps/pootle_store/fields.py
@@ -75,7 +75,7 @@ def to_python(value):
         ms.plural = plural
         return ms
     elif isinstance(value, dict):
-        return multistring([val for key, val in sorted(value.items())],
+        return multistring([val for __, val in sorted(value.items())],
                            encoding="UTF-8")
     else:
         return multistring(value, encoding="UTF-8")

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -116,7 +116,7 @@ class MultiStringWidget(forms.MultiWidget):
         else:
             widget = forms.TextInput
 
-        widgets = [widget(attrs=attrs) for i in xrange(nplurals)]
+        widgets = [widget(attrs=attrs) for i_ in xrange(nplurals)]
         super(MultiStringWidget, self).__init__(widgets, attrs)
 
     def format_output(self, rendered_widgets):
@@ -150,7 +150,7 @@ class HiddenMultiStringWidget(MultiStringWidget):
     """Uses hidden input instead of textareas."""
 
     def __init__(self, attrs=None, nplurals=1):
-        widgets = [forms.HiddenInput(attrs=attrs) for i in xrange(nplurals)]
+        widgets = [forms.HiddenInput(attrs=attrs) for i_ in xrange(nplurals)]
         super(MultiStringWidget, self).__init__(widgets, attrs)
 
     def format_output(self, rendered_widgets):
@@ -173,7 +173,7 @@ class MultiStringFormField(forms.MultiValueField):
         self.widget = MultiStringWidget(nplurals=nplurals, attrs=attrs,
                                         textarea=textarea)
         self.hidden_widget = HiddenMultiStringWidget(nplurals=nplurals)
-        fields = [forms.CharField() for i in range(nplurals)]
+        fields = [forms.CharField() for i_ in range(nplurals)]
         super(MultiStringFormField, self).__init__(fields=fields,
                                                    *args, **kwargs)
 

--- a/pootle/apps/pootle_store/migrations/0012_set_is_template.py
+++ b/pootle/apps/pootle_store/migrations/0012_set_is_template.py
@@ -20,7 +20,7 @@ def migrate_store_is_template(apps, schema_editor):
 
     for tp in tps:
         try:
-            project = tp.project
+            __ = tp.project
         except apps.get_model("pootle_project.Project").DoesNotExist:
             logger.warn("TP with missing project '%s', not updating", tp.pootle_path)
             continue

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1645,11 +1645,9 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
             if conflict_found:
                 if resolve_conflict == POOTLE_WINS:
-                    (suggestion,
-                     created) = unit.add_suggestion(newunit.target, user)
+                    created = unit.add_suggestion(newunit.target, user)[1]
                 else:
-                    (suggestion,
-                     created) = unit.add_suggestion(old_target, old_submitter)
+                    created = unit.add_suggestion(old_target, old_submitter)[1]
                 if created:
                     suggested += 1
         return updated, suggested

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -558,7 +558,7 @@ class Unit(models.Model, base.TranslationUnit):
                '#unit=%s' % unicode(self.id)))
 
     def get_search_locations_url(self, **kwargs):
-        lang, proj, dir, fn = split_pootle_path(self.store.pootle_path)
+        proj, dir, fn = split_pootle_path(self.store.pootle_path)[1:]
 
         return u''.join([
             reverse('pootle-project-translate', args=[proj, dir, fn]),

--- a/pootle/apps/pootle_store/templatetags/store_tags.py
+++ b/pootle/apps/pootle_store/templatetags/store_tags.py
@@ -233,6 +233,6 @@ def do_include_raw(parser, token):
             template_name[-1] == template_name[0]):
         template_name = template_name[1:-1]
 
-    source, path = get_template_source(template_name)
+    source, __ = get_template_source(template_name)
 
     return template.base.TextNode(source)

--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -309,7 +309,7 @@ class Timeline(object):
 
         # Group by submitter id and creation_time because
         # different submissions can have same creation time
-        for key, values in grouped_timeline:
+        for __, values in grouped_timeline:
             entry_group = {'entries': []}
             values = sorted(values, key=target_field_should_be_first)
             for item in values:

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -88,7 +88,7 @@ def get_alt_src_langs(request, user, translation_project):
         from pootle_language.models import Language
         accept = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
 
-        for accept_lang, unused in parse_accept_lang_header(accept):
+        for accept_lang, __ in parse_accept_lang_header(accept):
             if accept_lang == '*':
                 continue
 

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -56,7 +56,7 @@ def create_or_resurrect_translation_project(language, project):
 def create_translation_project(language, project):
     if translation_project_dir_exists(language, project):
         try:
-            translation_project, created = TranslationProject.objects.all() \
+            translation_project, __ = TranslationProject.objects.all() \
                 .get_or_create(language=language, project=project)
             return translation_project
         except OSError:
@@ -437,7 +437,7 @@ class TranslationProject(models.Model, CachedTreeItem):
         else:
             file_filter = lambda filename: True
 
-        all_files, new_files, is_empty = add_files(
+        all_files, new_files, __ = add_files(
             self,
             ignored_files,
             exts,

--- a/pootle/apps/reports/views.py
+++ b/pootle/apps/reports/views.py
@@ -257,14 +257,14 @@ def get_detailed_report_context(user, month):
                     'subtotal': subtotal,
                 }
 
-        for rate, words in totals['translated'].items():
+        for rate in totals['translated']:
             totals['translated'][rate]['rounded_words'] = \
                 int(round(totals['translated'][rate]['words']))
             totals['translated'][rate]['subtotal'] = \
                 rate * totals['translated'][rate]['rounded_words']
             totals['all'] += totals['translated'][rate]['subtotal']
 
-        for rate, words in totals['reviewed'].items():
+        for rate in totals['reviewed']:
             totals['reviewed'][rate]['subtotal'] = (
                 rate * totals['reviewed'][rate]['words'])
             totals['all'] += totals['reviewed'][rate]['subtotal']

--- a/pootle/apps/staticpages/forms.py
+++ b/pootle/apps/staticpages/forms.py
@@ -36,9 +36,9 @@ def agreement_form_factory(pages, user):
         def save(self, **kwargs):
             """Saves user agreements."""
             for page in self._pages:
-                agreement, created = Agreement.objects.get_or_create(
+                agreement = Agreement.objects.get_or_create(
                     user=self._user, document=page,
-                )
+                )[0]
                 agreement.save()
 
         def legal_fields(self):

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -365,10 +365,10 @@ class VirtualFolderTreeItem(models.Model, CachedTreeItem):
         # adjusted location.
         if (self.directory.pootle_path.count('/') >
                 self.vfolder.location.count('/')):
-            parent, created = VirtualFolderTreeItem.objects.get_or_create(
+            parent = VirtualFolderTreeItem.objects.get_or_create(
                 directory=self.directory.parent,
                 vfolder=self.vfolder,
-            )
+            )[0]
             self.parent = parent
 
         super(VirtualFolderTreeItem, self).save(*args, **kwargs)

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -250,7 +250,7 @@ def check_settings(app_configs=None, **kwargs):
         ))
 
     try:
-        markup_filter, markup_kwargs = settings.POOTLE_MARKUP_FILTER
+        markup_filter = settings.POOTLE_MARKUP_FILTER[0]
     except AttributeError:
         errors.append(checks.Warning(
             _("POOTLE_MARKUP_FILTER is missing."),

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -167,8 +167,7 @@ def set_resource(request, path_obj, dir_path, filename):
             directory = obj_directory
 
     if is_404:  # Try parent directory
-        language_code, project_code, dp, fn = \
-            split_pootle_path(clean_pootle_path)
+        language_code, project_code = split_pootle_path(clean_pootle_path)[:2]
         if not filename:
             dir_path = dir_path[:dir_path[:-1].rfind('/') + 1]
 

--- a/pootle/core/initdb.py
+++ b/pootle/core/initdb.py
@@ -127,7 +127,7 @@ class InitDB(object):
             'model': "directory",
         }
 
-        pootle_content_type, created = self._create_object(ContentType, **args)
+        pootle_content_type = self._create_object(ContentType, **args)[0]
         pootle_content_type.save()
 
         # Create the permissions.
@@ -211,12 +211,12 @@ class InitDB(object):
             'nplurals': 2,
             'pluralequation': "(n != 1)",
         }
-        en, created = self._create_object(Language, **criteria)
+        en = self._create_object(Language, **criteria)[0]
         return en
 
     def create_root_directories(self):
         """Create the root Directory items."""
-        root, created = self._create_object(Directory, **dict(name=""))
+        root = self._create_object(Directory, **dict(name=""))[0]
         self._create_object(Directory, **dict(name="projects", parent=root))
 
     def create_template_languages(self):
@@ -242,7 +242,7 @@ class InitDB(object):
             'checkstyle': "terminology",
         }
         po = Format.objects.get(name="po")
-        terminology, created = self._create_object(Project, **criteria)
+        terminology = self._create_object(Project, **criteria)[0]
         terminology.filetypes.add(po)
 
     def create_default_projects(self):
@@ -261,7 +261,7 @@ class InitDB(object):
             'checkstyle': "standard",
             'treestyle': "auto",
         }
-        tutorial, created = self._create_object(Project, **criteria)
+        tutorial = self._create_object(Project, **criteria)[0]
         tutorial.filetypes.add(po)
 
         criteria = {

--- a/pootle/core/markup/filters.py
+++ b/pootle/core/markup/filters.py
@@ -48,7 +48,7 @@ def rewrite_internal_link(link):
 
 def get_markup_filter_name():
     """Returns the current markup filter's name."""
-    name, args = get_markup_filter()
+    name = get_markup_filter()[0]
     return 'html' if name is None else name
 
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -439,7 +439,7 @@ class CachedTreeItem(TreeItem):
             if path == '/':
                 return True
 
-            lang, prj, dir, file = split_pootle_path(path)
+            prj = split_pootle_path(path)[1]
             key = self.get_cachekey()
 
             return key in path or path in key or key in '/projects/%s/' % prj

--- a/pootle/core/plugin/results.py
+++ b/pootle/core/plugin/results.py
@@ -24,7 +24,7 @@ class GatheredDict(Gathered):
     @property
     def results(self):
         gathered = OrderedDict()
-        for func, result in self.__results__:
+        for func_, result in self.__results__:
             if result:
                 try:
                     gathered.update(result)
@@ -64,7 +64,7 @@ class GatheredList(Gathered):
     @property
     def results(self):
         gathered = []
-        for func, result in self.__results__:
+        for func_, result in self.__results__:
             if isinstance(result, (list, tuple)):
                 gathered.extend(result)
         return gathered

--- a/pootle/core/url_helpers.py
+++ b/pootle/core/url_helpers.py
@@ -86,7 +86,7 @@ def get_path_sortkey(path):
     if path == '' or path.endswith('/'):
         return path
 
-    (head, tail) = os.path.split(path)
+    head = os.path.split(path)[0]
     return u'~'.join([head, path])
 
 
@@ -95,7 +95,7 @@ def get_path_parts(path):
     if not path:
         return []
 
-    (parent, filename) = os.path.split(path)
+    parent = os.path.split(path)[0]
     parent_parts = parent.split(u'/')
 
     if len(parent_parts) == 1 and parent_parts[0] == u'':

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -629,7 +629,7 @@ class PootleBrowseView(PootleDetailView):
 
     @cached_property
     def cookie_data(self):
-        ctx, cookie_data = self.sidebar_announcements
+        ctx_, cookie_data = self.sidebar_announcements
         return cookie_data
 
     @property
@@ -687,7 +687,7 @@ class PootleBrowseView(PootleDetailView):
             url_action_fixcritical = None
             url_action_review = None
             url_action_view_all = None
-        ctx, cookie_data = self.sidebar_announcements
+        ctx, cookie_data_ = self.sidebar_announcements
         ctx.update(
             super(PootleBrowseView, self).get_context_data(*args, **kwargs))
 
@@ -778,7 +778,7 @@ class PootleExportView(PootleDetailView):
             raise Http404(
                 ValidationError(search_form.errors).messages)
 
-        total, start, end, units_qs = search_backend.get(Unit)(
+        total, start_, end_, units_qs = search_backend.get(Unit)(
             self.request.user, **search_form.cleaned_data).search()
 
         units_qs = units_qs.select_related('store')

--- a/pootle/i18n/override.py
+++ b/pootle/i18n/override.py
@@ -68,7 +68,7 @@ def get_lang_from_http_header(request, supported):
     If nothing is found, return None.
     """
     accept = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
-    for accept_lang, unused in trans_real.parse_accept_lang_header(accept):
+    for accept_lang, __ in trans_real.parse_accept_lang_header(accept):
         if accept_lang == '*':
             return None
 

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -124,7 +124,7 @@ def init_command(parser, settings_template, args):
                         help=(u"Database port. Defaults to backend default. "
                               u"Not used with sqlite."))
 
-    args, remainder = parser.parse_known_args(args)
+    args, remainder_ = parser.parse_known_args(args)
     config_path = os.path.expanduser(args.config)
 
     if os.path.exists(config_path):

--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -288,12 +288,12 @@ class PootleTestEnv(object):
         from pootle_language.models import Language
 
         # add 2 languages
-        for i in range(0, 2):
+        for i_ in range(0, 2):
             LanguageDBFactory()
 
         source_language = Language.objects.get(code="en")
         po = Format.objects.get(name="po")
-        for i in range(0, 2):
+        for i_ in range(0, 2):
             # add 2 projects
             project = ProjectDBFactory(source_language=source_language)
             project.filetypes.add(po)
@@ -378,7 +378,7 @@ class PootleTestEnv(object):
         from pootle_format.utils import ProjectFiletypes
         from pootle_store.models import UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE
 
-        for i in range(0, n[0]):
+        for i_ in range(0, n[0]):
             # add 3 stores
             if parent is None:
                 store = StoreDBFactory(translation_project=tp)
@@ -390,7 +390,7 @@ class PootleTestEnv(object):
 
             # add 8 units to each store
             for state in [UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE]:
-                for i in range(0, n[1]):
+                for i_ in range(0, n[1]):
                     UnitDBFactory(store=store, state=state)
 
     def _update_submission_times(self, unit, update_time, last_update=None):
@@ -418,7 +418,7 @@ class PootleTestEnv(object):
         first_modified = created + timedelta(days=((30 * unit.index) + 10))
 
         # add suggestion at first_modified
-        suggestion, _ = unit.add_suggestion(
+        suggestion, created_ = unit.add_suggestion(
             "Suggestion for %s" % (unit.target or unit.source),
             user=member,
             touch=False)
@@ -438,7 +438,7 @@ class PootleTestEnv(object):
             unit, next_time, first_modified)
 
         # add another suggestion as different user 7 days later
-        suggestion2, _ = unit.add_suggestion(
+        suggestion2_, created_ = unit.add_suggestion(
             "Suggestion 2 for %s" % (unit.target or unit.source),
             user=member2,
             touch=False)

--- a/pytest_pootle/fixtures/models/permission.py
+++ b/pytest_pootle/fixtures/models/permission.py
@@ -30,7 +30,7 @@ def _require_permission(code, name, content_type):
         'name': name,
         'content_type': content_type,
     }
-    permission, created = Permission.objects.get_or_create(**criteria)
+    permission = Permission.objects.get_or_create(**criteria)[0]
 
     return permission
 

--- a/pytest_pootle/fixtures/models/permission_set.py
+++ b/pytest_pootle/fixtures/models/permission_set.py
@@ -16,7 +16,7 @@ def _require_permission_set(user, directory, positive_permissions=None,
         'user': user,
         'directory': directory,
     }
-    permission_set, created = PermissionSet.objects.get_or_create(**criteria)
+    permission_set = PermissionSet.objects.get_or_create(**criteria)[0]
     if positive_permissions is not None:
         permission_set.positive_permissions = positive_permissions
     if negative_permissions is not None:

--- a/pytest_pootle/fixtures/models/project.py
+++ b/pytest_pootle/fixtures/models/project.py
@@ -24,7 +24,7 @@ def _require_project(code, name, source_language, **kwargs):
         'treestyle': 'auto',
     }
     criteria.update(kwargs)
-    new_project, created = Project.objects.get_or_create(**criteria)
+    new_project = Project.objects.get_or_create(**criteria)[0]
     return new_project
 
 

--- a/pytest_pootle/fixtures/pootle_fs/state.py
+++ b/pytest_pootle/fixtures/pootle_fs/state.py
@@ -68,7 +68,7 @@ class DummyPlugin(object):
     def get_fs_path(self, pootle_path):
         from pootle.core.url_helpers import split_pootle_path
 
-        lang_code, proj_code, dir_path, fn = split_pootle_path(pootle_path)
+        lang_code, proj_code_, dir_path, fn = split_pootle_path(pootle_path)
         parts = ["", lang_code]
         if dir_path:
             parts.append(dir_path.rstrip("/"))

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -25,7 +25,7 @@ def _load_fixtures(*modules):
         path = mod.__path__
         prefix = '%s.' % mod.__name__
 
-        for loader, name, is_pkg in iter_modules(path, prefix):
+        for loader_, name, is_pkg in iter_modules(path, prefix):
             if not is_pkg:
                 yield name
 

--- a/pytest_pootle/search.py
+++ b/pytest_pootle/search.py
@@ -34,7 +34,7 @@ def calculate_search_results(kwargs, user):
     sfields = kwargs.get("sfields")
     soptions = kwargs.get("soptions", [])
     sort = kwargs.get("sort", None)
-    language_code, project_code, dir_path, filename = (
+    language_code, project_code, dir_path_, filename = (
         split_pootle_path(kwargs["pootle_path"]))
     uids = [
         int(x)

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -132,7 +132,7 @@ def get_translated_storefile(store, pootle_path=None):
     """Returns file store with added translations for untranslated units."""
     storeclass = store.get_file_class()
     filestore = store.convert(storeclass)
-    for i, unit in enumerate(filestore.units):
+    for unit in filestore.units:
         if not unit.istranslated():
             unit.target = "Translation of %s" % unit.source
 

--- a/tests/misc/checks.py
+++ b/tests/misc/checks.py
@@ -402,7 +402,7 @@ def test_get_qualitycheck_schema():
             'url': ''
         })
 
-    result = sorted([item for code, item in d.items()],
+    result = sorted([item for item in d.values()],
                     key=lambda x: x['code'],
                     reverse=True)
 

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -403,7 +403,7 @@ def _test_store_update_indexes(store, *test_args):
 def _test_store_update_units_before(*test_args):
     # test what has happened to the units that were present before the update
     (store, units_update, store_revision, resolve_conflict,
-     units_before, member, member2) = test_args
+     units_before, member_, member2) = test_args
 
     updates = {unit[0]: unit[1] for unit in units_update}
 
@@ -463,8 +463,8 @@ def _test_store_update_units_before(*test_args):
 
 
 def _test_store_update_ordering(*test_args):
-    (store, units_update, store_revision, resolve_conflict,
-     units_before, member, member2) = test_args
+    (store, units_update, store_revision, resolve_conflict_,
+     units_before, member_, member2_) = test_args
 
     updates = {unit[0]: unit[1] for unit in units_update}
     old_units = {unit.source: unit for unit in units_before}
@@ -477,7 +477,7 @@ def _test_store_update_ordering(*test_args):
                     and unit.revision > store_revision)
         if add_unit:
             new_unit_list.append(unit.source)
-    for source, target in units_update:
+    for source, target_ in units_update:
         if source in old_units:
             old_unit = old_units[source]
             should_add = (not old_unit.isobsolete()
@@ -490,8 +490,8 @@ def _test_store_update_ordering(*test_args):
 
 
 def _test_store_update_units_now(*test_args):
-    (store, units_update, store_revision, resolve_conflict,
-     units_before, member, member2) = test_args
+    (store, units_update, store_revision, resolve_conflict_,
+     units_before, member_, member2_) = test_args
 
     # test that all the current units should be there
     updates = {unit[0]: unit[1] for unit in units_update}

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -978,9 +978,9 @@ def test_store_get_or_create_templates(templates):
     project = ProjectDBFactory(source_language=templates)
     tp = TranslationProjectFactory(language=templates, project=project)
     po = Format.objects.get(name="po")
-    store, created = Store.objects.get_or_create(
+    store = Store.objects.get_or_create(
         name="mystore.pot",
         translation_project=tp,
-        parent=tp.directory)
+        parent=tp.directory)[0]
     assert store.filetype == po
     assert store.is_template

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -520,7 +520,7 @@ def test_store_diff(store_diff_tests):
     assert (
         update_units
         == [(x.source, x.target) for x in diff.file_store.units[1:]]
-        == [(v['source'], v['target']) for k, v in diff.file_units.items()])
+        == [(v['source'], v['target']) for v in diff.file_units.values()])
     assert diff.active_units == [x.source for x in store.units]
     assert diff.db_revision == store.get_max_unit_revision()
     assert (

--- a/tests/models/suggestion.py
+++ b/tests/models/suggestion.py
@@ -13,7 +13,7 @@ import pytest
 def test_hash(af_tutorial_po):
     """Tests that target hash changes when suggestion is modified"""
     unit = af_tutorial_po.getitem(0)
-    suggestion, created = unit.add_suggestion("gras")
+    suggestion, created_ = unit.add_suggestion("gras")
 
     first_hash = suggestion.target_hash
     suggestion.translator_comment = "my nice comment"

--- a/tests/models/translationproject.py
+++ b/tests/models/translationproject.py
@@ -135,7 +135,7 @@ def test_cannot_be_inited_from_templates():
 @pytest.mark.django_db
 def test_tp_checker(tp_checker_tests):
     language = Language.objects.get(code="language0")
-    checker_name, project = tp_checker_tests
+    checker_name_, project = tp_checker_tests
     tp = TranslationProject.objects.create(project=project, language=language)
 
     checkerclasses = [

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -228,7 +228,7 @@ def test_accept_suggestion_changes_state(issue_2401_po, system):
     unit = issue_2401_po.getitem(0)
     assert unit.state == UNTRANSLATED
 
-    suggestion, created = unit.add_suggestion('foo')
+    suggestion, created_ = unit.add_suggestion('foo')
     assert unit.state == UNTRANSLATED
 
     unit.accept_suggestion(suggestion, tp, system)
@@ -238,7 +238,7 @@ def test_accept_suggestion_changes_state(issue_2401_po, system):
     unit = issue_2401_po.getitem(1)
     assert unit.state == TRANSLATED
 
-    suggestion, created = unit.add_suggestion('bar')
+    suggestion, created_ = unit.add_suggestion('bar')
     assert unit.state == TRANSLATED
 
     unit.accept_suggestion(suggestion, tp, system)
@@ -248,7 +248,7 @@ def test_accept_suggestion_changes_state(issue_2401_po, system):
     unit = issue_2401_po.getitem(2)
     assert unit.state == FUZZY
 
-    suggestion, created = unit.add_suggestion('baz')
+    suggestion, created_ = unit.add_suggestion('baz')
     assert unit.state == FUZZY
 
     unit.accept_suggestion(suggestion, tp, system)

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -458,7 +458,7 @@ def test_user_has_manager_permissions(no_perms_user, administrate, tutorial,
         'user': no_perms_user,
         'directory': afrikaans_tutorial.directory,
     }
-    ps, created = PermissionSet.objects.get_or_create(**criteria)
+    ps = PermissionSet.objects.get_or_create(**criteria)[0]
     ps.positive_permissions = [administrate]
     ps.save()
     assert no_perms_user.has_manager_permissions()
@@ -467,7 +467,7 @@ def test_user_has_manager_permissions(no_perms_user, administrate, tutorial,
 
     # Assign 'administrate' right for 'Afrikaans' and check user is manager.
     criteria['directory'] = afrikaans.directory
-    ps, created = PermissionSet.objects.get_or_create(**criteria)
+    ps = PermissionSet.objects.get_or_create(**criteria)[0]
     ps.positive_permissions = [administrate]
     ps.save()
     assert no_perms_user.has_manager_permissions()
@@ -476,7 +476,7 @@ def test_user_has_manager_permissions(no_perms_user, administrate, tutorial,
 
     # Assign 'administrate' right for 'Tutorial' and check user is manager.
     criteria['directory'] = tutorial.directory
-    ps, created = PermissionSet.objects.get_or_create(**criteria)
+    ps = PermissionSet.objects.get_or_create(**criteria)[0]
     ps.positive_permissions = [administrate]
     ps.save()
     assert no_perms_user.has_manager_permissions()

--- a/tests/views/admin.py
+++ b/tests/views/admin.py
@@ -249,7 +249,7 @@ def test_admin_view_projects(client, request_users, english):
     languages = Language.objects.exclude(code='templates')
     language_choices = [(lang.id, unicode(lang)) for lang in languages]
     filetypes = []
-    for name, info in formats.get().items():
+    for info in formats.get().values():
         filetypes.append(
             [info["pk"], info["display_title"]])
     expected = {

--- a/tests/views/bad.py
+++ b/tests/views/bad.py
@@ -11,7 +11,7 @@ import pytest
 
 @pytest.mark.django_db
 def test_views_bad(bad_views):
-    path, response, test = bad_views
+    path_, response, test = bad_views
     assert response.status_code == test["code"]
     if test.get("location"):
         location = "http://testserver/%s" % test["location"].lstrip("/")

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -113,7 +113,7 @@ def _test_export_view(language, request, response, kwargs):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = search_backend.get(Unit)(
+    total_, start_, end_, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -169,7 +169,7 @@ def _test_export_view(project, request, response, kwargs, settings):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = search_backend.get(Unit)(
+    total, start_, end_, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     assertions = {}
@@ -314,7 +314,7 @@ def test_view_projects_export(client):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = search_backend.get(Unit)(
+    total_, start_, end_, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     unit_groups = [

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -143,7 +143,7 @@ def _calculate_timeline(request, unit):
 
     # Group by submitter id and creation_time because
     # different submissions can have same creation time
-    for key, values in grouped_timeline:
+    for key_, values in grouped_timeline:
         entry_group = {
             'entries': [],
         }

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -166,7 +166,7 @@ def _test_translate_view(tp, request, response, kwargs, settings):
     kwargs["language_code"] = tp.language.code
     resource_path = "%(dir_path)s%(filename)s" % kwargs
     request_path = "%s%s" % (tp.pootle_path, resource_path)
-    vfolder, pootle_path = extract_vfolder_from_path(request_path)
+    vfolder, pootle_path_ = extract_vfolder_from_path(request_path)
     current_vfolder_pk = (
         vfolder.pk
         if vfolder
@@ -206,7 +206,7 @@ def _test_export_view(tp, request, response, kwargs, settings):
     search_form = UnitExportForm(
         form_data, user=request.user)
     assert search_form.is_valid()
-    total, start, end, units_qs = search_backend.get(Unit)(
+    total, start_, end_, units_qs = search_backend.get(Unit)(
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     assertions = {}
@@ -265,6 +265,6 @@ def test_view_user_choice(client):
 
 @pytest.mark.django_db
 def test_uploads_tp(tp_uploads):
-    tp, request, response, kwargs, errors = tp_uploads
+    tp_, request_, response, kwargs_, errors = tp_uploads
     assert response.status_code == 200
     assert errors.keys() == response.context['upload_form'].errors.keys()

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ whitelist_externals=
     echo
     py.test
     codecov
+    pootle
 passenv=
     CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
 setenv=

--- a/tox.ini
+++ b/tox.ini
@@ -68,4 +68,4 @@ commands=
     make docs
     python setup.py build_mo
     make jslint
-    pylint --rcfile=.pylint-travisrc pootle
+    pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle


### PR DESCRIPTION
I did a number of pylint cleanups and added these to permanent checks.

* New checks: uneeded-not, unused-import, unused-variable
* Enabled checking in migrations to get some added cleanups
* With `unused-variables` I took a naming decision that such vars are either `__` (double underscore) or `sensible_variable_name_` (where you still want to convey the variable name but indicate that it is unused with a trailing underscore). 

Would love feedback on what is proposed here.