### PR TITLE
Update django-overextends to 0.4.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ django-allauth==0.25.2
 django-assets==0.11
 django-contact-form==1.2
 django-contrib-comments==1.7.1
-django-overextends==0.4.1
+django-overextends==0.4.2
 django-redis==4.4.3
 django-rq>=0.8.0,<=0.9.1
 django-sortedm2m


### PR DESCRIPTION
This version adds support for Django 1.10 and drops support for Django 1.7