### PR TITLE
Prevent cycling updates for obsolete units in update/sync stores

### DIFF
--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -205,10 +205,10 @@ class StoreSyncer(object):
              in new_ids - old_ids])
 
     def get_units_to_obsolete(self, old_ids, new_ids):
-        return (
-            self.disk_store.findid(uid)
-            for uid
-            in old_ids - new_ids)
+        for uid in old_ids - new_ids:
+            unit = self.disk_store.findid(uid)
+            if unit and not unit.isobsolete():
+                yield unit
 
     def obsolete_unit(self, unit, conservative):
         deleted = not unit.istranslated()

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -123,7 +123,8 @@ class UnitUpdater(object):
     def should_update_index(self):
         return (
             self.update.change_indices
-            and self.uid in self.update.indices)
+            and self.uid in self.update.indices
+            and self.unit.index != self.update.get_index(self.uid))
 
     @property
     def should_update_target(self):

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -1369,7 +1369,9 @@ def _test_get_obsolete(results, syncer, old_ids, new_ids):
     assert list(results) == list(
         syncer.disk_store.findid(uid)
         for uid
-        in old_ids - new_ids)
+        in old_ids - new_ids
+        if (syncer.disk_store.findid(uid)
+            and not syncer.disk_store.findid(uid).isobsolete()))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
 fixes #5117