### PR TITLE
Remove monkey patching i18n from lazy functions

### DIFF
--- a/pootle/apps/accounts/adapter.py
+++ b/pootle/apps/accounts/adapter.py
@@ -10,9 +10,10 @@ import logging
 
 from django.conf import settings
 from django.http import JsonResponse
-from django.utils.translation import ugettext_lazy as _
 
 from allauth.account.adapter import DefaultAccountAdapter
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 logger = logging.getLogger('action')

--- a/pootle/apps/accounts/forms.py
+++ b/pootle/apps/accounts/forms.py
@@ -9,11 +9,12 @@
 import logging
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
 
 from allauth.account import app_settings
 from allauth.account.app_settings import AuthenticationMethod
 from allauth.account.forms import LoginForm
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .utils import get_user_by_email
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -23,12 +23,12 @@ from django.forms.models import model_to_dict
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.lru_cache import lru_cache
-from django.utils.translation import ugettext_lazy as _
 
 from allauth.account.models import EmailAddress
 from allauth.account.utils import sync_user_email_addresses
 
 from pootle.core.cache import make_method_key
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_language.models import Language
 from pootle_statistics.models import (ScoreLog, Submission,
                                       TranslationActionCodes)

--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -10,12 +10,12 @@ from collections import OrderedDict
 
 from django import forms
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
 
 from contact_form.forms import ContactForm as OriginalContactForm
 
 from pootle.core.forms import MathCaptchaForm
 from pootle.core.mail import send_mail
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 class ContactForm(MathCaptchaForm, OriginalContactForm):

--- a/pootle/apps/contact/views.py
+++ b/pootle/apps/contact/views.py
@@ -8,12 +8,12 @@
 
 from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic import TemplateView
 
 from contact_form.views import ContactFormView as OriginalContactFormView
 
 from pootle.core.views.mixins import AjaxResponseMixin
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .forms import ContactForm, ReportForm
 

--- a/pootle/apps/import_export/utils.py
+++ b/pootle/apps/import_export/utils.py
@@ -10,8 +10,7 @@ import logging
 
 from translate.storage.factory import getclass
 
-from django.utils.translation import ugettext_lazy as _
-
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_app.models.permissions import check_user_permission
 from pootle_statistics.models import SubmissionTypes
 from pootle_store.models import Store

--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -11,8 +11,8 @@ import urlparse
 
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
 
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_store.models import Store

--- a/pootle/apps/pootle_format/abstracts.py
+++ b/pootle/apps/pootle_format/abstracts.py
@@ -7,7 +7,8 @@
 # AUTHORS file for copyright and authorship information.
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 class AbstractFileExtension(models.Model):

--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -15,12 +15,11 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.cache import make_method_key
 from pootle.core.mixins import TreeItem
 from pootle.core.url_helpers import get_editor_filter
-from pootle.i18n.gettext import language_dir, tr_lang
+from pootle.i18n.gettext import language_dir, tr_lang, ugettext_lazy as _
 from staticpages.models import StaticPage
 
 

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -14,7 +14,8 @@ from translate.filters.decorators import Category, cosmetic, critical
 from translate.lang import data
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .util import import_func
 

--- a/pootle/apps/pootle_misc/forms.py
+++ b/pootle/apps/pootle_misc/forms.py
@@ -8,7 +8,8 @@
 
 from django import forms
 from django.core.validators import EMPTY_VALUES
-from django.utils.translation import ugettext_lazy as _
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 class GroupedModelChoiceField(forms.ModelChoiceField):

--- a/pootle/apps/pootle_profile/forms.py
+++ b/pootle/apps/pootle_profile/forms.py
@@ -10,7 +10,8 @@ import urlparse
 
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 class EditUserForm(forms.ModelForm):

--- a/pootle/apps/pootle_profile/views.py
+++ b/pootle/apps/pootle_profile/views.py
@@ -7,12 +7,12 @@
 # AUTHORS file for copyright and authorship information.
 
 from django.contrib import auth
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView, UpdateView
 
 from pootle.core.views import APIView
 from pootle.core.views.mixins import (NoDefaultUserMixin, TestUserFieldMixin,
                                       UserObjectMixin)
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .forms import EditUserForm
 

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -23,7 +23,6 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.encoding import iri_to_uri
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
 
 from sortedm2m.fields import SortedManyToManyField
 
@@ -33,6 +32,7 @@ from pootle.core.mixins import CachedTreeItem
 from pootle.core.models import VirtualResource
 from pootle.core.url_helpers import (get_editor_filter, get_path_sortkey,
                                      split_pootle_path, to_tp_relative_path)
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import PermissionSet
 from pootle_config.utils import ObjectConfig

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -13,10 +13,10 @@ from django.db import models
 from django.db.models import F
 from django.template.defaultfilters import truncatechars
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.log import SCORE_CHANGED, log
 from pootle.core.utils import dateformat
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_misc.checks import check_names
 from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
 from pootle_store.fields import to_python

--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -6,7 +6,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.utils.translation import ugettext_lazy as _
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 #: Mapping of allowed sorting criteria.

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -27,7 +27,6 @@ from django.template.defaultfilters import truncatechars
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.http import urlquote
-from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.delegate import data_tool, format_syncers, format_updaters
 from pootle.core.log import (
@@ -46,6 +45,7 @@ from pootle.core.url_helpers import (
 from pootle.core.utils import dateformat
 from pootle.core.utils.aggregate import max_column
 from pootle.core.utils.timezone import datetime_min, make_aware
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_format.models import Format
 from pootle_misc.checks import check_names
 from pootle_misc.util import import_func

--- a/pootle/apps/pootle_translationproject/receivers.py
+++ b/pootle/apps/pootle_translationproject/receivers.py
@@ -10,10 +10,10 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.dispatch import receiver
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.mail import send_mail
 from pootle.core.url_helpers import urljoin
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .models import TranslationProject
 from .signals import tp_init_failed_async, tp_inited_async

--- a/pootle/apps/reports/forms.py
+++ b/pootle/apps/reports/forms.py
@@ -7,9 +7,10 @@
 # AUTHORS file for copyright and authorship information.
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
 
 from accounts.models import CURRENCIES
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .models import PaidTask, PaidTaskTypes
 

--- a/pootle/apps/reports/models.py
+++ b/pootle/apps/reports/models.py
@@ -9,7 +9,8 @@
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 __all__ = ('PaidTask', )

--- a/pootle/apps/reports/views.py
+++ b/pootle/apps/reports/views.py
@@ -19,7 +19,6 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic import CreateView, DetailView
 
 from accounts.models import CURRENCIES
@@ -30,6 +29,7 @@ from pootle.core.log import PAID_TASK_ADDED, PAID_TASK_DELETED, log
 from pootle.core.utils.timezone import make_aware, make_naive
 from pootle.core.views.mixins import (AjaxResponseMixin, NoDefaultUserMixin,
                                       TestUserFieldMixin, UserObjectMixin)
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_misc.util import (ajax_required, get_date_interval,
                               get_max_month_datetime, import_func)
 from pootle_statistics.models import ScoreLog

--- a/pootle/apps/staticpages/forms.py
+++ b/pootle/apps/staticpages/forms.py
@@ -9,7 +9,8 @@
 from django import forms
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .models import Agreement
 

--- a/pootle/apps/staticpages/models.py
+++ b/pootle/apps/staticpages/models.py
@@ -13,10 +13,10 @@ from django.db import models
 from django.db.models import Q
 from django.db.models.aggregates import Max
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.markup import MarkupField, get_markup_filter_display_name
 from pootle.core.mixins import DirtyFieldsMixin
+from pootle.i18n.gettext import ugettext_lazy as _
 
 from .managers import PageManager
 

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -12,13 +12,13 @@ from django.http import Http404
 from django.shortcuts import redirect, render
 from django.template import RequestContext
 from django.template.loader import get_template
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic import (CreateView, DeleteView, TemplateView,
                                   UpdateView)
 
 from pootle.core.http import JsonResponse, JsonResponseBadRequest
 from pootle.core.markup.filters import apply_markup_filter
 from pootle.core.views.mixins import SuperuserRequiredMixin
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_misc.util import ajax_required
 
 from .forms import agreement_form_factory

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -9,13 +9,13 @@
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.markup import MarkupField, get_markup_filter_display_name
 from pootle.core.mixins import CachedMethods, CachedTreeItem
 from pootle.core.mixins.treeitem import NoCachedStats
 from pootle.core.url_helpers import (get_all_pootle_paths, get_editor_filter,
                                      split_pootle_path)
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_app.models import Directory
 from pootle_language.models import Language
 from pootle_project.models import Project

--- a/pootle/core/browser.py
+++ b/pootle/core/browser.py
@@ -6,7 +6,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.utils.translation import ugettext_lazy as _
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 HEADING_CHOICES = [

--- a/pootle/core/utils/stats.py
+++ b/pootle/core/utils/stats.py
@@ -6,7 +6,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.utils.translation import ugettext_lazy as _
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 # Maximal number of top contributors which is loaded for each request

--- a/pootle/i18n/gettext.py
+++ b/pootle/i18n/gettext.py
@@ -10,6 +10,7 @@ from translate.lang import data as langdata
 
 from django.conf import settings
 from django.utils import translation
+from django.utils.functional import lazy
 from django.utils.translation import _trans
 
 
@@ -44,6 +45,12 @@ def ungettext(singular, plural, number, variables=None):
 
 def ngettext(singular, plural, number, variables=None):
     return _format_translation(_trans.ngettext(singular, plural, number), variables)
+
+
+gettext_lazy = lazy(gettext, str)
+ugettext_lazy = lazy(ugettext, unicode)
+ngettext_lazy = lazy(ngettext, str)
+ungettext_lazy = lazy(ungettext, unicode)
 
 
 def tr_lang(language_name):

--- a/pootle/i18n/override.py
+++ b/pootle/i18n/override.py
@@ -104,10 +104,6 @@ def get_language_from_request(request, check_path=False):
 
 def override_gettext(real_translation):
     """Replace Django's translation functions with safe versions."""
-    translation.gettext = real_translation.gettext
-    translation.ugettext = real_translation.ugettext
-    translation.ngettext = real_translation.ngettext
-    translation.ungettext = real_translation.ungettext
     translation.gettext_lazy = lazy(real_translation.gettext, str)
     translation.ugettext_lazy = lazy(real_translation.ugettext, unicode)
     translation.ngettext_lazy = lazy(real_translation.ngettext, str)

--- a/pootle/i18n/override.py
+++ b/pootle/i18n/override.py
@@ -13,7 +13,6 @@ import os
 from translate.lang import data
 
 from django.utils import translation
-from django.utils.functional import lazy
 from django.utils.translation import LANGUAGE_SESSION_KEY, trans_real
 
 from pootle.i18n import gettext
@@ -102,14 +101,6 @@ def get_language_from_request(request, check_path=False):
     return settings.LANGUAGE_CODE
 
 
-def override_gettext(real_translation):
-    """Replace Django's translation functions with safe versions."""
-    translation.gettext_lazy = lazy(real_translation.gettext, str)
-    translation.ugettext_lazy = lazy(real_translation.ugettext, unicode)
-    translation.ngettext_lazy = lazy(real_translation.ngettext, str)
-    translation.ungettext_lazy = lazy(real_translation.ungettext, unicode)
-
-
 def get_language_bidi():
     """Override for Django's get_language_bidi that's aware of more RTL
     languages.
@@ -126,7 +117,3 @@ def hijack_translation():
 
     # Override django's inadequate bidi detection
     translation.get_language_bidi = get_language_bidi
-
-    # We hijack gettext functions to install the safe variable formatting
-    # override
-    override_gettext(gettext)

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -18,8 +18,8 @@ from django.db.models import Q
 from django.template import RequestContext, loader
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
 
+from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_comment import get_model as get_comment_model
 from pootle_comment.forms import UnsecuredCommentForm
 from pootle_misc.checks import check_names


### PR DESCRIPTION
This uses the safe Pootle gettext functions directly instead of monkey patching the Django versions.