### PR TITLE
Pylint fixes/cleanups

### DIFF
--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+#: Mapping of allowed sorting criteria.
+#: Keys are supported query strings, values are the field + order that
+#: will be used against the DB.
+ALLOWED_SORTS = {
+    'units': {
+        'priority': '-priority',
+        'oldest': 'submitted_on',
+        'newest': '-submitted_on',
+    },
+    'suggestions': {
+        'oldest': 'suggestion__creation_time',
+        'newest': '-suggestion__creation_time',
+    },
+    'submissions': {
+        'oldest': 'submission__creation_time',
+        'newest': '-submission__creation_time',
+    },
+}
+
+#: List of fields from `ALLOWED_SORTS` that can be sorted by simply using
+#: `order_by(field)`
+SIMPLY_SORTED = ['units']

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -31,6 +31,7 @@ from pootle_project.models import Project
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 
+from .constants import ALLOWED_SORTS
 from .fields import to_db
 from .form_fields import (
     CategoryChoiceField, ISODateTimeField, MultipleArgsField,
@@ -500,8 +501,6 @@ class UnitSearchForm(forms.Form):
         self.fields["modified-since"] = ISODateTimeField(required=False)
 
     def clean(self):
-        from .views import ALLOWED_SORTS
-
         if "checks" in self.errors:
             del self.errors["checks"]
             self.cleaned_data["checks"] = None

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -9,9 +9,9 @@
 from django.db.models import Max
 from django.utils.functional import cached_property
 
+from pootle_store.constants import SIMPLY_SORTED
 from pootle_store.models import Unit
 from pootle_store.unit.filters import UnitSearchFilter, UnitTextSearch
-from pootle_store.views import SIMPLY_SORTED
 
 
 class DBSearchBackend(object):

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -50,31 +50,6 @@ from .unit.timeline import Timeline
 from .util import find_altsrcs
 
 
-#: Mapping of allowed sorting criteria.
-#: Keys are supported query strings, values are the field + order that
-#: will be used against the DB.
-ALLOWED_SORTS = {
-    'units': {
-        'priority': '-priority',
-        'oldest': 'submitted_on',
-        'newest': '-submitted_on',
-    },
-    'suggestions': {
-        'oldest': 'suggestion__creation_time',
-        'newest': '-suggestion__creation_time',
-    },
-    'submissions': {
-        'oldest': 'submission__creation_time',
-        'newest': '-submission__creation_time',
-    },
-}
-
-
-#: List of fields from `ALLOWED_SORTS` that can be sorted by simply using
-#: `order_by(field)`
-SIMPLY_SORTED = ['units']
-
-
 def get_alt_src_langs(request, user, translation_project):
     language = translation_project.language
     project = translation_project.project

--- a/pytest_pootle/search.py
+++ b/pytest_pootle/search.py
@@ -15,10 +15,10 @@ from django.db.models import Max
 from pootle.core.dateparse import parse_datetime
 from pootle.core.url_helpers import split_pootle_path
 from pootle_misc.checks import get_category_id
+from pootle_store.constants import ALLOWED_SORTS, SIMPLY_SORTED
 from pootle_store.models import Unit
 from pootle_store.unit.filters import UnitSearchFilter, UnitTextSearch
 from pootle_store.unit.results import GroupedResults, StoreResults
-from pootle_store.views import ALLOWED_SORTS, SIMPLY_SORTED
 from virtualfolder.helpers import extract_vfolder_from_path
 from virtualfolder.models import VirtualFolderTreeItem
 


### PR DESCRIPTION
- Cleanup: dont use super on non-parent, fixes pylint error
- remove cyclic imports