### PR TITLE
Cleanup fix

### DIFF
--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -148,6 +148,14 @@ class StoreSyncer(object):
             *split_pootle_path(self.store.pootle_path)[2:])
 
     @property
+    def relative_file_path(self):
+        path_parts = split_pootle_path(self.store.pootle_path)
+        path_prefix = [path_parts[1]]
+        if self.project.get_treestyle() != "gnu":
+            path_prefix.append(path_parts[0])
+        return os.path.join(*(path_prefix + list(path_parts[2:])))
+
+    @property
     def unit_class(self):
         return self.file_class.UnitClass
 
@@ -235,10 +243,10 @@ class StoreSyncer(object):
         store = self.convert()
         if not os.path.exists(os.path.dirname(self.store_file_path)):
             os.makedirs(os.path.dirname(self.store_file_path))
+        self.store.file = self.relative_file_path
         store.savefile(self.store_file_path)
         log(u"Created file for %s [revision: %d]" %
             (self.store.pootle_path, last_revision))
-        self.store.file = self.store_file_path
         self.update_store_header(user=user)
         self.store.file.savestore()
         self.store.file_mtime = self.store.get_file_mtime()

--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -260,7 +260,9 @@ class PootleTestEnv(object):
         po = Format.objects.get(name="po")
         for i_ in range(0, 2):
             # add 2 projects
-            project = ProjectDBFactory(source_language=source_language)
+            project = ProjectDBFactory(
+                source_language=source_language,
+                treestyle="nongnu")
             project.filetypes.add(po)
 
     def setup_terminology(self):


### PR DESCRIPTION
Currently, when creating a Store, StoreSyncer doesnt respect whether the project is gnu/nongnu.

Also, it sets the wrong path for the `store.file`

This PR fixes these 2 problems - and sets the default test projects to "nongnu" explicitly. Currently they were being treated as both gnu and non-gnu according to the state of the the filesystem when it was being checked