### PR TITLE
Fix broken admin URLs

### DIFF
--- a/pootle/apps/pootle_app/urls.py
+++ b/pootle/apps/pootle_app/urls.py
@@ -12,7 +12,7 @@ from .views.admin import urls as admin_urls
 
 
 urlpatterns = [
-    url(r'^admin',
+    url(r'^admin/',
         include(admin_urls)),
     url(r'^xhr/admin/',
         include(admin_urls.api_patterns)),


### PR DESCRIPTION
Now we can use /admin/languages/ instead of /adminlanguages/

This was exposed by 3bef6f52.