### PR TITLE
Cleanup: Move TEST_USERS out of pytest_pootle.env

### DIFF
--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -10,30 +10,6 @@ import os
 from datetime import timedelta
 
 
-TEST_USERS = {
-    'nobody': dict(
-        fullname='Nobody',
-        password=''),
-    'system': dict(
-        fullname='System',
-        password=''),
-    'default': dict(
-        fullname='Default',
-        password=''),
-    'admin': dict(
-        fullname='Admin',
-        password='admin',
-        is_superuser=True,
-        email="admin@poot.le"),
-    'member': dict(
-        fullname='Member',
-        password=''),
-    'member2': dict(
-        fullname='Member2',
-        password=''),
-}
-
-
 class PootleTestEnv(object):
 
     methods = (
@@ -238,7 +214,7 @@ class PootleTestEnv(object):
         Revision.initialize(force=True)
 
     def setup_system_users(self):
-        from .fixtures.models.user import _require_user
+        from .fixtures.models.user import TEST_USERS, _require_user
 
         for username, user_params in TEST_USERS.items():
             user = _require_user(username=username, **user_params)

--- a/pytest_pootle/fixtures/models/user.py
+++ b/pytest_pootle/fixtures/models/user.py
@@ -10,7 +10,28 @@ import copy
 
 import pytest
 
-from pytest_pootle.env import TEST_USERS
+
+TEST_USERS = {
+    'nobody': dict(
+        fullname='Nobody',
+        password=''),
+    'system': dict(
+        fullname='System',
+        password=''),
+    'default': dict(
+        fullname='Default',
+        password=''),
+    'admin': dict(
+        fullname='Admin',
+        password='admin',
+        is_superuser=True,
+        email="admin@poot.le"),
+    'member': dict(
+        fullname='Member',
+        password=''),
+    'member2': dict(
+        fullname='Member2',
+        password='')}
 
 
 @pytest.fixture(

--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -18,7 +18,7 @@ from dateutil.relativedelta import relativedelta
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 
-from pytest_pootle.env import TEST_USERS
+from pytest_pootle.fixtures.models.user import TEST_USERS
 from pytest_pootle.utils import create_store, get_test_uids
 
 

--- a/tests/views/admin.py
+++ b/tests/views/admin.py
@@ -11,7 +11,7 @@ import pytest
 from django.core.urlresolvers import reverse_lazy, reverse
 from django.utils.safestring import mark_safe
 
-from pytest_pootle.env import TEST_USERS
+from pytest_pootle.fixtures.models.user import TEST_USERS
 from pytest_pootle.factories import LanguageDBFactory
 
 from pootle.core.delegate import formats


### PR DESCRIPTION
fixes pylint circular reference
