### PR TITLE
l10n: Use incomplete for untranslated+needs work

### DIFF
--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -62,7 +62,7 @@ HEADING_CHOICES = [
     {
         'id': 'need-translation',
         'class': 'stats-number sorttable_numeric when-loaded',
-        'display_name': _("Need Translation"),
+        'display_name': _("Incomplete"),
     },
     {
         'id': 'activity',

--- a/pootle/templates/browser/_actions.html
+++ b/pootle/templates/browser/_actions.html
@@ -34,7 +34,7 @@
     </a>
     {% else %}
     <span class="continue-translation">
-      <span class="caption">{% trans 'Needs translation' %}</span>
+      <span class="caption">{% trans 'Incomplete' %}</span>
       <span class="counter">0</span>
     </span>
     {% endif %}


### PR DESCRIPTION
This way it is less likely to be confused with "needs work".
Also aligns with the naming already used in the editor, and
the filters in the editor URLs.