### PR TITLE
Cleanup: renames of 'obj' and 'split_pootle_path

### DIFF
--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -131,17 +131,17 @@ class Directory(models.Model, CachedTreeItem):
         return l(self.pootle_path)
 
     def get_translate_url(self, **kwargs):
-        lang, proj, dir_path = split_pootle_path(self.pootle_path)[:3]
+        lang_code, proj_code, dir_path = split_pootle_path(self.pootle_path)[:3]
 
-        if lang and proj:
+        if lang_code and proj_code:
             pattern_name = 'pootle-tp-translate'
-            pattern_args = [lang, proj, dir_path]
-        elif lang:
+            pattern_args = [lang_code, proj_code, dir_path]
+        elif lang_code:
             pattern_name = 'pootle-language-translate'
-            pattern_args = [lang]
-        elif proj:
+            pattern_args = [lang_code]
+        elif proj_code:
             pattern_name = 'pootle-project-translate'
-            pattern_args = [proj]
+            pattern_args = [proj_code]
         else:
             pattern_name = 'pootle-projects-translate'
             pattern_args = []

--- a/pootle/apps/pootle_comment/forms.py
+++ b/pootle/apps/pootle_comment/forms.py
@@ -52,13 +52,13 @@ class CommentForm(DjCommentForm):
             raise CommentNotSaved(dict(comment=should_not_save))
 
     def save(self):
-        ob = self.comment
-        ob.user = self.cleaned_data["user"]
-        ob.submit_date = datetime.now()
-        ob.save()
+        comment = self.comment
+        comment.user = self.cleaned_data["user"]
+        comment.submit_date = datetime.now()
+        comment.save()
         comment_was_saved.send(
-            sender=ob.__class__,
-            comment=ob)
+            sender=comment.__class__,
+            comment=comment)
 
 
 class UnsecuredCommentForm(CommentForm):

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -143,11 +143,11 @@ class ProjectURLMixin(object):
     """
 
     def get_absolute_url(self):
-        proj = split_pootle_path(self.pootle_path)[1]
+        proj_code = split_pootle_path(self.pootle_path)[1]
 
-        if proj is not None:
+        if proj_code is not None:
             pattern_name = 'pootle-project-browse'
-            pattern_args = [proj, '']
+            pattern_args = [proj_code, '']
         else:
             pattern_name = 'pootle-projects-browse'
             pattern_args = []
@@ -155,11 +155,11 @@ class ProjectURLMixin(object):
         return reverse(pattern_name, args=pattern_args)
 
     def get_translate_url(self, **kwargs):
-        proj, dir_path, fn = split_pootle_path(self.pootle_path)[1:]
+        proj_code, dir_path, filename = split_pootle_path(self.pootle_path)[1:]
 
-        if proj is not None:
+        if proj_code is not None:
             pattern_name = 'pootle-project-translate'
-            pattern_args = [proj, dir_path, fn]
+            pattern_args = [proj_code, dir_path, filename]
         else:
             pattern_name = 'pootle-projects-translate'
             pattern_args = []
@@ -583,9 +583,9 @@ def invalidate_resources_cache(**kwargs):
         (not kwargs['created'] or kwargs['raw'])):
         return
 
-    proj = split_pootle_path(instance.pootle_path)[1]
-    if proj is not None:
-        cache.delete(make_method_key(Project, 'resources', proj))
+    proj_code = split_pootle_path(instance.pootle_path)[1]
+    if proj_code is not None:
+        cache.delete(make_method_key(Project, 'resources', proj_code))
 
 
 @receiver([post_delete, post_save])

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -558,14 +558,14 @@ class UnitSearchForm(forms.Form):
         return self.cleaned_data["user"] or self.request_user
 
     def clean_path(self):
-        language_code, project_code = split_pootle_path(
+        lang_code, proj_code = split_pootle_path(
             self.cleaned_data["path"])[:2]
-        if not (language_code or project_code):
+        if not (lang_code or proj_code):
             permission_context = Directory.objects.projects
-        elif project_code and not language_code:
+        elif proj_code and not lang_code:
             try:
                 permission_context = Project.objects.select_related(
-                    "directory").get(code=project_code).directory
+                    "directory").get(code=proj_code).directory
             except Project.DoesNotExist:
                 raise forms.ValidationError("Unrecognized path")
         else:

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -557,10 +557,12 @@ class Unit(models.Model, base.TranslationUnit):
                '#unit=%s' % unicode(self.id)))
 
     def get_search_locations_url(self, **kwargs):
-        proj, dir_path, fn = split_pootle_path(self.store.pootle_path)[1:]
+        (proj_code, dir_path,
+         filename) = split_pootle_path(self.store.pootle_path)[1:]
 
         return u''.join([
-            reverse('pootle-project-translate', args=[proj, dir_path, fn]),
+            reverse('pootle-project-translate',
+                    args=[proj_code, dir_path, filename]),
             get_editor_filter(search=self.locations, sfields='locations'),
         ])
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -439,10 +439,10 @@ class CachedTreeItem(TreeItem):
             if path == '/':
                 return True
 
-            prj = split_pootle_path(path)[1]
+            proj_code = split_pootle_path(path)[1]
             key = self.get_cachekey()
 
-            return key in path or path in key or key in '/projects/%s/' % prj
+            return key in path or path in key or key in '/projects/%s/' % proj_code
 
         return False
 

--- a/pootle/core/views.py
+++ b/pootle/core/views.py
@@ -698,10 +698,10 @@ class PootleBrowseView(PootleDetailView):
         ctx.update(
             super(PootleBrowseView, self).get_context_data(*args, **kwargs))
 
-        language_code, project_code = split_pootle_path(self.pootle_path)[:2]
+        lang_code, proj_code = split_pootle_path(self.pootle_path)[:2]
         top_scorers = User.top_scorers(
-            project=project_code,
-            language=language_code,
+            project=proj_code,
+            language=lang_code,
             limit=TOP_CONTRIBUTORS_CHUNK_SIZE + 1,
         )
 

--- a/pytest_pootle/fixtures/pootle_fs/state.py
+++ b/pytest_pootle/fixtures/pootle_fs/state.py
@@ -68,11 +68,11 @@ class DummyPlugin(object):
     def get_fs_path(self, pootle_path):
         from pootle.core.url_helpers import split_pootle_path
 
-        lang_code, proj_code_, dir_path, fn = split_pootle_path(pootle_path)
+        lang_code, proj_code_, dir_path, filename = split_pootle_path(pootle_path)
         parts = ["", lang_code]
         if dir_path:
             parts.append(dir_path.rstrip("/"))
-        parts.append(fn)
+        parts.append(filename)
         return "/".join(parts)
 
 

--- a/tests/misc/state.py
+++ b/tests/misc/state.py
@@ -191,7 +191,7 @@ def test_state_bad():
         def state_foo(self, **kwargs):
             yield []
 
-    # context.state_* methods should yield dict-like ob
+    # context.state_* methods should yield dict-like object
     with pytest.raises(TypeError):
         ContextualState(DummyContext())
 

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -90,14 +90,14 @@ def _test_browse_view(project, request, response, kwargs):
         "%s/%s"
         % (kwargs["project_code"], resource_path))
     if not (kwargs["dir_path"] or kwargs["filename"]):
-        ob = project
+        obj = project
     elif not kwargs["filename"]:
-        ob = ProjectResource(
+        obj = ProjectResource(
             Directory.objects.live().filter(
                 pootle_path__regex="^/.*/%s$" % project_path),
             pootle_path="/projects/%s" % project_path)
     else:
-        ob = ProjectResource(
+        obj = ProjectResource(
             Store.objects.live().filter(
                 pootle_path__regex="^/.*/%s$" % project_path),
             pootle_path="/projects/%s" % project_path)
@@ -110,7 +110,7 @@ def _test_browse_view(project, request, response, kwargs):
     items = [
         item_func(item)
         for item
-        in ob.get_children_for_user(request.user)
+        in obj.get_children_for_user(request.user)
     ]
     items.sort(lambda x, y: locale.strcoll(x['title'], y['title']))
 
@@ -123,10 +123,10 @@ def _test_browse_view(project, request, response, kwargs):
         'items': items}
 
     if request.user.is_superuser or kwargs.get("language_code"):
-        url_action_continue = ob.get_translate_url(state='incomplete')
-        url_action_fixcritical = ob.get_critical_url()
-        url_action_review = ob.get_translate_url(state='suggestions')
-        url_action_view_all = ob.get_translate_url(state='all')
+        url_action_continue = obj.get_translate_url(state='incomplete')
+        url_action_fixcritical = obj.get_critical_url()
+        url_action_review = obj.get_translate_url(state='suggestions')
+        url_action_view_all = obj.get_translate_url(state='all')
     else:
         (url_action_continue,
          url_action_fixcritical,
@@ -146,12 +146,12 @@ def _test_browse_view(project, request, response, kwargs):
         url_action_fixcritical=url_action_fixcritical,
         url_action_review=url_action_review,
         url_action_view_all=url_action_view_all,
-        translation_states=get_translation_states(ob),
-        checks=get_qualitycheck_list(ob),
+        translation_states=get_translation_states(obj),
+        checks=get_qualitycheck_list(obj),
         table=table,
         top_scorers=top_scorers,
         top_scorers_data=get_top_scorers_data(top_scorers, 10),
-        stats=ob.get_stats(),
+        stats=obj.get_stats(),
     )
     sidebar = get_sidebar_announcements_context(
         request, (project, ))
@@ -219,10 +219,10 @@ def test_view_projects_browse(client, request_users):
     user_projects = (
         Project.objects.for_user(request.user)
                        .filter(code__in=user_projects))
-    ob = ProjectSet(user_projects)
+    obj = ProjectSet(user_projects)
     items = [
         make_project_list_item(project)
-        for project in ob.children]
+        for project in obj.children]
     items.sort(lambda x, y: locale.strcoll(x['title'], y['title']))
     table_fields = [
         'name', 'progress', 'total', 'need-translation',
@@ -234,10 +234,10 @@ def test_view_projects_browse(client, request_users):
         'items': items}
 
     if request.user.is_superuser:
-        url_action_continue = ob.get_translate_url(state='incomplete')
-        url_action_fixcritical = ob.get_critical_url()
-        url_action_review = ob.get_translate_url(state='suggestions')
-        url_action_view_all = ob.get_translate_url(state='all')
+        url_action_continue = obj.get_translate_url(state='incomplete')
+        url_action_fixcritical = obj.get_critical_url()
+        url_action_review = obj.get_translate_url(state='suggestions')
+        url_action_view_all = obj.get_translate_url(state='all')
     else:
         (url_action_continue,
          url_action_fixcritical,
@@ -251,14 +251,14 @@ def test_view_projects_browse(client, request_users):
         pootle_path="/projects/",
         resource_path="",
         resource_path_parts=[],
-        object=ob,
+        object=obj,
         table=table,
         browser_extends="projects/all/base.html",
-        stats=ob.get_stats(),
-        checks=get_qualitycheck_list(ob),
+        stats=obj.get_stats(),
+        checks=get_qualitycheck_list(obj),
         top_scorers=top_scorers,
         top_scorers_data=get_top_scorers_data(top_scorers, 10),
-        translation_states=get_translation_states(ob),
+        translation_states=get_translation_states(obj),
         url_action_continue=url_action_continue,
         url_action_fixcritical=url_action_fixcritical,
         url_action_review=url_action_review,

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -53,15 +53,15 @@ def _test_browse_view(tp, request, response, kwargs):
     pootle_path = "%s%s" % (tp.pootle_path, resource_path)
 
     if not (kwargs["dir_path"] or kwargs.get("filename")):
-        ob = tp.directory
+        obj = tp.directory
     elif not kwargs.get("filename"):
-        ob = Directory.objects.get(
+        obj = Directory.objects.get(
             pootle_path=pootle_path)
     else:
-        ob = Store.objects.get(
+        obj = Store.objects.get(
             pootle_path=pootle_path)
     if not kwargs.get("filename"):
-        vftis = ob.vf_treeitems.select_related("vfolder")
+        vftis = obj.vf_treeitems.select_related("vfolder")
         if not ctx["has_admin_access"]:
             vftis = vftis.filter(vfolder__is_public=True)
         vfolders = [
@@ -76,18 +76,18 @@ def _test_browse_view(tp, request, response, kwargs):
                 vfolder_treeitem['code']] = vfolder_treeitem["stats"]
             del vfolder_treeitem["stats"]
         if stats["vfolders"]:
-            stats.update(ob.get_stats())
+            stats.update(obj.get_stats())
         else:
-            stats = ob.get_stats()
+            stats = obj.get_stats()
     else:
-        stats = ob.get_stats()
+        stats = obj.get_stats()
         vfolders = None
 
     filters = {}
     if vfolders:
         filters['sort'] = 'priority'
 
-    dirs_with_vfolders = vftis_for_child_dirs(ob).values_list(
+    dirs_with_vfolders = vftis_for_child_dirs(obj).values_list(
         "directory__pk", flat=True)
     directories = [
         make_directory_item(
@@ -95,11 +95,11 @@ def _test_browse_view(tp, request, response, kwargs):
             **(dict(sort="priority")
                if child.pk in dirs_with_vfolders
                else {}))
-        for child in ob.get_children()
+        for child in obj.get_children()
         if isinstance(child, Directory)]
     stores = [
         make_store_item(child)
-        for child in ob.get_children()
+        for child in obj.get_children()
         if isinstance(child, Store)]
 
     if not kwargs.get("filename"):
@@ -119,7 +119,7 @@ def _test_browse_view(tp, request, response, kwargs):
                                    project=tp.project.code, limit=11)
     assertions = dict(
         page="browse",
-        object=ob,
+        object=obj,
         translation_project=tp,
         language=tp.language,
         project=tp.project,
@@ -129,18 +129,18 @@ def _test_browse_view(tp, request, response, kwargs):
         pootle_path=pootle_path,
         resource_path=resource_path,
         resource_path_parts=get_path_parts(resource_path),
-        translation_states=get_translation_states(ob),
-        checks=get_qualitycheck_list(ob),
+        translation_states=get_translation_states(obj),
+        checks=get_qualitycheck_list(obj),
         top_scorers=top_scorers,
         top_scorers_data=get_top_scorers_data(top_scorers, 10),
-        url_action_continue=ob.get_translate_url(
+        url_action_continue=obj.get_translate_url(
             state='incomplete', **filters),
-        url_action_fixcritical=ob.get_critical_url(**filters),
-        url_action_review=ob.get_translate_url(
+        url_action_fixcritical=obj.get_critical_url(**filters),
+        url_action_review=obj.get_translate_url(
             state='suggestions', **filters),
-        url_action_view_all=ob.get_translate_url(state='all'),
+        url_action_view_all=obj.get_translate_url(state='all'),
         stats=stats,
-        parent=get_parent(ob))
+        parent=get_parent(obj))
     if table:
         assertions["table"] = table
     sidebar = get_sidebar_announcements_context(


### PR DESCRIPTION
* Since `object` is a builtin in Python, prefer `obj` instead of `ob`
* `split_pootle_path` has various naming conventions for the returned values.  Renamed `lang`, `proj`, `dir`, `fn` to more explicit `lang_code`, `proj_code`, `dir_path` (avoids a builtin also), `filename`.  Where `language_code` or `project_code` i.e. in fullform exists I've changed some but left others where the code felt too complicated to intervene.