### PR TITLE
Cleanup pootle_store

### DIFF
--- a/pootle/apps/accounts/utils.py
+++ b/pootle/apps/accounts/utils.py
@@ -17,8 +17,8 @@ from django.db.models import Count
 from allauth.account.models import EmailAddress
 from allauth.account.utils import sync_user_email_addresses
 
+from pootle_store.constants import FUZZY, UNTRANSLATED
 from pootle_store.models import SuggestionStates
-from pootle_store.util import FUZZY, UNTRANSLATED
 
 
 logger = logging.getLogger(__name__)

--- a/pootle/apps/accounts/utils.py
+++ b/pootle/apps/accounts/utils.py
@@ -18,7 +18,7 @@ from allauth.account.models import EmailAddress
 from allauth.account.utils import sync_user_email_addresses
 
 from pootle_store.constants import FUZZY, UNTRANSLATED
-from pootle_store.models import SuggestionStates
+from pootle_store.util import SuggestionStates
 
 
 logger = logging.getLogger(__name__)

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -24,8 +24,8 @@ from pootle.core.decorators import admin_required
 from pootle.core.utils.aggregate import sum_column
 from pootle.i18n.gettext import ugettext as _, ungettext
 from pootle_statistics.models import Submission
+from pootle_store.constants import TRANSLATED
 from pootle_store.models import Suggestion, Unit
-from pootle_store.util import TRANSLATED
 
 
 def _format_numbers(numbers):

--- a/pootle/apps/pootle_fs/abstracts.py
+++ b/pootle/apps/pootle_fs/abstracts.py
@@ -11,7 +11,8 @@ from django.utils.functional import cached_property
 
 from pootle.core.exceptions import MissingPluginError, NotConfiguredError
 from pootle_project.models import Project
-from pootle_store.models import POOTLE_WINS, SOURCE_WINS, Store
+from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
+from pootle_store.models import Store
 
 from .delegate import fs_file
 from .managers import StoreFSManager, validate_store_fs

--- a/pootle/apps/pootle_fs/files.py
+++ b/pootle/apps/pootle_fs/files.py
@@ -18,7 +18,8 @@ from django.utils.functional import cached_property
 
 from pootle.core.models import Revision
 from pootle_statistics.models import SubmissionTypes
-from pootle_store.models import POOTLE_WINS, SOURCE_WINS, Store
+from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
+from pootle_store.models import Store
 
 
 logger = logging.getLogger(__name__)

--- a/pootle/apps/pootle_fs/plugin.py
+++ b/pootle/apps/pootle_fs/plugin.py
@@ -16,7 +16,8 @@ from django.utils.lru_cache import lru_cache
 
 from pootle.core.delegate import (
     config, response as pootle_response, state as pootle_state)
-from pootle_store.models import POOTLE_WINS, SOURCE_WINS, Store
+from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
+from pootle_store.models import Store
 from pootle_project.models import Project
 
 from .decorators import emits_state, responds_to_state

--- a/pootle/apps/pootle_fs/state.py
+++ b/pootle/apps/pootle_fs/state.py
@@ -13,7 +13,7 @@ from django.utils.functional import cached_property
 from django.utils.lru_cache import lru_cache
 
 from pootle.core.state import ItemState, State
-from pootle_store.models import POOTLE_WINS, SOURCE_WINS
+from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
 
 from .resources import FSProjectStateResources
 

--- a/pootle/apps/pootle_statistics/models.py
+++ b/pootle/apps/pootle_statistics/models.py
@@ -18,8 +18,8 @@ from django.utils.translation import ugettext_lazy as _
 from pootle.core.log import SCORE_CHANGED, log
 from pootle.core.utils import dateformat
 from pootle_misc.checks import check_names
+from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
 from pootle_store.fields import to_python
-from pootle_store.util import FUZZY, TRANSLATED, UNTRANSLATED
 
 
 SIMILARITY_THRESHOLD = 0.5

--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -28,3 +28,21 @@ ALLOWED_SORTS = {
 #: List of fields from `ALLOWED_SORTS` that can be sorted by simply using
 #: `order_by(field)`
 SIMPLY_SORTED = ['units']
+
+#
+# Store States
+#
+
+# Store just created, not parsed yet
+NEW = 0
+# Store just parsed, units added but no quality checks were run
+PARSED = 1
+# Quality checks run
+CHECKED = 2
+
+# Resolve conflict flags for Store.update
+POOTLE_WINS = 1
+SOURCE_WINS = 2
+
+LANGUAGE_REGEX = r"[^/]{2,255}"
+PROJECT_REGEX = r"[^/]{1,255}"

--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -6,6 +6,9 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from django.utils.translation import ugettext_lazy as _
+
+
 #: Mapping of allowed sorting criteria.
 #: Keys are supported query strings, values are the field + order that
 #: will be used against the DB.
@@ -46,3 +49,27 @@ SOURCE_WINS = 2
 
 LANGUAGE_REGEX = r"[^/]{2,255}"
 PROJECT_REGEX = r"[^/]{1,255}"
+
+# Unit States
+#: Unit is no longer part of the store
+OBSOLETE = -100
+#: Empty unit
+UNTRANSLATED = 0
+#: Marked as fuzzy, typically means translation needs more work
+FUZZY = 50
+#: Unit is fully translated
+TRANSLATED = 200
+
+# Map for retrieving natural names for unit states
+STATES_MAP = {
+    OBSOLETE: _("Obsolete"),
+    UNTRANSLATED: _("Untranslated"),
+    FUZZY: _("Needs work"),
+    TRANSLATED: _("Translated"),
+}
+
+STATES_NAMES = {
+    OBSOLETE: "obsolete",
+    UNTRANSLATED: "untranslated",
+    FUZZY: "fuzzy",
+    TRANSLATED: "translated"}

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -14,9 +14,9 @@ from django.utils.functional import cached_property
 
 from pootle.core.delegate import format_diffs
 
+from .constants import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 from .fields import to_python as multistring_to_python
 from .unit import UnitProxy
-from .util import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 
 
 class UnitDiffProxy(UnitProxy):

--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -32,13 +32,12 @@ from pootle_project.models import Project
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 
-from .constants import ALLOWED_SORTS
+from .constants import ALLOWED_SORTS, FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 from .fields import to_db
 from .form_fields import (
     CategoryChoiceField, ISODateTimeField, MultipleArgsField,
     CommaSeparatedCheckboxSelectMultiple)
 from .models import Unit, Suggestion
-from .util import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 
 
 EXPORT_VIEW_QUERY_LIMIT = 10000

--- a/pootle/apps/pootle_store/managers.py
+++ b/pootle/apps/pootle_store/managers.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.db import models
+
+from pootle.core.url_helpers import split_pootle_path
+from pootle_app.models import Directory
+
+from .constants import LANGUAGE_REGEX, OBSOLETE, PROJECT_REGEX
+from .util import SuggestionStates
+
+
+class SuggestionManager(models.Manager):
+
+    def pending(self):
+        return self.get_queryset().filter(state=SuggestionStates.PENDING)
+
+
+class UnitManager(models.Manager):
+
+    def live(self):
+        """Filters non-obsolete units."""
+        return self.filter(state__gt=OBSOLETE)
+
+    def get_for_user(self, user):
+        """Filters units for a specific user.
+
+        - Admins always get all non-obsolete units
+        - Regular users only get units from enabled projects accessible
+            to them.
+
+        :param user: The user for whom units need to be retrieved for.
+        :return: A filtered queryset with `Unit`s for `user`.
+        """
+        from pootle_project.models import Project
+
+        if user.is_superuser:
+            return self.live()
+
+        user_projects = Project.accessible_by_user(user)
+        filter_by = {
+            "store__translation_project__project__disabled": False,
+            "store__translation_project__project__code__in": user_projects
+        }
+        return self.live().filter(**filter_by)
+
+    def get_translatable(self, user, project_code=None, language_code=None,
+                         dir_path=None, filename=None):
+        """Returns translatable units for a `user`, optionally filtered by their
+        location within Pootle.
+
+        :param user: The user who is accessing the units.
+        :param project_code: A string for matching the code of a Project.
+        :param language_code: A string for matching the code of a Language.
+        :param dir_path: A string for matching the dir_path and descendants
+           from the TP.
+        :param filename: A string for matching the filename of Stores.
+        """
+
+        units_qs = self.get_for_user(user)
+
+        if language_code:
+            units_qs = units_qs.filter(
+                store__translation_project__language__code=language_code)
+        else:
+            units_qs = units_qs.exclude(
+                store__pootle_path__startswith="/templates/")
+
+        if project_code:
+            units_qs = units_qs.filter(
+                store__translation_project__project__code=project_code)
+
+        if not (dir_path or filename):
+            return units_qs
+
+        pootle_path = "/%s/%s/%s%s" % (
+            language_code or LANGUAGE_REGEX,
+            project_code or PROJECT_REGEX,
+            dir_path or "",
+            filename or "")
+        if language_code and project_code:
+            if filename:
+                return units_qs.filter(
+                    store__pootle_path=pootle_path)
+            else:
+                return units_qs.filter(
+                    store__pootle_path__startswith=pootle_path)
+        else:
+            # we need to use a regex in this case as lang or proj are not
+            # set
+            if filename:
+                pootle_path = "%s$" % pootle_path
+            return units_qs.filter(
+                store__pootle_path__regex=pootle_path)
+
+
+class StoreManager(models.Manager):
+    use_for_related_fields = True
+
+    def live(self):
+        """Filters non-obsolete stores."""
+        return self.filter(obsolete=False)
+
+    def create(self, *args, **kwargs):
+        if "filetype" not in kwargs:
+            filetypes = kwargs["translation_project"].project.filetype_tool
+            kwargs['filetype'] = filetypes.choose_filetype(kwargs["name"])
+        if kwargs["translation_project"].is_template_project:
+            kwargs["is_template"] = True
+        kwargs["pootle_path"] = (
+            "%s%s"
+            % (kwargs["parent"].pootle_path, kwargs["name"]))
+        return super(StoreManager, self).create(*args, **kwargs)
+
+    def get_or_create(self, *args, **kwargs):
+        store, created = super(StoreManager, self).get_or_create(*args, **kwargs)
+        if not created:
+            return store, created
+        update = False
+        if store.translation_project.is_template_project:
+            store.is_template = True
+            update = True
+        if "filetype" not in kwargs:
+            filetypes = store.translation_project.project.filetype_tool
+            store.filetype = filetypes.choose_filetype(store.name)
+            update = True
+        if update:
+            store.save()
+        return store, created
+
+    def create_by_path(self, pootle_path, project=None,
+                       create_tp=True, create_directory=True, **kwargs):
+        from pootle_language.models import Language
+        from pootle_project.models import Project
+
+        (lang_code, proj_code,
+         dir_path, filename) = split_pootle_path(pootle_path)
+
+        ext = filename.split(".")[-1]
+
+        if project is None:
+            project = Project.objects.get(code=proj_code)
+        elif project.code != proj_code:
+            raise ValueError(
+                "Project must match pootle_path when provided")
+        if ext not in project.filetype_tool.valid_extensions:
+            raise ValueError(
+                "'%s' is not a valid extension for this Project"
+                % ext)
+        if create_tp:
+            tp, created = (
+                project.translationproject_set.get_or_create(
+                    language=Language.objects.get(code=lang_code)))
+        elif create_directory or not dir_path:
+            tp = project.translationproject_set.get(
+                language__code=lang_code)
+        if dir_path:
+            if not create_directory:
+                parent = Directory.objects.get(
+                    pootle_path="/".join(
+                        ["", lang_code, proj_code, dir_path]))
+            else:
+                parent = tp.directory
+                for child in dir_path.strip("/").split("/"):
+                    parent, created = Directory.objects.get_or_create(
+                        name=child, parent=parent)
+        else:
+            parent = tp.directory
+
+        store, created = self.get_or_create(
+            name=filename, parent=parent, translation_project=tp, **kwargs)
+        if created:
+            store.mark_all_dirty()
+        return store

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -55,16 +55,14 @@ from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 
 from .constants import (
-    NEW, PARSED, POOTLE_WINS,
-    LANGUAGE_REGEX, PROJECT_REGEX)
+    FUZZY, LANGUAGE_REGEX, NEW, OBSOLETE, PARSED, POOTLE_WINS,
+    PROJECT_REGEX, TRANSLATED, UNTRANSLATED)
 from .diff import StoreDiff
 from .fields import (PLURAL_PLACEHOLDER, SEPARATOR, MultiStringField,
                      TranslationStoreField)
 from .store.deserialize import StoreDeserialization
 from .store.serialize import StoreSerialization
-from .util import (
-    FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED, get_change_str,
-    vfolders_installed)
+from .util import get_change_str, vfolders_installed
 
 
 TM_BROKER = None

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -54,6 +54,9 @@ from pootle_misc.util import import_func
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 
+from .constants import (
+    NEW, PARSED, POOTLE_WINS,
+    LANGUAGE_REGEX, PROJECT_REGEX)
 from .diff import StoreDiff
 from .fields import (PLURAL_PLACEHOLDER, SEPARATOR, MultiStringField,
                      TranslationStoreField)
@@ -72,24 +75,6 @@ def get_tm_broker():
     if TM_BROKER is None:
         TM_BROKER = SearchBroker()
     return TM_BROKER
-
-#
-# Store States
-#
-
-# Store just created, not parsed yet
-NEW = 0
-# Store just parsed, units added but no quality checks were run
-PARSED = 1
-# Quality checks run
-CHECKED = 2
-
-# Resolve conflict flags for Store.update
-POOTLE_WINS = 1
-SOURCE_WINS = 2
-
-LANGUAGE_REGEX = r"[^/]{2,255}"
-PROJECT_REGEX = r"[^/]{1,255}"
 
 
 # # # # # # # # Quality Check # # # # # # #

--- a/pootle/apps/pootle_store/unit/filters.py
+++ b/pootle/apps/pootle_store/unit/filters.py
@@ -9,8 +9,8 @@
 from django.db.models import Q
 
 from pootle_statistics.models import SubmissionTypes
+from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
 from pootle_store.models import SuggestionStates
-from pootle_store.util import FUZZY, TRANSLATED, UNTRANSLATED
 
 
 class FilterNotFound(Exception):

--- a/pootle/apps/pootle_store/unit/filters.py
+++ b/pootle/apps/pootle_store/unit/filters.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 
 from pootle_statistics.models import SubmissionTypes
 from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
-from pootle_store.models import SuggestionStates
+from pootle_store.util import SuggestionStates
 
 
 class FilterNotFound(Exception):

--- a/pootle/apps/pootle_store/unit/results.py
+++ b/pootle/apps/pootle_store/unit/results.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 
 from pootle.core.url_helpers import split_pootle_path
 from pootle.i18n.gettext import language_dir
-from pootle_store.models import FUZZY
+from pootle_store.constants import FUZZY
 from pootle_store.templatetags.store_tags import (
     pluralize_source, pluralize_target)
 from pootle_store.unit.proxy import UnitProxy

--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -22,9 +22,9 @@ from pootle_misc.checks import check_names
 from pootle_statistics.models import (
     Submission, SubmissionFields, SubmissionTypes)
 
+from pootle_store.constants import STATES_MAP
 from pootle_store.fields import to_python
 from pootle_store.models import Suggestion
-from pootle_store.util import STATES_MAP
 
 
 class DisplayUser(object):

--- a/pootle/apps/pootle_store/util.py
+++ b/pootle/apps/pootle_store/util.py
@@ -9,32 +9,8 @@
 import os
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
 
-
-# Unit States
-#: Unit is no longer part of the store
-OBSOLETE = -100
-#: Empty unit
-UNTRANSLATED = 0
-#: Marked as fuzzy, typically means translation needs more work
-FUZZY = 50
-#: Unit is fully translated
-TRANSLATED = 200
-
-# Map for retrieving natural names for unit states
-STATES_MAP = {
-    OBSOLETE: _("Obsolete"),
-    UNTRANSLATED: _("Untranslated"),
-    FUZZY: _("Needs work"),
-    TRANSLATED: _("Translated"),
-}
-
-STATES_NAMES = {
-    OBSOLETE: "obsolete",
-    UNTRANSLATED: "untranslated",
-    FUZZY: "fuzzy",
-    TRANSLATED: "translated"}
+from .constants import STATES_NAMES, TRANSLATED
 
 
 def add_trailing_slash(path):

--- a/pootle/apps/pootle_store/util.py
+++ b/pootle/apps/pootle_store/util.py
@@ -13,6 +13,12 @@ from django.conf import settings
 from .constants import STATES_NAMES, TRANSLATED
 
 
+class SuggestionStates(object):
+    PENDING = 'pending'
+    ACCEPTED = 'accepted'
+    REJECTED = 'rejected'
+
+
 def add_trailing_slash(path):
     """If path does not end with /, add it and return."""
 

--- a/pootle/apps/pootle_translationproject/migrations/0002_remove_translationproject_disabled.py
+++ b/pootle/apps/pootle_translationproject/migrations/0002_remove_translationproject_disabled.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 
-from pootle_store.util import OBSOLETE
+from pootle_store.constants import OBSOLETE
 
 
 def make_tp_directories_obsolete(apps, schema_editor):

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -26,7 +26,8 @@ from pootle_format.models import Format
 from pootle_language.models import Language
 from pootle_misc.checks import excluded_filters
 from pootle_project.models import Project
-from pootle_store.models import PARSED, Store
+from pootle_store.constants import PARSED
+from pootle_store.models import Store
 from pootle_store.util import absolute_real_path, relative_real_path
 from staticpages.models import StaticPage
 

--- a/pootle/apps/pootle_translationproject/utils.py
+++ b/pootle/apps/pootle_translationproject/utils.py
@@ -11,8 +11,9 @@ from django.contrib.auth import get_user_model
 from pootle.core.models import Revision
 from pootle_app.models import Directory
 from pootle_statistics.models import SubmissionTypes
+from pootle_store.constants import SOURCE_WINS
 from pootle_store.diff import StoreDiff
-from pootle_store.models import SOURCE_WINS, Store
+from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
 
 

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -19,8 +19,8 @@ from pootle.core.url_helpers import (get_all_pootle_paths, get_editor_filter,
 from pootle_app.models import Directory
 from pootle_language.models import Language
 from pootle_project.models import Project
+from pootle_store.constants import OBSOLETE
 from pootle_store.models import Store, Unit
-from pootle_store.util import OBSOLETE
 
 from .signals import vfolder_post_save
 

--- a/pootle/apps/virtualfolder/receivers.py
+++ b/pootle/apps/virtualfolder/receivers.py
@@ -9,8 +9,8 @@
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
+from pootle_store.constants import OBSOLETE
 from pootle_store.models import Unit
-from pootle_store.util import OBSOLETE
 
 from .models import VirtualFolder, VirtualFolderTreeItem
 from .signals import vfolder_post_save

--- a/pootle/core/checks/checker.py
+++ b/pootle/core/checks/checker.py
@@ -17,9 +17,9 @@ from django.utils.lru_cache import lru_cache
 from pootle.core.mixins.treeitem import CachedMethods
 from pootle_misc.checks import run_given_filters
 from pootle_misc.util import import_func
+from pootle_store.constants import OBSOLETE
 from pootle_store.models import QualityCheck, Store, Unit
 from pootle_store.unit import UnitProxy
-from pootle_store.util import OBSOLETE
 from pootle_translationproject.models import TranslationProject
 
 

--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -350,7 +350,7 @@ class PootleTestEnv(object):
     def _add_stores(self, tp, n=(3, 2), parent=None):
         from pytest_pootle.factories import StoreDBFactory, UnitDBFactory
 
-        from pootle_store.models import UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE
+        from pootle_store.constants import UNTRANSLATED, TRANSLATED, FUZZY, OBSOLETE
 
         for i_ in range(0, n[0]):
             # add 3 stores
@@ -375,7 +375,8 @@ class PootleTestEnv(object):
 
     def _add_submissions(self, unit, created):
         from pootle_statistics.models import SubmissionTypes
-        from pootle_store.models import UNTRANSLATED, FUZZY, OBSOLETE, Unit
+        from pootle_store.constants import UNTRANSLATED, FUZZY, OBSOLETE
+        from pootle_store.models import Unit
 
         from django.contrib.auth import get_user_model
         from django.utils import timezone

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -151,7 +151,7 @@ class UnitDBFactory(factory.django.DjangoModelFactory):
     class Meta(object):
         model = 'pootle_store.Unit'
 
-    state = pootle_store.util.UNTRANSLATED
+    state = pootle_store.constants.UNTRANSLATED
 
     @factory.lazy_attribute
     def index(self):

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -249,7 +249,7 @@ def _create_comment_on_unit(unit, user, comment):
 
 
 def _mark_unit_fuzzy(unit, user):
-    from pootle_store.util import FUZZY
+    from pootle_store.constants import FUZZY
     from pootle_statistics.models import (Submission, SubmissionFields,
                                           SubmissionTypes)
     sub = Submission(

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -114,7 +114,7 @@ UPDATE_STORE_TESTS['max_obsolete'] = {
 
 
 def _setup_store_test(store, member, member2, test):
-    from pootle_store.models import POOTLE_WINS, SOURCE_WINS
+    from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
 
     setup = test.get("setup", None)
 
@@ -177,7 +177,8 @@ def param_update_store_test(request, en_tutorial_po, member, member2):
 
 def _require_store(tp, po_dir, name):
     """Helper to get/create a new store."""
-    from pootle_store.models import PARSED, Store
+    from pootle_store.constants import PARSED
+    from pootle_store.models import Store
 
     file_path = os.path.join(po_dir, tp.real_path, name)
     parent_dir = tp.directory

--- a/pytest_pootle/fixtures/pootle_fs/plugin.py
+++ b/pytest_pootle/fixtures/pootle_fs/plugin.py
@@ -328,7 +328,7 @@ def localfs_merge_pootle_wins(localfs, localfs_dummy_finder):
 
 @pytest.fixture
 def localfs_merge_fs_wins(localfs, localfs_dummy_finder):
-    from pootle_store.models import SOURCE_WINS
+    from pootle_store.constants import SOURCE_WINS
 
     plugin = localfs
 
@@ -434,7 +434,7 @@ def localfs_force_added(localfs, localfs_dummy_finder):
 
 @pytest.fixture
 def localfs_force_fetched(localfs, localfs_dummy_finder):
-    from pootle_store.models import SOURCE_WINS
+    from pootle_store.constants import SOURCE_WINS
 
     plugin = localfs
     for store_fs in plugin.resources.tracked:

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -77,7 +77,8 @@ def get_test_uids(offset=0, count=1, pootle_path="^/language0/"):
     """Returns a list translated unit uids from ~middle of
     translated units dataset
     """
-    from pootle_store.models import TRANSLATED, Unit
+    from pootle_store.constants import TRANSLATED
+    from pootle_store.models import Unit
 
     units = Unit.objects.filter(
         store__pootle_path__regex=pootle_path).filter(state=TRANSLATED)

--- a/tests/commands/sync_stores.py
+++ b/tests/commands/sync_stores.py
@@ -11,7 +11,8 @@ import pytest
 from django.core.management import call_command
 
 from pootle_project.models import Project
-from pootle_store.models import PARSED, Store
+from pootle_store.constants import PARSED
+from pootle_store.models import Store
 
 
 @pytest.mark.cmd

--- a/tests/commands/test_checks.py
+++ b/tests/commands/test_checks.py
@@ -11,7 +11,8 @@ import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from pootle_store.models import Unit, TRANSLATED
+from pootle_store.constants import TRANSLATED
+from pootle_store.models import Unit
 
 
 @pytest.mark.cmd

--- a/tests/forms/unit.py
+++ b/tests/forms/unit.py
@@ -10,7 +10,7 @@ import pytest
 
 from pootle_app.models.permissions import get_matching_permissions
 from pootle_store.forms import UnitStateField, unit_form_factory
-from pootle_store.util import FUZZY, TRANSLATED, UNTRANSLATED
+from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
 
 
 def _create_post_request(rf, directory, user, url='/', data=None):

--- a/tests/import_export/import.py
+++ b/tests/import_export/import.py
@@ -18,9 +18,8 @@ from pytest_pootle.utils import create_store
 from import_export.exceptions import UnsupportedFiletypeError
 from import_export.utils import import_file
 from pootle_app.models.permissions import check_user_permission
-from pootle_store.constants import NEW, PARSED
+from pootle_store.constants import NEW, OBSOLETE, PARSED, TRANSLATED
 from pootle_store.models import Store, Unit
-from pootle_store.util import OBSOLETE, TRANSLATED
 
 
 IMPORT_SUCCESS = "headers_correct.po"

--- a/tests/import_export/import.py
+++ b/tests/import_export/import.py
@@ -18,8 +18,9 @@ from pytest_pootle.utils import create_store
 from import_export.exceptions import UnsupportedFiletypeError
 from import_export.utils import import_file
 from pootle_app.models.permissions import check_user_permission
-from pootle_store.models import NEW, PARSED, Store
-from pootle_store.models import OBSOLETE, TRANSLATED, Unit
+from pootle_store.constants import NEW, PARSED
+from pootle_store.models import Store, Unit
+from pootle_store.util import OBSOLETE, TRANSLATED
 
 
 IMPORT_SUCCESS = "headers_correct.po"

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -36,9 +36,10 @@ from pootle_format.models import Format
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_statistics.models import SubmissionTypes
+from pootle_store.constants import NEW, PARSED, POOTLE_WINS
 from pootle_store.diff import DiffableStore, StoreDiff
-from pootle_store.models import NEW, OBSOLETE, PARSED, POOTLE_WINS, Store
-from pootle_store.util import parse_pootle_revision
+from pootle_store.models import Store
+from pootle_store.util import OBSOLETE, parse_pootle_revision
 from pootle_translationproject.models import TranslationProject
 
 from .unit import _update_translation

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -36,10 +36,10 @@ from pootle_format.models import Format
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_statistics.models import SubmissionTypes
-from pootle_store.constants import NEW, PARSED, POOTLE_WINS
+from pootle_store.constants import NEW, OBSOLETE, PARSED, POOTLE_WINS
 from pootle_store.diff import DiffableStore, StoreDiff
 from pootle_store.models import Store
-from pootle_store.util import OBSOLETE, parse_pootle_revision
+from pootle_store.util import parse_pootle_revision
 from pootle_translationproject.models import TranslationProject
 
 from .unit import _update_translation

--- a/tests/models/submission.py
+++ b/tests/models/submission.py
@@ -16,8 +16,8 @@ from pytest_pootle.utils import create_store
 from pootle_app.models.permissions import check_permission
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
+from pootle_store.constants import TRANSLATED, UNTRANSLATED
 from pootle_store.models import Suggestion, Unit
-from pootle_store.util import TRANSLATED, UNTRANSLATED
 
 
 def _create_comment_submission(unit, user, creation_time, comment):

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -16,7 +16,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from pootle.core.mixins.treeitem import CachedMethods
-from pootle_store.util import FUZZY, TRANSLATED, UNTRANSLATED
+from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
 from pootle_store.models import Unit
 
 

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -23,7 +23,7 @@ from pootle_app.models.directory import Directory
 from pootle_app.models.permissions import PermissionSet, check_user_permission
 from pootle_language.models import Language
 from pootle_project.models import Project
-from pootle_store.util import FUZZY, TRANSLATED
+from pootle_store.constants import FUZZY, TRANSLATED
 from pootle_translationproject.models import TranslationProject
 
 

--- a/tests/models/virtualfolder.py
+++ b/tests/models/virtualfolder.py
@@ -14,8 +14,8 @@ import pytest
 
 from pytest_pootle.factories import VirtualFolderDBFactory
 
+from pootle_store.constants import OBSOLETE, TRANSLATED
 from pootle_store.models import Unit
-from pootle_store.util import OBSOLETE, TRANSLATED
 from virtualfolder.models import VirtualFolder, VirtualFolderTreeItem
 
 

--- a/tests/pootle_fs/files.py
+++ b/tests/pootle_fs/files.py
@@ -19,7 +19,7 @@ from pootle_fs.models import StoreFS
 from pootle_fs.files import FSFile
 from pootle_project.models import Project
 from pootle_statistics.models import SubmissionTypes
-from pootle_store.models import POOTLE_WINS, SOURCE_WINS
+from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
 
 
 @pytest.mark.django_db

--- a/tests/pootle_fs/fs_state.py
+++ b/tests/pootle_fs/fs_state.py
@@ -13,7 +13,7 @@ from pytest_pootle.factories import ProjectDBFactory
 from pytest_pootle.fixtures.pootle_fs.state import DummyPlugin
 
 from pootle_fs.state import FS_STATE, ProjectFSState
-from pootle_store.models import POOTLE_WINS, SOURCE_WINS
+from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
 
 
 def _test_state(plugin, pootle_path, fs_path, state_type, paths=None):

--- a/tests/search.py
+++ b/tests/search.py
@@ -13,9 +13,9 @@ from pootle.core.plugin import getter
 from pootle_project.models import Project
 from pootle_statistics.models import SubmissionTypes
 from pootle_store.getters import get_search_backend
-from pootle_store.models import (
-    FUZZY, TRANSLATED, UNTRANSLATED,
-    SuggestionStates, Unit)
+from pootle_store.constants import FUZZY, TRANSLATED, UNTRANSLATED
+from pootle_store.models import Unit
+from pootle_store.util import SuggestionStates
 from pootle_store.unit.filters import (
     FilterNotFound, UnitChecksFilter, UnitContributionFilter, UnitSearchFilter,
     UnitStateFilter, UnitTextSearch)

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -29,7 +29,8 @@ from pootle_store.constants import (
     FUZZY, OBSOLETE, STATES_MAP, TRANSLATED, UNTRANSLATED)
 from pootle_store.fields import to_python
 from pootle_store.models import (
-    Suggestion, SuggestionStates, QualityCheck, Store, Unit)
+    Suggestion, QualityCheck, Store, Unit)
+from pootle_store.util import SuggestionStates
 
 
 class ProxyTimelineLanguage(object):

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -25,11 +25,11 @@ from pootle_comment.forms import UnsecuredCommentForm
 from pootle_misc.checks import check_names
 from pootle_statistics.models import (
     Submission, SubmissionFields, SubmissionTypes)
+from pootle_store.constants import (
+    FUZZY, OBSOLETE, STATES_MAP, TRANSLATED, UNTRANSLATED)
 from pootle_store.fields import to_python
 from pootle_store.models import (
-    FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED,
     Suggestion, SuggestionStates, QualityCheck, Store, Unit)
-from pootle_store.util import STATES_MAP
 
 
 class ProxyTimelineLanguage(object):

--- a/tests/views/unit.py
+++ b/tests/views/unit.py
@@ -15,8 +15,8 @@ from pytest_pootle.utils import create_api_request
 from pootle.core.exceptions import Http400
 from pootle_app.models.permissions import check_permission
 from pootle_comment import get_model as get_comment_model
-from pootle_store.models import (QualityCheck, Suggestion, Unit, TRANSLATED,
-                                 UNTRANSLATED)
+from pootle_store.constants import TRANSLATED, UNTRANSLATED
+from pootle_store.models import QualityCheck, Suggestion, Unit
 from pootle_statistics.models import Submission, SubmissionTypes
 from pootle_store.views import get_units, toggle_qualitycheck
 


### PR DESCRIPTION
- move constants out of models.py and other files (and prevent cyclic imports)
- move managers out and models.py and make it easier to work with