### PR TITLE
Editor: do not append history entry on filter initialization

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -571,7 +571,6 @@ PTL.editor = {
           } else {
             uId = this.units.uIds[0];
           }
-          $.history.load(utils.updateHashPart('unit', uId));
         }
         this.offsetRequested = 0;
         this.setUnit(uId);


### PR DESCRIPTION
While having the unit id in the URL for initial loads is desirable, the existing
implementation prevents the browser back button from working as expected.

The ideal solution would be using the history API instead of relying on the
`onhashchange` event, although while that is not in place, not updating the hash
on the first load is an acceptable compromise — in fact, this is how it worked
until this issue was introduced.

Fixes #4793.