### PR TITLE
Fix: only use live units in StoreDiff.source_db_store

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -110,7 +110,7 @@ class DiffableStore(object):
     @cached_property
     def source_units(self):
         if isinstance(self.source_store, models.Model):
-            return self.get_db_units(self.source_store.unit_set)
+            return self.get_db_units(self.source_store.unit_set.live())
         return self.get_file_units(self.source_store.units)
 
     @property

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -1062,7 +1062,7 @@ def test_store_diff_delete_source_unit(diffable_stores):
         target_store,
         source_store,
         target_store.get_max_unit_revision() - 1)
-    result = differ.diff()
+    assert not differ.diff()
 
 
 @pytest.mark.django_db

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -1189,3 +1189,21 @@ def test_store_diff_custom(diffable_stores):
 
     assert isinstance(
         differ.diffable, CustomDiffableStore)
+
+
+@pytest.mark.django_db
+def test_store_diff_delete_obsoleted_source_unit(diffable_stores):
+    target_store, source_store = diffable_stores
+    # delete a unit in the target store
+    remove_unit = target_store.units.first()
+    remove_unit.delete()
+    # and obsolete the same unit in the target
+    obsolete_unit = source_store.units.get(unitid=remove_unit.unitid)
+    obsolete_unit.makeobsolete()
+    obsolete_unit.save()
+    # as the unit is already obsolete - nothing
+    differ = StoreDiff(
+        target_store,
+        source_store,
+        target_store.get_max_unit_revision() + 1)
+    assert not differ.diff()


### PR DESCRIPTION
when doing a diff from a db Store with obsolete units it was trying to readd them to target