### PR TITLE
Add tp_tool for manipulating TranslationProjects

### DIFF
--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -28,7 +28,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.cache import make_method_key
-from pootle.core.delegate import filetype_tool
+from pootle.core.delegate import filetype_tool, tp_tool
 from pootle.core.mixins import CachedTreeItem
 from pootle.core.models import VirtualResource
 from pootle.core.url_helpers import (get_editor_filter, get_path_sortkey,
@@ -321,6 +321,10 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
     @cached_property
     def filetype_tool(self):
         return filetype_tool.get(self.__class__)(self)
+
+    @cached_property
+    def tp_tool(self):
+        return tp_tool.get(self.__class__)(self)
 
     @property
     def local_fs_path(self):

--- a/pootle/apps/pootle_translationproject/apps.py
+++ b/pootle/apps/pootle_translationproject/apps.py
@@ -22,3 +22,4 @@ class PootleTPConfig(AppConfig):
 
     def ready(self):
         importlib.import_module("pootle_translationproject.receivers")
+        importlib.import_module("pootle_translationproject.getters")

--- a/pootle/apps/pootle_translationproject/getters.py
+++ b/pootle/apps/pootle_translationproject/getters.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.delegate import tp_tool
+from pootle.core.plugin import getter
+from pootle_project.models import Project
+
+from .utils import TPTool
+
+
+@getter(tp_tool, sender=Project)
+def tp_tool_getter(**kwargs_):
+    return TPTool

--- a/pootle/apps/pootle_translationproject/utils.py
+++ b/pootle/apps/pootle_translationproject/utils.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.contrib.auth import get_user_model
+
+from pootle.core.models import Revision
+from pootle_app.models import Directory
+from pootle_statistics.models import SubmissionTypes
+from pootle_store.diff import StoreDiff
+from pootle_store.models import SOURCE_WINS, Store
+from pootle_translationproject.models import TranslationProject
+
+
+User = get_user_model()
+
+
+class TPTool(object):
+
+    def __init__(self, project):
+        self.project = project
+
+    def get_path(self, language_code):
+        return "/%s/%s/" % (language_code, self.project.code)
+
+    def get_tp(self, language):
+        try:
+            return self.project.translationproject_set.get(
+                language=language)
+        except TranslationProject.DoesNotExist:
+            pass
+
+    def check_tp(self, tp):
+        if tp.project != self.project:
+            raise ValueError(
+                "TP '%s' is not part of project '%s'"
+                % (tp, self.project.code))
+
+    def create_tp(self, language):
+        return self.project.translationproject_set.create(
+            language=language)
+
+    def update_from_tp(self, source, target):
+        self.check_tp(source)
+        self.check_tp(target)
+        self.update_children(source.directory, target.directory)
+
+    def update_store(self, source, target):
+        source_revision = target.get_max_unit_revision() + 1
+        differ = StoreDiff(target, source, source_revision)
+        diff = differ.diff()
+        if diff is None:
+            return
+        system = User.objects.get_system_user()
+        update_revision = Revision.incr()
+        return target.update_from_diff(
+            source,
+            source_revision,
+            diff,
+            update_revision,
+            system,
+            SubmissionTypes.SYSTEM,
+            SOURCE_WINS,
+            True)
+
+    def update_children(self, source_dir, target_dir):
+        stores = []
+        dirs = []
+        for store in source_dir.child_stores.live():
+            stores.append(store.name)
+            try:
+                self.update_store(
+                    store,
+                    Store.objects.get(
+                        name=store.name,
+                        parent=target_dir))
+            except Store.DoesNotExist:
+                self.clone_store(store, target_dir)
+        for subdir in source_dir.child_dirs.live():
+            dirs.append(subdir.name)
+            try:
+                self.update_children(
+                    subdir,
+                    Directory.objects.get(
+                        name=subdir.name,
+                        parent=target_dir))
+            except Directory.DoesNotExist:
+                self.clone_directory(subdir, target_dir)
+
+        for store in target_dir.child_stores.exclude(name__in=stores):
+            store.makeobsolete()
+
+    def clone_store(self, store, target_dir):
+        cloned = target_dir.child_stores.create(
+            name=store.name,
+            translation_project=target_dir.translation_project)
+        cloned.mark_all_dirty()
+        cloned.update(cloned.deserialize(store.serialize()))
+        cloned.state = store.state
+        cloned.save()
+        return cloned
+
+    def clone(self, tp, language):
+        self.check_tp(tp)
+        self.check_no_tp(language)
+        new_tp = self.create_tp(language)
+        self.clone_children(
+            tp.directory,
+            new_tp.directory)
+        return new_tp
+
+    def clone_directory(self, source_dir, target_parent):
+        target_dir = target_parent.child_dirs.create(
+            name=source_dir.name)
+        self.clone_children(
+            source_dir,
+            target_dir)
+        return target_dir
+
+    def clone_children(self, source_dir, target_parent):
+        for store in source_dir.child_stores.live():
+            self.clone_store(store, target_parent)
+        for subdir in source_dir.child_dirs.live():
+            self.clone_directory(subdir, target_parent)
+
+    def check_no_tp(self, language):
+        if self.get_tp(language):
+            raise ValueError(
+                "TranslationProject '%s' already exists"
+                % self.get_path(language.code))
+
+    def set_parents(self, directory, parent):
+        """Recursively sets the parent for children of a directory"""
+        self.check_tp(directory.translation_project)
+        self.check_tp(parent.translation_project)
+        for store in directory.child_stores.all():
+            store.clear_all_cache(parents=False, children=False)
+            store.parent = parent
+            store.mark_all_dirty()
+            store.save()
+        for subdir in directory.child_dirs.all():
+            subdir.clear_all_cache(parents=False, children=False)
+            subdir.parent = parent
+            subdir.save()
+            self.set_parents(subdir, subdir)
+
+    def move(self, tp, language):
+        """Re-assign a tp to a different language"""
+        self.check_tp(tp)
+        if tp.language == language:
+            return
+        self.check_no_tp(language)
+        pootle_path = self.get_path(language.code)
+        directory = tp.directory
+        tp.language = language
+        tp.pootle_path = pootle_path
+        tp.save()
+        self.set_parents(directory, self.get_tp(language).directory)
+        directory.delete()

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -21,6 +21,7 @@ format_registration = Provider()
 format_classes = Provider()
 format_diffs = Provider()
 filetype_tool = Getter()
+tp_tool = Getter()
 
 serializers = Provider(providing_args=["instance"])
 deserializers = Provider(providing_args=["instance"])

--- a/pytest_pootle/fixtures/models/translation_project.py
+++ b/pytest_pootle/fixtures/models/translation_project.py
@@ -10,6 +10,8 @@ import shutil
 
 import pytest
 
+from pootle.core.delegate import tp_tool
+
 
 def pytest_generate_tests(metafunc):
     from pootle_project.models import PROJECT_CHECKERS
@@ -122,3 +124,14 @@ def tp0(language0, project0):
     return TranslationProject.objects.get(
         language=language0,
         project=project0)
+
+
+@pytest.fixture
+def no_tp_tool_(request):
+    start_receivers = tp_tool.receivers
+    tp_tool.receivers = []
+
+    def _reset_tp_tool():
+        tp_tool.receivers = start_receivers
+
+    request.addfinalizer(_reset_tp_tool)

--- a/tests/models/translationproject.py
+++ b/tests/models/translationproject.py
@@ -15,11 +15,17 @@ from translate.filters import checks
 
 from django.db import IntegrityError
 
-from pytest_pootle.factories import LanguageDBFactory, TranslationProjectFactory
+from pytest_pootle.factories import (
+    LanguageDBFactory, ProjectDBFactory, TranslationProjectFactory)
 
+from pootle.core.plugin import getter
+from pootle.core.delegate import tp_tool
+from pootle_app.models import Directory
 from pootle_language.models import Language
 from pootle_project.models import Project
+from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
+from pootle_translationproject.utils import TPTool
 
 
 @pytest.mark.django_db
@@ -149,8 +155,6 @@ def test_tp_checker(tp_checker_tests):
 
 @pytest.mark.django_db
 def test_tp_create_with_none_treestyle(english, templates, settings):
-    from pytest_pootle.factories import ProjectDBFactory
-
     project = ProjectDBFactory(
         source_language=english,
         treestyle="none")
@@ -173,3 +177,143 @@ def test_tp_create_with_none_treestyle(english, templates, settings):
         os.path.join(
             settings.POOTLE_TRANSLATION_DIRECTORY,
             project.code))
+
+
+@pytest.mark.django_db
+def test_tp_tool_move(language0, project0, templates):
+    tp = project0.translationproject_set.get(language=language0)
+    original_stores = list(tp.stores.all())
+
+    TPTool(project0).move(tp, templates)
+    assert tp.language == templates
+    assert (
+        tp.pootle_path
+        == tp.directory.pootle_path
+        == "/%s/%s/" % (templates.code, project0.code))
+    assert tp.directory.parent == templates.directory
+
+    # all of the stores and their directories are updated
+    for store in original_stores:
+        store = Store.objects.get(pk=store.pk)
+        assert store.pootle_path.startswith(tp.pootle_path)
+        assert store.parent.pootle_path.startswith(tp.pootle_path)
+
+    assert not Store.objects.filter(
+        pootle_path__startswith="/%s/%s"
+        % (language0.code, project0.code))
+    assert not Directory.objects.filter(
+        pootle_path__startswith="/%s/%s/"
+        % (language0.code, project0.code))
+
+    # calling with already set language does nothing
+    assert TPTool(project0).move(tp, templates) is None
+
+
+@pytest.mark.django_db
+def test_tp_tool_bad(tp0, templates, english):
+    other_project = ProjectDBFactory(source_language=english)
+    other_tp = TranslationProjectFactory(
+        project=other_project,
+        language=LanguageDBFactory())
+    tp_tool = TPTool(tp0.project)
+
+    with pytest.raises(ValueError):
+        tp_tool.check_tp(other_tp)
+
+    with pytest.raises(ValueError):
+        tp_tool.set_parents(tp0.directory, other_tp.directory)
+
+    with pytest.raises(ValueError):
+        tp_tool.set_parents(other_tp.directory, tp0.directory)
+
+    with pytest.raises(ValueError):
+        tp_tool.move(other_tp, templates)
+
+    with pytest.raises(ValueError):
+        tp_tool.clone(other_tp, templates)
+
+    with pytest.raises(ValueError):
+        # cant set tp to a language if a tp already exists
+        tp_tool.move(
+            tp0, Language.objects.get(code="language1"))
+
+    with pytest.raises(ValueError):
+        # cant clone tp to a language if a tp already exists
+        tp_tool.clone(
+            tp0, Language.objects.get(code="language1"))
+
+
+def _test_tp_match(source_tp, target_tp):
+    source_stores = []
+    for store in source_tp.stores.live():
+        source_stores.append(store.pootle_path)
+        update_path = (
+            "/%s/%s"
+            % (target_tp.language.code,
+               store.pootle_path[(len(source_tp.language.code) + 2):]))
+        updated = Store.objects.get(pootle_path=update_path)
+        assert store.state == updated.state
+        updated_units = updated.units
+        for i, unit in enumerate(store.units):
+            updated_unit = updated_units[i]
+            assert unit.source == updated_unit.source
+            assert unit.target == updated_unit.target
+            assert unit.state == updated_unit.state
+    for store in target_tp.stores.live():
+        source_path = (
+            "/%s/%s"
+            % (source_tp.language.code,
+               store.pootle_path[(len(target_tp.language.code) + 2):]))
+        assert source_path in source_stores
+
+
+@pytest.mark.django_db
+def test_tp_tool_clone(tp0, templates):
+    new_lang = LanguageDBFactory()
+    tp_tool = TPTool(tp0.project)
+    _test_tp_match(tp0, tp_tool.clone(tp0, new_lang))
+
+
+@pytest.mark.django_db
+def test_tp_tool_update(tp0, templates):
+    new_lang = LanguageDBFactory()
+    tp0_tool = TPTool(tp0.project)
+    new_tp = tp0.project.translationproject_set.create(
+        language=new_lang)
+
+    # this will clone stores/directories as new_tp is empty
+    tp0_tool.update_from_tp(tp0, new_tp)
+    _test_tp_match(tp0, new_tp)
+    tp0_tool.update_from_tp(tp0, new_tp)
+
+    tp0.stores.first().delete()
+    tp0.stores.first().units.first().delete()
+    unit = tp0.stores.first().units.first()
+    unit.target = "NEW TARGET"
+    unit.save()
+    tp0_tool.update_from_tp(tp0, new_tp)
+    _test_tp_match(tp0, new_tp)
+
+    # doing another update does nothing
+    tp0_tool.update_from_tp(tp0, new_tp)
+    _test_tp_match(tp0, new_tp)
+
+
+@pytest.mark.django_db
+def test_tp_tool_getter(project0):
+    assert tp_tool.get(Project) is TPTool
+    assert isinstance(project0.tp_tool, TPTool)
+
+
+@pytest.mark.django_db
+def test_tp_tool_custom_getter(project0, no_tp_tool_):
+
+    class CustomTPTool(TPTool):
+        pass
+
+    @getter(tp_tool, sender=Project, weak=False)
+    def custom_tp_tool_getter(**kwargs_):
+        return CustomTPTool
+
+    assert tp_tool.get(Project) is CustomTPTool
+    assert isinstance(project0.tp_tool, CustomTPTool)


### PR DESCRIPTION
allows us to reassign/clone/update a tp to a different language (and does the required path-fu)

this is required to be able to create a testable migration for template tps, and for monolingual support

it will also be useful in the future for copying/cloning/moving tps more generally