### PR TITLE
DOM: use wrappers for querySelector[All]

### DIFF
--- a/pootle/static/js/admin/app.js
+++ b/pootle/static/js/admin/app.js
@@ -11,6 +11,8 @@ import 'imports?Backbone=>require("backbone")!backbone-move';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { q } from 'utils/dom';
+
 import AdminController from './components/AdminController';
 import User from './components/User';
 import Language from './components/Language';
@@ -42,7 +44,7 @@ PTL.admin = {
         formChoices={opts.formChoices || {}}
         router={new AdminRouter()}
       />,
-      document.querySelector('.js-admin-app')
+      q('.js-admin-app')
     );
   },
 

--- a/pootle/static/js/admin/general/components/LiveEditor.js
+++ b/pootle/static/js/admin/general/components/LiveEditor.js
@@ -10,6 +10,7 @@ import React from 'react';
 import _ from 'underscore';
 
 import { outerHeight } from 'utils/dimensions';
+import { qAll } from 'utils/dom';
 import fetch from 'utils/fetch';
 
 import ContentEditor from './ContentEditor';
@@ -67,8 +68,7 @@ export const LiveEditor = React.createClass({
     );
     const footerHeight = outerHeight(document.querySelector('#footer'));
 
-    const formFieldNodes = document.querySelectorAll('.js-staticpage-non-content');
-    const formFields = Array.prototype.slice.call(formFieldNodes, 0);
+    const formFields = qAll('.js-staticpage-non-content');
     const fieldsHeight = (
       formFields.reduce((total, fieldEl) => total + outerHeight(fieldEl), 0)
     );

--- a/pootle/static/js/admin/general/components/LiveEditor.js
+++ b/pootle/static/js/admin/general/components/LiveEditor.js
@@ -10,7 +10,7 @@ import React from 'react';
 import _ from 'underscore';
 
 import { outerHeight } from 'utils/dimensions';
-import { qAll } from 'utils/dom';
+import { q, qAll } from 'utils/dom';
 import fetch from 'utils/fetch';
 
 import ContentEditor from './ContentEditor';
@@ -62,11 +62,11 @@ export const LiveEditor = React.createClass({
 
   getContentHeight() {
     const topHeight = (
-      outerHeight(document.querySelector('#navbar')) +
-      outerHeight(document.querySelector('#header-meta')) +
-      outerHeight(document.querySelector('#header-tabs'))
+      outerHeight(q('#navbar')) +
+      outerHeight(q('#header-meta')) +
+      outerHeight(q('#header-tabs'))
     );
-    const footerHeight = outerHeight(document.querySelector('#footer'));
+    const footerHeight = outerHeight(q('#footer'));
 
     const formFields = qAll('.js-staticpage-non-content');
     const fieldsHeight = (

--- a/pootle/static/js/admin/general/staticpages.js
+++ b/pootle/static/js/admin/general/staticpages.js
@@ -9,6 +9,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { q } from 'utils/dom';
+
 import LiveEditor from './components/LiveEditor';
 
 
@@ -21,7 +23,7 @@ const staticpages = {
         markup={opts.markup}
         name={opts.htmlName}
       />,
-      document.querySelector('.js-staticpage-editor')
+      q('.js-staticpage-editor')
     );
   },
 

--- a/pootle/static/js/auth/index.js
+++ b/pootle/static/js/auth/index.js
@@ -12,6 +12,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
+import { q } from 'utils/dom';
+
 import Auth from './containers/Auth';
 
 
@@ -40,12 +42,12 @@ export default {
       <Provider store={PTL.store}>
         <Auth onClose={this.close} {...newProps} />
       </Provider>,
-      document.querySelector(mountNodeSelector)
+      q(mountNodeSelector)
     );
   },
 
   close() {
-    ReactDOM.unmountComponentAtNode(document.querySelector(mountNodeSelector));
+    ReactDOM.unmountComponentAtNode(q(mountNodeSelector));
   },
 
 };

--- a/pootle/static/js/browser/components/VisibilityToggle.js
+++ b/pootle/static/js/browser/components/VisibilityToggle.js
@@ -9,6 +9,7 @@
 import React, { PropTypes } from 'react';
 
 import TextToggle from 'components/TextToggle';
+import { qAll } from 'utils/dom';
 
 
 const VisibilityToggle = React.createClass({
@@ -27,13 +28,13 @@ const VisibilityToggle = React.createClass({
    * The implementation must change once the table is rendered as a component.
    */
   handleVisibility({ isActive: showDisabled }) {
-    const rows = [...document.querySelectorAll('tr.item')];
+    const rows = qAll('tr.item');
     rows.map(row => row.classList.remove('odd'));
     rows
       .filter(row => row.classList.contains('is-disabled'))
       .forEach(row => row.classList.toggle('is-visible', showDisabled));
 
-    [...document.querySelectorAll('tr.is-visible')].forEach((row, i) => {
+    qAll('tr.is-visible').forEach((row, i) => {
       row.classList.toggle('odd', i % 2 === 0);
     });
   },

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -33,6 +33,7 @@ import assign from 'object-assign';
 import StatsAPI from 'api/StatsAPI';
 import UnitAPI from 'api/UnitAPI';
 import cookie from 'utils/cookie';
+import { qAll } from 'utils/dom';
 import fetch from 'utils/fetch';
 import linkHashtags from 'utils/linkHashtags';
 
@@ -231,9 +232,8 @@ PTL.editor = {
     /* Copy original translation */
     $('#editor').on('click', '.js-copyoriginal', (e) => {
       const uId = e.currentTarget.dataset.uid;
-      const sources = [
-        ...document.querySelectorAll(`#js-unit-${uId} .js-translation-text`),
-      ].map((el) => el.textContent);
+      const sources = qAll(`#js-unit-${uId} .js-translation-text`)
+        .map((el) => el.textContent);
       this.copyOriginal(sources);
     });
 
@@ -2149,7 +2149,7 @@ PTL.editor = {
         $(data.timeline).hide().prependTo('#extras-container')
                         .slideDown(1000, 'easeOutQuad');
       }
-      [...document.querySelectorAll('.js-mount-timesince')].forEach((el, i) => {
+      qAll('.js-mount-timesince').forEach((el, i) => {
         const props = {
           title: data.entries_group[i].display_datetime,
           dateTime: data.entries_group[i].iso_datetime,

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -33,7 +33,7 @@ import assign from 'object-assign';
 import StatsAPI from 'api/StatsAPI';
 import UnitAPI from 'api/UnitAPI';
 import cookie from 'utils/cookie';
-import { qAll } from 'utils/dom';
+import { q, qAll } from 'utils/dom';
 import fetch from 'utils/fetch';
 import linkHashtags from 'utils/linkHashtags';
 
@@ -97,10 +97,10 @@ PTL.editor = {
     }
 
     /* Cached elements */
-    this.backToBrowserEl = document.querySelector('.js-back-to-browser');
+    this.backToBrowserEl = q('.js-back-to-browser');
     this.$editorActivity = $('#js-editor-act');
     this.$editorBody = $('.js-editor-body');
-    this.editorTableEl = document.querySelector('.js-editor-table');
+    this.editorTableEl = q('.js-editor-table');
     this.$filterStatus = $('#js-filter-status');
     this.$filterChecks = $('#js-filter-checks');
     this.$filterChecksWrapper = $('.js-filter-checks-wrapper');
@@ -108,8 +108,8 @@ PTL.editor = {
     this.$msgOverlay = $('#js-editor-msg-overlay');
     this.$navNext = $('#js-nav-next');
     this.$navPrev = $('#js-nav-prev');
-    this.unitCountEl = document.querySelector('.js-unit-count');
-    this.unitIndexEl = document.querySelector('.js-unit-index');
+    this.unitCountEl = q('.js-unit-count');
+    this.unitIndexEl = q('.js-unit-index');
     this.offsetRequested = 0;
 
     /* Initialize variables */
@@ -297,7 +297,7 @@ PTL.editor = {
       e.preventDefault();
       $('.js-translate-translation').toggleClass('raw');
       $('.js-toggle-raw').toggleClass('selected');
-      autosize.update(document.querySelector('.js-translation-area'));
+      autosize.update(q('.js-translation-area'));
     });
 
     /* Confirmation prompt */
@@ -585,7 +585,7 @@ PTL.editor = {
       this.displayObsoleteMsg();
     }
 
-    autosize(document.querySelector('textarea.expanding:not([disabled="disabled"])'));
+    autosize(q('textarea.expanding:not([disabled="disabled"])'));
 
     // set direction of the comment body
     $('.extra-item-comment').filter(':not([dir])').bidi();
@@ -728,9 +728,9 @@ PTL.editor = {
   },
 
   copyComment(text) {
-    const comment = document.querySelector('.js-editor-comment');
-    const commentForm = document.querySelector('.js-editor-comment-form');
-    const commentInput = document.querySelector('#id_translator_comment');
+    const comment = q('.js-editor-comment');
+    const commentForm = q('.js-editor-comment-form');
+    const commentInput = q('#id_translator_comment');
 
     if (!comment.classList.contains('selected')) {
       commentForm.style.display = 'inline-block';
@@ -824,30 +824,30 @@ PTL.editor = {
     $('.js-translation-area').each(function setDefaultValue() {
       this.defaultValue = this.value;
     });
-    const checkbox = document.querySelector('#id_state');
+    const checkbox = q('#id_state');
     checkbox.defaultChecked = checkbox.checked;
     this.handleTranslationChange();
   },
 
   /* Updates comment area's `defaultValue` value. */
   updateCommentDefaultProperties() {
-    const comment = document.querySelector('#id_translator_comment');
+    const comment = q('#id_translator_comment');
     comment.defaultValue = comment.value;
     this.handleTranslationChange();
   },
 
   handleTranslationChange() {
-    const comment = document.querySelector('#id_translator_comment');
+    const comment = q('#id_translator_comment');
     const commentChanged = comment !== null ?
                            comment.value !== comment.defaultValue : false;
 
-    const submit = document.querySelector('.js-submit');
-    const suggest = document.querySelector('.js-suggest');
+    const submit = q('.js-submit');
+    const suggest = q('.js-suggest');
     const translations = $('.js-translation-area').get();
     const suggestions = $('.js-user-suggestion').map(function getSuggestions() {
       return $(this).data('translation-aid');
     }).get();
-    const checkbox = document.querySelector('#id_state');
+    const checkbox = q('#id_state');
     const stateChanged = checkbox.defaultChecked !== checkbox.checked;
 
     let areaChanged = false;
@@ -1372,7 +1372,7 @@ PTL.editor = {
   /* reDraws the translate table rows */
   reDraw(newTbody) {
     // Remove autosize event listeners for textarea before removing
-    autosize.destroy(document.querySelectorAll('textarea.expanding'));
+    autosize.destroy(qAll('textarea.expanding'));
 
     this.$editorBody.find('tr').remove();
 
@@ -1558,7 +1558,7 @@ PTL.editor = {
 
   /* Pushes translation submissions and moves to the next unit */
   handleSubmit(comment = '') {
-    const el = document.querySelector('input.submit');
+    const el = q('input.submit');
     const newTranslation = $('.js-translation-area')[0].value;
     const suggestions = $('.js-user-suggestion').map(function getSuggestions() {
       return {
@@ -2326,7 +2326,7 @@ PTL.editor = {
     suggId, { requestData = {}, isSuggestionChanged = false } = {}
   ) {
     if (isSuggestionChanged) {
-      const area = document.querySelector('.js-translation-area');
+      const area = q('.js-translation-area');
       area.value = decodeEntities(requestData.translation);
       this.undoFuzzyBox();
       this.handleSubmit(requestData.comment);
@@ -2429,7 +2429,7 @@ PTL.editor = {
       return false;
     }
 
-    const area = document.querySelector('.js-translation-area');
+    const area = q('.js-translation-area');
 
     area.value = decodeEntities(translation);
     autosize.update(area);
@@ -2459,8 +2459,8 @@ PTL.editor = {
       onChange: this.handleSuggestionFeedbackChange.bind(this),
     };
     const mountSelector = `.js-mnt-suggestion-feedback-${suggId}`;
-    const feedbackMountPoint = document.querySelector(mountSelector);
-    const editorBody = document.querySelector('.js-editor-body .translate-full');
+    const feedbackMountPoint = q(mountSelector);
+    const editorBody = q('.js-editor-body .translate-full');
     suggestion.classList.add('suggestion-expanded');
     editorBody.classList.add('suggestion-expanded');
 
@@ -2490,10 +2490,10 @@ PTL.editor = {
   closeSuggestion({ checkIfCanNavigate = true } = {}) {
     if (this.selectedSuggestionId !== undefined &&
         (!checkIfCanNavigate || this.canNavigate())) {
-      const suggestion = document.querySelector(`#suggestion-${this.selectedSuggestionId}`);
-      const editorBody = document.querySelector('.js-editor-body .translate-full');
+      const suggestion = q(`#suggestion-${this.selectedSuggestionId}`);
+      const editorBody = q('.js-editor-body .translate-full');
       const mountSelector = `.js-mnt-suggestion-feedback-${this.selectedSuggestionId}`;
-      const feedbackMountPoint = document.querySelector(mountSelector);
+      const feedbackMountPoint = q(mountSelector);
       editorBody.classList.remove('suggestion-expanded');
       suggestion.classList.remove('suggestion-expanded');
       ReactDOM.unmountComponentAtNode(feedbackMountPoint);

--- a/pootle/static/js/reports/app.js
+++ b/pootle/static/js/reports/app.js
@@ -18,6 +18,8 @@ import 'jquery-flot-time';
 import 'jquery-history';
 import 'jquery-serializeObject';
 
+import { q } from 'utils/dom';
+
 import msg from '../msg';
 import utils from '../utils';
 
@@ -504,7 +506,7 @@ PTL.reports = {
           $('#user-rates-form .currency').text($('#id_currency').val());
 
           if ('task' in PTL.reports.params) {
-            const task = document.querySelector(`.task${PTL.reports.params.task}`);
+            const task = q(`.task${PTL.reports.params.task}`);
             if (!!task) {
               task.classList.add('highlight');
               setTimeout(() => {

--- a/pootle/static/js/score.js
+++ b/pootle/static/js/score.js
@@ -10,12 +10,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import Score from 'components/Score';
+import { q } from 'utils/dom';
 
 
 function init(value) {
   ReactDOM.render(
     <Score value={value} />,
-    document.querySelector('.js-score')
+    q('.js-score')
   );
 }
 

--- a/pootle/static/js/shared/utils/dom.js
+++ b/pootle/static/js/shared/utils/dom.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+
+/**
+ * Queries the DOM for a collection matching `selector`.
+ *
+ * @param {String} selector - The CSS selector
+ * @return {Array} - Array of matched `Node`s
+ */
+export function qAll(selector) {
+  const nodes = document.querySelectorAll(selector);
+  // XXX: not using array spread because this requires an extra polyfill to
+  // support IE 11
+  return Array.prototype.slice.call(nodes);
+}

--- a/pootle/static/js/shared/utils/dom.js
+++ b/pootle/static/js/shared/utils/dom.js
@@ -8,6 +8,17 @@
 
 
 /**
+ * Queries the DOM for an element matching `selector`.
+ *
+ * @param {String} selector - The CSS selector
+ * @return {Node} - the matched `Node`, `null` otherwise.
+ */
+export function q(selector) {
+  return document.querySelector(selector);
+}
+
+
+/**
  * Queries the DOM for a collection matching `selector`.
  *
  * @param {String} selector - The CSS selector

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -19,6 +19,7 @@ import LastUpdate from 'components/LastUpdate';
 import TimeSince from 'components/TimeSince';
 import UserEvent from 'components/UserEvent';
 import cookie from 'utils/cookie';
+import { q } from 'utils/dom';
 
 import Stats from './browser/components/Stats';
 import VisibilityToggle from './browser/components/VisibilityToggle';
@@ -116,7 +117,7 @@ const stats = {
 
     if (this.isAdmin && options.hasDisabledItems) {
       ReactDOM.render(<VisibilityToggle uiLocaleDir={options.uiLocaleDir} />,
-                      document.querySelector('.js-mnt-visibility-toggle'));
+                      q('.js-mnt-visibility-toggle'));
     }
 
     ReactDOM.render(
@@ -125,7 +126,7 @@ const stats = {
         topContributors={options.topContributorsData.items}
         pootlePath={this.pootlePath}
       />,
-      document.querySelector('#js-mnt-top-contributors')
+      q('#js-mnt-top-contributors')
     );
 
     // Retrieve async data if needed
@@ -246,18 +247,18 @@ const stats = {
   },
 
   updateLastUpdates(statsData) {
-    const luWrapper = document.querySelector('#js-last-updated-wrapper');
+    const luWrapper = q('#js-last-updated-wrapper');
     const hideLastUpdated = !statsData.lastupdated || statsData.lastupdated.mtime === 0;
     luWrapper.classList.toggle('hide', hideLastUpdated);
     if (statsData.lastupdated) {
-      const lastUpdated = document.querySelector('#js-last-updated');
+      const lastUpdated = q('#js-last-updated');
       this.renderLastUpdate(lastUpdated, statsData.lastupdated);
     }
-    const laWrapper = document.querySelector('#js-last-action-wrapper');
+    const laWrapper = q('#js-last-action-wrapper');
     const hideLastAction = !statsData.lastaction || statsData.lastaction.mtime === 0;
     laWrapper.classList.toggle('hide', hideLastAction);
     if (statsData.lastaction) {
-      const lastAction = document.querySelector('#js-last-action');
+      const lastAction = q('#js-last-action');
       this.renderLastEvent(lastAction, statsData.lastaction);
     }
   },

--- a/pootle/static/js/user/app.js
+++ b/pootle/static/js/user/app.js
@@ -11,7 +11,7 @@ import ReactDOM from 'react-dom';
 
 import UserEvent from 'components/UserEvent';
 import { User } from 'models/user';
-import { qAll } from 'utils/dom';
+import { q, qAll } from 'utils/dom';
 
 import UserProfileEdit from './components/UserProfileEdit';
 
@@ -23,7 +23,7 @@ PTL.user = {
 
   init(opts) {
     if (opts.userData !== undefined) {
-      const editButton = document.querySelector('.js-user-profile-edit');
+      const editButton = q('.js-user-profile-edit');
 
       const user = new User(opts.userData, { urlRoot: l('/xhr/users/') });
       const props = {
@@ -49,7 +49,7 @@ PTL.user = {
       });
     }
 
-    const lastActivity = document.querySelector('.js-last-action');
+    const lastActivity = q('.js-last-action');
     const data = opts.lastEvent;
     const props = {
       checkName: data.check_name,

--- a/pootle/static/js/user/app.js
+++ b/pootle/static/js/user/app.js
@@ -11,6 +11,7 @@ import ReactDOM from 'react-dom';
 
 import UserEvent from 'components/UserEvent';
 import { User } from 'models/user';
+import { qAll } from 'utils/dom';
 
 import UserProfileEdit from './components/UserProfileEdit';
 
@@ -33,8 +34,7 @@ PTL.user = {
 
       // FIXME: let's make the whole profile page a component, so a lot of the
       // boilerplate here is rendered redundant
-      const popupBtns = document.querySelectorAll('.js-popup-tweet');
-      [...popupBtns].map((btn) => {
+      qAll('.js-popup-tweet').map((btn) => {
         btn.addEventListener('click', (e) => {
           e.preventDefault();
 


### PR DESCRIPTION
Most notably this is handy to be able to use `Array.prototype` methods over the collection of `NodeList`s returned by `querySelectorAll`.

Update: forgot to mention this basically fixes #5089. 