### PR TITLE
Update django-contact-form to 1.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ Django>=1.8.13,<1.9
 # Django apps
 django-allauth==0.25.2
 django-assets==0.11
-django-contact-form==1.0
+django-contact-form==1.2
 django-contrib-comments==1.7.1
 django-overextends==0.4.1
 django-redis==4.4.3


### PR DESCRIPTION
Tested locally with entering some test data in the "contact us" form:

----------------8<---------------------8<------------------------

[16/Aug/2016 14:33:01] "GET /contact/xhr/ HTTP/1.1" 200 1728
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 7bit
Subject: [Pootle Development Server] hallo
From: rene <webmaster@localhost>
To: info@YOUR_DOMAIN.com
Date: Tue, 16 Aug 2016 14:33:23 -0000
Message-ID: <20160816143323.4651.98348@e17>
Reply-To: rene <r.c.ladan@gmail.com>

Username: anonymous user
Current URL: http://localhost:8000/
IP address: 127.0.0.1
User-Agent: Mozilla/5.0 (X11; FreeBSD amd64; rv:47.0) Gecko/20100101 Firefox/47.0

hello world

--------8<--------------8<----------------