### PR TITLE
Editor: allow selecting similar translations' text

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -220,6 +220,7 @@ PTL.editor = {
 
     /* Write TM results, special chars... into the currently focused element */
     $('#editor').on('click', '.js-editor-copytext', (e) => this.copyText(e));
+    $('#editor').on('click', '.js-editor-copy-tm-text', (e) => this.copyTMText(e));
 
     /* Copy translator comment */
     $('#editor').on('click', '.js-editor-copy-comment', (e) => {
@@ -691,6 +692,14 @@ PTL.editor = {
 
     $target.caret(start, start);
     autosize.update(this.focused);
+  },
+
+  copyTMText(e) {
+    // Don't do anything if we're selecting text
+    if (window.getSelection().toString() !== '') {
+      return;
+    }
+    this.copyText(e);
   },
 
 

--- a/pootle/templates/editor/units/xhr_tm.html
+++ b/pootle/templates/editor/units/xhr_tm.html
@@ -1,7 +1,7 @@
 <div id="tm-results" class="tm-server">
   <div class="extra-item-title"><%= name %></div>
   <% _.each(suggs, function (sugg, i) { %>
-  <div id="tm<%= i %>" class="extra-item-block js-editor-copytext"
+  <div id="tm<%= i %>" class="extra-item-block js-editor-copy-tm-text"
     data-action="overwrite" data-translation-aid="<%- sugg.target %>">
     <div class="extra-item-content">
       <div class="extra-item">


### PR DESCRIPTION
Potentially this could have been integrated into `copyText()`, although with the
will to avoid near-term conflicts with the raw font branch, a new handler via a
different explicit selector has been added to address this particular case.

Fixes #5009.