### PR TITLE
Don't check required_permission if it equals permission parameter

### DIFF
--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -92,7 +92,11 @@ def requires_permission(permission):
         def method_wrapper(self, request, *args, **kwargs):
             directory_permission = check_directory_permission(
                 permission, request, self.permission_context)
-            if directory_permission and hasattr(self, "required_permission"):
+            check_class_permission = (
+                directory_permission
+                and hasattr(self, "required_permission")
+                and permission != self.required_permission)
+            if check_class_permission:
                 directory_permission = check_directory_permission(
                     self.required_permission, request, self.permission_context)
             if not directory_permission:


### PR DESCRIPTION
This PR optimises #5057.