### PR TITLE
Allow django-rq 0.9.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-contact-form==1.0
 django-contrib-comments==1.7.1
 django-overextends==0.4.1
 django-redis==4.4.3
-django-rq>=0.8.0,<=0.9.1
+django-rq>=0.8.0,<=0.9.2
 django-sortedm2m
 django-transaction-hooks==0.2
 django-statici18n


### PR DESCRIPTION
This version of django-rq drops support for Django < 1.8 and adds support
for Django 1.10
It also adds a new option --queue-class to the rq-worker management command.