### PR TITLE
Cleanups from adding StoreSyncer

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -18,7 +18,6 @@ from translate.storage import base
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.core.validators import MinValueValidator
 from django.db import models
@@ -285,8 +284,7 @@ class Unit(models.Model, base.TranslationUnit):
         return unicode(self.source)
 
     def __str__(self):
-        unitclass = self.get_unit_class()
-        return str(self.convert(unitclass))
+        return str(self.convert())
 
     def __init__(self, *args, **kwargs):
         super(Unit, self).__init__(*args, **kwargs)
@@ -490,18 +488,11 @@ class Unit(models.Model, base.TranslationUnit):
     def unit_syncer(self):
         return self.store.syncer.unit_sync_class(self)
 
-    def convert(self, unitclass):
+    def convert(self, unitclass=None):
         """Convert to a unit of type :param:`unitclass` retaining as much
         information from the database as the target format can support.
         """
         return self.unit_syncer.convert(unitclass)
-
-    def get_unit_class(self):
-        try:
-            return self.store.syncer.file_class.UnitClass
-        except ObjectDoesNotExist:
-            from translate.storage import po
-            return po.pounit
 
     def getorig(self):
         unit = self.store.file.store.units[self.index]
@@ -1243,9 +1234,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         return unicode(self.pootle_path)
 
     def __str__(self):
-        storeclass = self.syncer.file_class
-        store = self.syncer.convert(storeclass)
-        return str(store)
+        return str(self.syncer.convert())
 
     def save(self, *args, **kwargs):
         created = not self.id

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1767,11 +1767,3 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
 
 # # # # # # # # # # # # # # # #  Translation # # # # # # # # # # # # # # #
-
-    def getitem(self, item):
-        """Returns a single unit based on the item number."""
-        # store.units[item] is unreliable so we need to enumerate
-        #   - please see #4160 for discussion
-        for i, unit in enumerate(self.units):
-            if i == item:
-                return unit

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -464,9 +464,6 @@ class Unit(models.Model, base.TranslationUnit):
         if prefix:
             return prefix + urlquote(self.source_f)
 
-    def get_mtime(self):
-        return self.mtime
-
     def is_accessible_by(self, user):
         """Returns `True` if the current unit is accessible by `user`."""
         if user.is_superuser:

--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -62,8 +62,13 @@ class UnitSyncer(object):
     def unitid(self):
         return self.unit.getid()
 
-    def convert(self, unitclass):
-        newunit = self.create_unit(unitclass)
+    @property
+    def unit_class(self):
+        return self.unit.store.syncer.unit_class
+
+    def convert(self, unitclass=None):
+        newunit = self.create_unit(
+            unitclass or self.unit_class)
         self.set_target(newunit)
         self.set_fuzzy(newunit)
         self.set_locations(newunit)
@@ -140,6 +145,10 @@ class StoreSyncer(object):
         return os.path.join(
             self.translation_project.abs_real_path,
             self.store.name)
+
+    @property
+    def unit_class(self):
+        return self.file_class.UnitClass
 
     @cached_property
     def file_class(self):

--- a/tests/forms/unit.py
+++ b/tests/forms/unit.py
@@ -34,7 +34,7 @@ def _create_unit_form(request, language, unit):
 def test_submit_no_source(rf, default, af_tutorial_po):
     """Tests that the source string cannot be modified."""
     language = af_tutorial_po.translation_project.language
-    unit = af_tutorial_po.getitem(0)
+    unit = af_tutorial_po.units[0]
     source_string = unit.source_f
     directory = unit.store.parent
     post_dict = {
@@ -50,7 +50,7 @@ def test_submit_no_source(rf, default, af_tutorial_po):
     assert form.is_valid()
     form.save()
 
-    unit = af_tutorial_po.getitem(0)
+    unit = af_tutorial_po.units[0]
     assert unit.source_f == source_string
     assert unit.target_f == 'dummy'
 
@@ -60,7 +60,7 @@ def test_submit_fuzzy(rf, admin, default,
                       afrikaans, af_tutorial_po):
     """Tests that non-admin users can't set the fuzzy flag."""
     language = afrikaans
-    unit = af_tutorial_po.getitem(0)
+    unit = af_tutorial_po.units[0]
     directory = unit.store.parent
     post_dict = {
         'id': unit.id,
@@ -83,7 +83,7 @@ def test_submit_fuzzy(rf, admin, default,
 def test_submit_similarity(rf, default, afrikaans, af_tutorial_po):
     """Tests that similarities are within a particular range."""
     language = afrikaans
-    unit = af_tutorial_po.getitem(0)
+    unit = af_tutorial_po.units[0]
     directory = unit.store.parent
 
     post_dict = {

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -281,7 +281,7 @@ def test_update_set_last_sync_revision(ru_update_set_last_sync_revision_po):
     # Get unsynced unit in DB. Its revision should be greater
     # than store.last_sync_revision to allow to keep this change during
     # update from a file
-    dbunit = store.getitem(item_index)
+    dbunit = store.units[item_index]
     assert dbunit.revision == store.last_sync_revision + 1
 
 

--- a/tests/models/suggestion.py
+++ b/tests/models/suggestion.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.mark.django_db
 def test_hash(af_tutorial_po):
     """Tests that target hash changes when suggestion is modified"""
-    unit = af_tutorial_po.getitem(0)
+    unit = af_tutorial_po.units[0]
     suggestion, created_ = unit.add_suggestion("gras")
 
     first_hash = suggestion.target_hash

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -289,7 +289,7 @@ def test_accept_suggestion_update_wordcount(it_tutorial_po, system):
 @pytest.mark.django_db
 def test_unit_repr():
     unit = Unit.objects.first()
-    assert str(unit) == str(unit.convert(unit.get_unit_class()))
+    assert str(unit) == str(unit.convert())
     assert unicode(unit) == unicode(unit.source)
 
 

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -25,7 +25,7 @@ User = get_user_model()
 
 
 def _update_translation(store, item, new_values, sync=True):
-    unit = store.getitem(item)
+    unit = store.units[item]
 
     if 'target' in new_values:
         unit.target = new_values['target']
@@ -44,7 +44,7 @@ def _update_translation(store, item, new_values, sync=True):
     if sync:
         store.sync()
 
-    return store.getitem(item)
+    return store.units[item]
 
 
 @pytest.mark.django_db
@@ -183,8 +183,8 @@ def test_update_comment(af_tutorial_po):
 @pytest.mark.django_db
 def test_add_suggestion(af_tutorial_po, system):
     """Tests adding new suggestions to units."""
-    untranslated_unit = af_tutorial_po.getitem(0)
-    translated_unit = af_tutorial_po.getitem(1)
+    untranslated_unit = af_tutorial_po.units[0]
+    translated_unit = af_tutorial_po.units[1]
     suggestion_text = 'foo bar baz'
 
     # Empty suggestion is not recorded
@@ -226,7 +226,7 @@ def test_accept_suggestion_changes_state(issue_2401_po, system):
     tp = issue_2401_po.translation_project
 
     # First test with an untranslated unit
-    unit = issue_2401_po.getitem(0)
+    unit = issue_2401_po.units[0]
     assert unit.state == UNTRANSLATED
 
     suggestion, created_ = unit.add_suggestion('foo')
@@ -236,7 +236,7 @@ def test_accept_suggestion_changes_state(issue_2401_po, system):
     assert unit.state == TRANSLATED
 
     # Let's try with a translated unit now
-    unit = issue_2401_po.getitem(1)
+    unit = issue_2401_po.units[1]
     assert unit.state == TRANSLATED
 
     suggestion, created_ = unit.add_suggestion('bar')
@@ -246,7 +246,7 @@ def test_accept_suggestion_changes_state(issue_2401_po, system):
     assert unit.state == TRANSLATED
 
     # And finally a fuzzy unit
-    unit = issue_2401_po.getitem(2)
+    unit = issue_2401_po.units[2]
     assert unit.state == FUZZY
 
     suggestion, created_ = unit.add_suggestion('baz')
@@ -265,7 +265,7 @@ def test_accept_suggestion_update_wordcount(it_tutorial_po, system):
     # Parse store
     it_tutorial_po.update(it_tutorial_po.file.store)
 
-    untranslated_unit = it_tutorial_po.getitem(0)
+    untranslated_unit = it_tutorial_po.units[0]
     suggestion_text = 'foo bar baz'
 
     sugg, added = untranslated_unit.add_suggestion(suggestion_text)


### PR DESCRIPTION
- StoreSyncer.convert allows fileclass to be empty and uses a default
- removes unnecessary or unused methods from Store