### PR TITLE
Cleanup: rename get_obsolete_units > get_units_to_obsolete

### DIFF
--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -204,7 +204,7 @@ class StoreSyncer(object):
              for uid
              in new_ids - old_ids])
 
-    def get_obsolete_units(self, old_ids, new_ids):
+    def get_units_to_obsolete(self, old_ids, new_ids):
         return (
             self.disk_store.findid(uid)
             for uid
@@ -299,7 +299,7 @@ class StoreSyncer(object):
         file_changed = False
         changes = {}
         if update_structure:
-            obsolete_units = self.get_obsolete_units(old_ids, new_ids)
+            obsolete_units = self.get_units_to_obsolete(old_ids, new_ids)
             new_units = self.get_new_units(old_ids, new_ids)
             if obsolete_units or new_units:
                 file_changed = True

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -532,7 +532,7 @@ def dummy_store_syncer():
         def dbid_index(self):
             return self.expected["db_index"]
 
-        def get_obsolete_units(self, old_ids_, new_ids_):
+        def get_units_to_obsolete(self, old_ids_, new_ids_):
             return self.expected["obsolete_units"]
 
         def get_new_units(self, old_ids, new_ids):

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -1380,7 +1380,7 @@ def test_store_syncer_obsolete_units(dummy_store_syncer_units, tp0):
         new_ids=set(),
         disk_ids={})
     syncer = dummy_store_syncer_units(store, expected=expected)
-    results = syncer.get_obsolete_units(
+    results = syncer.get_units_to_obsolete(
         expected["old_ids"], expected["new_ids"])
     _test_get_obsolete(
         results, syncer, expected["old_ids"], expected["new_ids"])
@@ -1388,7 +1388,7 @@ def test_store_syncer_obsolete_units(dummy_store_syncer_units, tp0):
         old_ids=set(["2", "3", "4"]),
         new_ids=set(["3", "4", "5"]),
         disk_ids={"3": "foo", "4": "bar", "5": "baz"})
-    results = syncer.get_obsolete_units(
+    results = syncer.get_units_to_obsolete(
         expected["old_ids"], expected["new_ids"])
     _test_get_obsolete(
         results, syncer, expected["old_ids"], expected["new_ids"])


### PR DESCRIPTION
renames method in StoreSyncer to better reflect what it returns