### PR TITLE
Cleanup: to prevent calling super on grandparents in PootleDetailView descendants

### DIFF
--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -26,8 +26,8 @@ from pootle.core.helpers import get_sidebar_announcements_context
 from pootle.core.paginator import paginate
 from pootle.core.url_helpers import split_pootle_path
 from pootle.core.views import (
-    PootleAdminView, PootleDetailView, PootleBrowseView, PootleExportView,
-    PootleTranslateView, set_permissions, requires_permission)
+    PootleAdminView, PootleBrowseView, PootleExportView,
+    PootleTranslateView)
 from pootle_app.models import Directory
 from pootle_app.views.admin import util
 from pootle_app.views.admin.permissions import admin_permissions
@@ -161,11 +161,7 @@ class ProjectBrowseView(ProjectMixin, PootleBrowseView):
 
 
 class ProjectTranslateView(ProjectMixin, PootleTranslateView):
-
-    @set_permissions
-    @requires_permission("administrate")
-    def dispatch(self, request, *args, **kwargs):
-        return super(PootleDetailView, self).dispatch(request, *args, **kwargs)
+    required_permission = "administrate"
 
     @property
     def pootle_path(self):
@@ -374,11 +370,7 @@ class ProjectsBrowseView(ProjectsMixin, PootleBrowseView):
 
 
 class ProjectsTranslateView(ProjectsMixin, PootleTranslateView):
-
-    @set_permissions
-    @requires_permission("administrate")
-    def dispatch(self, request, *args, **kwargs):
-        return super(PootleDetailView, self).dispatch(request, *args, **kwargs)
+    required_permission = "administrate"
 
 
 class ProjectsExportView(ProjectsMixin, PootleExportView):

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -92,6 +92,9 @@ def requires_permission(permission):
         def method_wrapper(self, request, *args, **kwargs):
             directory_permission = check_directory_permission(
                 permission, request, self.permission_context)
+            if directory_permission and hasattr(self, "required_permission"):
+                directory_permission = check_directory_permission(
+                    self.required_permission, request, self.permission_context)
             if not directory_permission:
                 raise PermissionDenied(
                     _("Insufficient rights to access this page."), )


### PR DESCRIPTION
- adds a required_permission var in `requires_permission` decorator
- updates the `ProjectsTranslateView` to use required_permission