### PR TITLE
Cleanup add stylelint for CSS linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ install:
       -r requirements/base.txt
       -r requirements/travis.txt
       -e .
+  # http://entulho.fiatjaf.alhur.es/guias/how-to-use-node-along-with-other-language-on-travis-ci/
+  - source $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
 script:
   - tox -e $TOXENV
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ put-translations:
 linguas:
 	@${SRC_DIR}/tools/make-LINGUAS.sh 80 > ${SRC_DIR}/locale/LINGUAS
 
-jslint:
+lint-js:
 	cd ${JS_DIR} \
 	&& npm run lint
 

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,15 @@ put-translations:
 linguas:
 	@${SRC_DIR}/tools/make-LINGUAS.sh 80 > ${SRC_DIR}/locale/LINGUAS
 
+lint: lint-js lint-css
+
 lint-js:
 	cd ${JS_DIR} \
 	&& npm run lint
+
+lint-css:
+	cd ${JS_DIR} \
+	&& npm run stylelint
 
 publish-pypi:
 	python setup.py sdist ${FORMATS} upload

--- a/pootle/static/css/actions.css
+++ b/pootle/static/css/actions.css
@@ -12,7 +12,7 @@
 
 #actions
 {
-    padding-bottom: .5em;
+    padding-bottom: 0.5em;
     z-index: 200;
     position: relative;
 }

--- a/pootle/static/css/admin.css
+++ b/pootle/static/css/admin.css
@@ -207,7 +207,6 @@ html[dir="rtl"] td.pootle_path
 .admin-buttons-block input
 {
     display: inline;
-    margin-bottom: 1em;
     margin-left: 0.25em;
     margin-right: 0.25em;
 }

--- a/pootle/static/css/admin.css
+++ b/pootle/static/css/admin.css
@@ -22,7 +22,7 @@ div#depchecks ul#optimal
 {
     font-style: italic;
     background-color: inherit;
-    color: #4B4740;
+    color: #4b4740;
 }
 
 div#depchecks ul li
@@ -448,13 +448,13 @@ html[dir="rtl"] .admin-content .item-delete input
 
 .search-results tr:nth-child(2n+1)
 {
-    background-color: #F5FBFD;
+    background-color: #f5fbfd;
     color: #000;
 }
 
 .search-results tr:hover
 {
-    background-color: #E2F4F8;
+    background-color: #e2f4f8;
 }
 
 .search-results tr.is-disabled

--- a/pootle/static/css/admin.css
+++ b/pootle/static/css/admin.css
@@ -208,8 +208,8 @@ html[dir="rtl"] td.pootle_path
 {
     display: inline;
     margin-bottom: 1em;
-    margin-left: .25em;
-    margin-right: .25em;
+    margin-left: 0.25em;
+    margin-right: 0.25em;
 }
 
 

--- a/pootle/static/css/admin.css
+++ b/pootle/static/css/admin.css
@@ -65,7 +65,8 @@ html[dir="rtl"] .staticpages-edit
     height: 30em;
 }
 
-.staticpages td {
+.staticpages td
+{
     width: 1%;
 }
 

--- a/pootle/static/css/admin.css
+++ b/pootle/static/css/admin.css
@@ -438,7 +438,7 @@ html[dir="rtl"] .admin-content .item-delete input
 
 .search-results caption
 {
-    padding: 0 0 1em 0;
+    padding: 0 0 1em;
 }
 
 .search-results tr

--- a/pootle/static/css/auth.css
+++ b/pootle/static/css/auth.css
@@ -133,6 +133,7 @@
 {
     margin: 1em auto;
 }
+
 .auth-window .actions.password-forgotten
 {
     margin-top: -1.2em;

--- a/pootle/static/css/breadcrumbs.css
+++ b/pootle/static/css/breadcrumbs.css
@@ -15,7 +15,7 @@
 
 .browser .breadcrumb
 {
-    padding: 5px 0 0 0;
+    padding: 5px 0 0;
 }
 
 /* By default (on small screens), place resource dropdown on the second line */

--- a/pootle/static/css/breadcrumbs.css
+++ b/pootle/static/css/breadcrumbs.css
@@ -61,7 +61,7 @@ html[dir="rtl"] .breadcrumb li
     content: " / ";
 }
 
-.breadcrumb li:first-child:before,
+.breadcrumb li:first-child::before,
 .translate .breadcrumb li::before,
 .browser .breadcrumb li::before
 {

--- a/pootle/static/css/breadcrumbs.css
+++ b/pootle/static/css/breadcrumbs.css
@@ -116,6 +116,7 @@ html[dir="rtl"] .breadcrumb .select2-container .select2-choice abbr
 {
     cursor: default;
 }
+
 /* END HACK */
 
 .select2-results .project-disabled

--- a/pootle/static/css/breadcrumbs.css
+++ b/pootle/static/css/breadcrumbs.css
@@ -6,7 +6,6 @@
     font-weight: normal;
     font-family: 'Helvetica Neue', Helvetica, Helvetica, Arial, sans-serif;
     visibility: hidden;
-    margin-left: -5px;
     padding: 5px 0;
     height: 2em;
     display: table-cell;

--- a/pootle/static/css/buttons.css
+++ b/pootle/static/css/buttons.css
@@ -22,7 +22,7 @@
     box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.2) inset;
 
     text-align: center;
-    text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
 
     transition: all 0.25s linear 0s;
 

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -469,7 +469,7 @@ div.language-name
     border-bottom: 1px solid #f1f7f8;
     border-radius: 5px 5px 0 0;
 
-    padding: 1px 5px 0px;
+    padding: 1px 5px 0;
     display: inline-block;
     position: absolute;
     bottom: -1px;
@@ -771,7 +771,7 @@ html[dir="rtl"] .extras-bar a
 .extras-bar a.selected
 {
     background: rgba(0, 0, 0, 0.05);
-    box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.3) inset;
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.3) inset;
 }
 
 .extras-bar a i
@@ -892,7 +892,7 @@ html[dir="rtl"] .suggestion-action
 
 .extra-item-block .suggestion-feedback .field-wrapper
 {
-    margin: 5px 5px 0px 0px;
+    margin: 5px 5px 0 0;
 }
 
 .extra-item-block .suggestion-feedback .field-wrapper label,
@@ -910,13 +910,13 @@ html[dir="rtl"] .suggestion-action
 .extra-item-block .suggestion-feedback .buttons button
 {
     float: right;
-    margin: 15px 0px 5px 15px;
+    margin: 15px 0 5px 15px;
 }
 
 html[dir="rtl"] .extra-item-block .suggestion-feedback .buttons button
 {
     float: left;
-    margin: 15px 15px 5px 0px;
+    margin: 15px 15px 5px 0;
 }
 
 .extra-item-block .suggestion-feedback .buttons button i
@@ -1373,7 +1373,7 @@ table.suggest-mode .translate-fuzzy-block
 {
     position: absolute;
     left: 120px;
-    top: 0px;
+    top: 0;
     padding: 5px 0;
     line-height: 150%;
 }

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -1493,7 +1493,7 @@ a.editor-specialchar:hover
 {
     color: #999;
     border: 1px dotted #d9d9d9;
-    background-color: #F1F7F8; /* same as edit-row bg */
+    background-color: #f1f7f8; /* same as edit-row bg */
 }
 
 .tm-server .diff-delete,

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -1403,6 +1403,7 @@ table.suggest-mode .switch-suggest-mode .submit
 {
     position: absolute;
     top: -12px;
+
     /* LTR */
     right: 0;
 }

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -231,7 +231,7 @@ tr.edit-row.with-ctx
 
 tr.edit-ctx
 {
-    font-size: 82%
+    font-size: 82%;
 }
 
 tr.edit-ctx td

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -1099,7 +1099,7 @@ html[dir="rtl"] #target-item-gravatar
 
 .timeline-extra
 {
-    position:absolute;
+    position: absolute;
     top: 0;
     left: 100%;
     font-size: 0.9em;
@@ -1148,7 +1148,7 @@ html[dir="rtl"] .timeline-arrow::before
     font-size: 115%;
     display: inline-block;
     white-space: nowrap;
-    width:100%;
+    width: 100%;
     margin-top: 1em;
 }
 

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -776,7 +776,7 @@ html[dir="rtl"] .extras-bar a
 
 .extras-bar a i
 {
-    margin: 0 0.3em 0;
+    margin: 0 0.3em;
 }
 
 .extra-item-block
@@ -926,7 +926,7 @@ html[dir="rtl"] .extra-item-block .suggestion-feedback .buttons button
 
 .extra-item-block .suggestion-feedback form
 {
-    margin: 20px 20px 10px 20px;
+    margin: 20px 20px 10px;
 }
 
 .translate-full

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -628,7 +628,7 @@ td.translate-full textarea.translation
 {
     width: 100%;
     margin: 0;
-    min-height: 2.7em; 
+    min-height: 2.7em;
 }
 
 

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -424,7 +424,7 @@ html[dir="rtl"] div.unit-path li span.content-wrapper
 div.unit-path li a
 {
     color: #cff;
-    opacity: .8;
+    opacity: 0.8;
 }
 
 div.translate-left,

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -388,22 +388,22 @@ html[dir="rtl"] div.unit-path li
     margin-left: 0.3em;
 }
 
-div.unit-path li:after
+div.unit-path li::after
 {
     content: '→';
 }
 
-html[dir="rtl"] div.unit-path li:after
+html[dir="rtl"] div.unit-path li::after
 {
     content: '←';
 }
 
-div.unit-path li:last-child:after
+div.unit-path li:last-child::after
 {
     content: '';
 }
 
-html[dir="rtl"] div.unit-path li:last-child:after
+html[dir="rtl"] div.unit-path li:last-child::after
 {
     content: '';
 }
@@ -1128,12 +1128,12 @@ html[dir="rtl"] .timeline-extra
     unicode-bidi: embed;
 }
 
-.timeline-arrow:before
+.timeline-arrow::before
 {
     content: "→";
 }
 
-html[dir="rtl"] .timeline-arrow:before
+html[dir="rtl"] .timeline-arrow::before
 {
     content: "←";
 }

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -244,16 +244,16 @@ tr.edit-ctx td
 
 tr.edit-ctx a
 {
-     text-decoration: none;
+    text-decoration: none;
 
-     opacity: 0.5;
+    opacity: 0.5;
 }
 
 tr.edit-ctx a:hover
 {
-     text-decoration: none;
+    text-decoration: none;
 
-     opacity: 1;
+    opacity: 1;
 }
 
 tr.edit-ctx.before .edit-ctx-wrapper

--- a/pootle/static/css/navbar.css
+++ b/pootle/static/css/navbar.css
@@ -240,14 +240,16 @@ html[dir="rtl"] #nav-access
 
 /* Responsive styles */
 
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 900px)
+{
     #nav-main
     {
         display: block !important;
     }
 }
 
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 900px)
+{
     .brand-name
     {
         display: none;

--- a/pootle/static/css/navbar.css
+++ b/pootle/static/css/navbar.css
@@ -260,7 +260,7 @@ html[dir="rtl"] #nav-access
         max-width: 70%;
     }
 
-    #navbar:after
+    #navbar::after
     {
         clear: both;
     }

--- a/pootle/static/css/navbar.css
+++ b/pootle/static/css/navbar.css
@@ -175,7 +175,7 @@ html[dir="rtl"] #nav-main > li
     margin: 0 8px;
     border: 2px solid white;
     border-radius: 50%;
-    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 #nav-main .login .btn

--- a/pootle/static/css/odometer.css
+++ b/pootle/static/css/odometer.css
@@ -9,8 +9,9 @@
     background: rgba(0, 0, 0, 0.3);
     padding: 2px 4px;
     border-radius: 4px;
-    box-shadow: 0 -1px 0px rgba(255, 255, 255, 0.2) inset,
-                0  1px 0px rgba(0, 0, 0, 0.2) inset;
+    box-shadow:
+        0 -1px 0px rgba(255, 255, 255, 0.2) inset,
+        0  1px 0px rgba(0, 0, 0, 0.2) inset;
     transition: 2s width ease;
 }
 

--- a/pootle/static/css/odometer.css
+++ b/pootle/static/css/odometer.css
@@ -10,8 +10,8 @@
     padding: 2px 4px;
     border-radius: 4px;
     box-shadow:
-        0 -1px 0px rgba(255, 255, 255, 0.2) inset,
-        0  1px 0px rgba(0, 0, 0, 0.2) inset;
+        0 -1px 0 rgba(255, 255, 255, 0.2) inset,
+        0  1px 0 rgba(0, 0, 0, 0.2) inset;
     transition: 2s width ease;
 }
 

--- a/pootle/static/css/odometer.css
+++ b/pootle/static/css/odometer.css
@@ -88,21 +88,25 @@ html[dir='rtl'] .odometer-inside
 {
     position: absolute;
 }
+
 .odometer.odometer-auto-theme.odometer-animating-up .odometer-ribbon-inner,
 .odometer.odometer-theme-default.odometer-animating-up .odometer-ribbon-inner
 {
     transition: transform 2s;
 }
+
 .odometer.odometer-auto-theme.odometer-animating-up.odometer-animating .odometer-ribbon-inner,
 .odometer.odometer-theme-default.odometer-animating-up.odometer-animating .odometer-ribbon-inner
 {
     transform: translateY(-100%);
 }
+
 .odometer.odometer-auto-theme.odometer-animating-down .odometer-ribbon-inner,
 .odometer.odometer-theme-default.odometer-animating-down .odometer-ribbon-inner
 {
     transform: translateY(-100%);
 }
+
 .odometer.odometer-auto-theme.odometer-animating-down.odometer-animating .odometer-ribbon-inner,
 .odometer.odometer-theme-default.odometer-animating-down.odometer-animating .odometer-ribbon-inner
 {

--- a/pootle/static/css/popup.css
+++ b/pootle/static/css/popup.css
@@ -33,7 +33,7 @@
 .popup-ajax .popup-form,
 .lightbox-body
 {
-    line-height: 1!important;
+    line-height: 1 !important;
 }
 
 /* MFP popus are next to the body, they need a bigger font-size */

--- a/pootle/static/css/popup.css
+++ b/pootle/static/css/popup.css
@@ -76,7 +76,7 @@ html[dir="rtl"] .lightbox-body
 .popup-form .buttons input,
 .lightbox-body .buttons input
 {
-    margin: 0.3em 0px 0px;
+    margin: 0.3em 0 0;
 }
 
 .popup-form label,
@@ -89,5 +89,5 @@ html[dir="rtl"] .lightbox-body
 /* for forms displayed in lightbox mode (via magnificPopup plugin), use different shadow */
 .mfp-content .form
 {
-    box-shadow: 0px 2px 30px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 2px 30px rgba(0, 0, 0, 0.5);
 }

--- a/pootle/static/css/reports.css
+++ b/pootle/static/css/reports.css
@@ -228,7 +228,7 @@ html[dir="rtl"] #detailed
     text-align: center;
     background-color: #eee;
     padding-top: 2em;
-    padding-bottom: 2em ;
+    padding-bottom: 2em;
 }
 
 #forms h2

--- a/pootle/static/css/reports.css
+++ b/pootle/static/css/reports.css
@@ -278,7 +278,7 @@ html[dir="rtl"] #detailed
 #paid-task-form .units
 {
     float: left;
-    padding: 5px 5px 0px 5px;
+    padding: 5px 5px 0 5px;
 }
 
 #paid-task-form #id_description

--- a/pootle/static/css/reports.css
+++ b/pootle/static/css/reports.css
@@ -278,7 +278,7 @@ html[dir="rtl"] #detailed
 #paid-task-form .units
 {
     float: left;
-    padding: 5px 5px 0 5px;
+    padding: 5px 5px 0;
 }
 
 #paid-task-form #id_description

--- a/pootle/static/css/select2-pootle.css
+++ b/pootle/static/css/select2-pootle.css
@@ -29,7 +29,7 @@
     border-radius: 2px;
 
     background-color: #fcfcfc;
-    background-image: linear-gradient(to bottom, #fcfcfc 0%, #eeeeee 50%);
+    background-image: linear-gradient(to bottom, #fcfcfc 0%, #eee 50%);
 }
 
 .breadcrumb .select2-container .select2-choice,
@@ -81,7 +81,7 @@ html[dir="rtl"] .select2-container.select2-allowclear .select2-choice span
     border-radius: 0 2px 2px 0;
 
     background-color: #ddd;
-    background-image: linear-gradient(to top, #dddddd 0%, #eeeeee 60%);
+    background-image: linear-gradient(to top, #ddd 0%, #eee 60%);
 }
 
 html[dir="rtl"] .select2-container .select2-choice div
@@ -122,7 +122,7 @@ html[dir="rtl"] .select2-container .select2-choice div
 .unit-sort .select2-dropdown-open .select2-choice
 {
     background-color: #eee;
-    background-image: linear-gradient(to bottom, #ffffff 0%,#eeeeee 50%);
+    background-image: linear-gradient(to bottom, #fff 0%,#eee 50%);
 }
 
 .select2-results .select2-highlighted

--- a/pootle/static/css/select2-pootle.css
+++ b/pootle/static/css/select2-pootle.css
@@ -41,12 +41,14 @@
     filter: none;
 }
 
-html[dir="rtl"] .select2-container .select2-choice span {
+html[dir="rtl"] .select2-container .select2-choice span
+{
     margin-right: auto;
     margin-left: 26px;
 }
 
-html[dir="rtl"] .select2-container.select2-allowclear .select2-choice span {
+html[dir="rtl"] .select2-container.select2-allowclear .select2-choice span
+{
     margin-right: auto;
     margin-left: 42px;
 }

--- a/pootle/static/css/select2-pootle.css
+++ b/pootle/static/css/select2-pootle.css
@@ -122,7 +122,7 @@ html[dir="rtl"] .select2-container .select2-choice div
 .unit-sort .select2-dropdown-open .select2-choice
 {
     background-color: #eee;
-    background-image: linear-gradient(to bottom, #fff 0%,#eee 50%);
+    background-image: linear-gradient(to bottom, #fff 0%, #eee 50%);
 }
 
 .select2-results .select2-highlighted

--- a/pootle/static/css/select2-pootle.css
+++ b/pootle/static/css/select2-pootle.css
@@ -162,7 +162,6 @@ html[dir="rtl"] .select2-search-choice-close
 }
 
 
-
 /* Width specification for several selects */
 
 /* Styles for "multiple" selects */

--- a/pootle/static/css/select2-pootle.css
+++ b/pootle/static/css/select2-pootle.css
@@ -61,7 +61,7 @@ html[dir="rtl"] .select2-container.select2-allowclear .select2-choice span
 .select2-container.select2-drop-above .select2-choice
 {
     border-bottom-color: #d9d9d9;
-    border-radius:0 0 2px 2px;
+    border-radius: 0 0 2px 2px;
 }
 
 .select2-drop

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -812,6 +812,7 @@ html[dir="rtl"] #autorefresh-notice .x
     position: relative;
     width: 100%;
     display: inline-block;
+
     /* height calculated via js */
 }
 
@@ -1842,6 +1843,7 @@ html[dir="rtl"] .summary-3-col
     background-color: #ccc;
     width: 100%;
     margin-bottom: 1em;
+
     /* hide graph areas while we don't render anything there */
     display: none;
 }

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -455,7 +455,7 @@ td.stats-name a:hover > i + span,
 
 #footer .nav li::after
 {
-    content:  " | ";
+    content: " | ";
     margin: 0 1em;
 }
 

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1024,17 +1024,17 @@ html[dir="rtl"] .form .buttons
 
 .form.message
 {
-    background: linear-gradient(to bottom,  #e5f3f8,  #cde7f1);
+    background: linear-gradient(to bottom, #e5f3f8, #cde7f1);
 }
 
 .form.success
 {
-    background: linear-gradient(to bottom,  #efd,  #cf9);
+    background: linear-gradient(to bottom, #efd, #cf9);
 }
 
 .form.error
 {
-    background: linear-gradient(to bottom,  #fee,  #fcc);
+    background: linear-gradient(to bottom, #fee, #fcc);
 }
 
 .form p.info

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -57,7 +57,7 @@ body
 html
 {
     color: #130f30;
-    background: #FFF;
+    background: #fff;
     width: 100%;
     margin: 0;
     padding: 0;
@@ -65,7 +65,7 @@ html
 
 body
 {
-    background: #FFF;
+    background: #fff;
     color: #130f30;
     width: 100%;
 
@@ -399,7 +399,7 @@ td.stats-name a:hover > i + span,
 {
     background-color: #f8f8f8;
     color: #d9d9d9;
-    border-top: 1px dashed #D9D9D9;
+    border-top: 1px dashed #d9d9d9;
     clear: both;
     font-size: 12px;
     text-align: center;
@@ -1554,7 +1554,7 @@ html[dir="rtl"] ul.pager li:last-child > *
 
 #header-tabs
 {
-    border-bottom: 1px solid #D9D9D9;
+    border-bottom: 1px solid #d9d9d9;
 }
 
 #header-meta

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -38,12 +38,15 @@
  * BASIC ELEMENT STYLING
  */
 
-#header-meta, #footer, .header
+#header-meta,
+#footer,
+.header
 {
     background-color: #eee;
 }
 
-#body, html#tp
+#body,
+html#tp
 {
     background: white;
 }
@@ -137,14 +140,21 @@ td
     padding: 5px 0;
 }
 
-h1, h2, h3, h4, h5, h6
+h1,
+h2,
+h3,
+h4,
+h5,
+h6
 {
     font-weight: normal;
     font-size: 100%;
     color: #999;
 }
 
-h1, h2, h3
+h1,
+h2,
+h3
 {
     font-family: sans-serif;
 }
@@ -180,18 +190,31 @@ h6
     font-size: 100%;
 }
 
-body, div,
-ul, ol, li,
-h1, h2, h3, h4, h5, h6,
-pre, code,
-form, fieldset, legend,
-p, blockquote
+body,
+div,
+ul,
+ol,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+p,
+blockquote
 {
     margin: 0;
     padding: 0;
 }
 
-input, textarea
+input,
+textarea
 {
     margin: 0;
 }
@@ -209,8 +232,13 @@ img
     border: 0;
 }
 
-address, caption, cite, code, dfn,
-th, var
+address,
+caption,
+cite,
+code,
+dfn,
+th,
+var
 {
     font-style: normal;
     font-weight: normal;
@@ -272,7 +300,11 @@ legend
     color: #130f30;
 }
 
-pre, code, kbd, samp, tt
+pre,
+code,
+kbd,
+samp,
+tt
 {
     font-family: monospace;
     line-height: 100%;
@@ -2170,7 +2202,15 @@ table.stats .item.dirty .last-updated
  */
 
 /* Doesn't work: [dir="rtl"] */
-*:lang(ar), *:lang(arc), *:lang(dv), *:lang(fa), *:lang(he), *:lang(ks), *:lang(ps), *:lang(ur), *:lang(yi)
+*:lang(ar),
+*:lang(arc),
+*:lang(dv),
+*:lang(fa),
+*:lang(he),
+*:lang(ks),
+*:lang(ps),
+*:lang(ur),
+*:lang(yi)
 {
     /* If any styling is necessary for the rtl languages, add it here */
     direction: rtl;

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1243,7 +1243,7 @@ td.stats-number.suggestions .stats-data
 
 td.stats-number.suggestions a.stats-data
 {
-    background: #bbaa66;
+    background: #ba6;
 }
 
 td.stats-number.critical .stats-data

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -262,8 +262,8 @@ html[dir="rtl"] th
     text-align: right;
 }
 
-q:before,
-q:after
+q::before,
+q::after
 {
     content: '';
 }
@@ -315,7 +315,7 @@ tt
     clear: both;
 }
 
-#bd:after
+#bd::after
 {
     content: ".";
     display: block;
@@ -454,13 +454,13 @@ td.stats-name a:hover > i + span,
     display: inline;
 }
 
-#footer .nav li:after
+#footer .nav li::after
 {
     content:  " | ";
     margin: 0 1em;
 }
 
-#footer .nav li:last-child:after
+#footer .nav li:last-child::after
 {
     content: '';
     margin: 0;
@@ -607,12 +607,12 @@ html[dir="rtl"] #sidebar
     display: block;
 }
 
-.sidebar-open #sidebar-toggle:after
+.sidebar-open #sidebar-toggle::after
 {
     content: '»';
 }
 
-#sidebar-toggle:after
+#sidebar-toggle::after
 {
     content: '«';
 }
@@ -2015,8 +2015,8 @@ html[dir="rtl"] #tabs li
     outline: 0;
 }
 
-.search-container:after,
-.search-container:before
+.search-container::after,
+.search-container::before
 {
     bottom: 100%;
     border: solid transparent;
@@ -2027,7 +2027,7 @@ html[dir="rtl"] #tabs li
     pointer-events: none;
 }
 
-.search-container:after
+.search-container::after
 {
     border-color: rgba(255, 255, 255, 0);
     border-bottom-color: #fff;
@@ -2036,7 +2036,7 @@ html[dir="rtl"] #tabs li
     margin-left: -5px;
 }
 
-.search-container:before
+.search-container::before
 {
     border-color: rgba(217, 217, 217, 0);
     border-bottom-color: #d9d9d9;

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -432,7 +432,6 @@ td.stats-name a:hover > i + span,
     background-color: #f8f8f8;
     color: #d9d9d9;
     border-top: 1px dashed #d9d9d9;
-    clear: both;
     font-size: 12px;
     text-align: center;
     position: absolute;
@@ -910,7 +909,6 @@ html[dir="rtl"] .hd h2
 
 .last-action img
 {
-    vertical-align: text-bottom;
     width: 20px;
     height: 20px;
     position: absolute;

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -130,7 +130,7 @@ pre
 th
 {
     font-size: 110%;
-    padding: 0 0 7px 0;
+    padding: 0 0 7px;
     background-color: inherit;
     color: #4b4742;
 }
@@ -1688,7 +1688,7 @@ html[dir="rtl"] .expand-stats
     display: block;
     margin-top: 11px;
     margin-left: -10px;
-    padding: 10px 0 10px 0;
+    padding: 10px 0;
     height: 15px;
 }
 
@@ -1756,7 +1756,7 @@ html[dir="rtl"] .summary-3-col
 
 .path-summary-more .summary-2-col
 {
-    margin: 0 3.125% 0 3.125%;
+    margin: 0 3.125%;
 }
 
 
@@ -1777,12 +1777,12 @@ html[dir="rtl"] .summary-3-col
 
     #top-stats .path-summary-more .summary-3-col h3.top
     {
-        margin: 1em 0 0 0;
+        margin: 1em 0 0;
     }
 
     .path-summary-more.expand .path-summary-expanded
     {
-        margin: 2.5em 0 1em 0;
+        margin: 2.5em 0 1em;
     }
 
     .path-summary-more .summary-2-col
@@ -1808,19 +1808,19 @@ html[dir="rtl"] .summary-3-col
 
 .path-summary-more .bd
 {
-    margin: 1em 0 1em 0;
+    margin: 1em 0;
 }
 
 .path-summary-more .summary-3-col .bd
 {
-    margin: 1em 0 1em 0;
+    margin: 1em 0;
 }
 
 
 #top-stats .path-summary-more h3
 {
     border: 0;
-    margin: 2em 0 0 0;
+    margin: 2em 0 0;
 }
 
 #top-stats .path-summary-more h3.top

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -188,7 +188,7 @@ form, fieldset, legend,
 p, blockquote
 {
     margin: 0;
-    padding: 0px;
+    padding: 0;
 }
 
 input, textarea
@@ -541,7 +541,7 @@ td.stats-name a:hover > i + span,
 
     background-color: #fff;
 
-    box-shadow: -1px 0px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: -1px 0 2px rgba(0, 0, 0, 0.2);
     transition: all 0.3s ease 0s;
 }
 
@@ -562,7 +562,7 @@ html[dir="rtl"] #sidebar
     right: auto;
     left: 0;
 
-    box-shadow: 1px 0px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: 1px 0 2px rgba(0, 0, 0, 0.2);
 }
 
 #sidebar #sidebar-content
@@ -600,7 +600,7 @@ html[dir="rtl"] #sidebar
     text-decoration: none;
     font-size: 24px;
 
-    box-shadow: -2px 0px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: -2px 0 2px rgba(0, 0, 0, 0.2);
     border-radius: 2px 0 0 2px;
 }
 
@@ -609,7 +609,7 @@ html[dir="rtl"] #sidebar-toggle
     left: auto;
     right: -1em;
 
-    box-shadow: 2px 0px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: 2px 0 2px rgba(0, 0, 0, 0.2);
     border-radius: 0 2px 2px 0;
 }
 
@@ -945,7 +945,7 @@ html[dir="rtl"] .last-action .user-name
     padding: 1em;
     text-align: left;
     border-radius: 10px;
-    box-shadow: 0px 2px 5px #777;
+    box-shadow: 0 2px 5px #777;
 
     background: #eee;
 }
@@ -1634,7 +1634,7 @@ html[dir="rtl"] .expand-stats
 {
     position: relative;
     top: 20px;
-    left: 0px;
+    left: 0;
 }
 
 .path-summary-more
@@ -1936,7 +1936,7 @@ html[dir="rtl"] #tabs li
     border: 0 none;
     height: 16px;
     line-height: 16px;
-    padding: 0px 4px;
+    padding: 0 4px;
     width: 145px;
     background-color: #fff;
     color: #666;

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -795,12 +795,12 @@ html[dir="rtl"] #autorefresh-notice .x
 
 .stats tr.item
 {
-   display: none;
+    display: none;
 }
 
 .stats tr.item.is-visible
 {
-   display: table-row;
+    display: table-row;
 }
 
 tr.view-row:nth-child(odd),
@@ -1440,7 +1440,7 @@ table.sortable th
 
 table.sortable th i
 {
-  vertical-align: middle;
+    vertical-align: middle;
 }
 
 table.sortable th.sorttable_nosort
@@ -2241,7 +2241,7 @@ table.stats .item.dirty .last-updated
 
 .vfolders
 {
-     margin-bottom: 3em;
+    margin-bottom: 3em;
 }
 
 /* FIX FOR HEADING SIZES */

--- a/pootle/static/css/user.css
+++ b/pootle/static/css/user.css
@@ -10,7 +10,7 @@
 
 #profile-page #content
 {
-    background: url(../images/bg.png) 0px 0px repeat-x;
+    background: url(../images/bg.png) 0 0 repeat-x;
     margin: 0;
 }
 

--- a/pootle/static/css/user.css
+++ b/pootle/static/css/user.css
@@ -164,7 +164,7 @@
 
 #user-details .edit-profile-btn
 {
-    margin: 2em 0 1em 0;
+    margin: 2em 0 1em;
 }
 
 

--- a/pootle/static/css/user.css
+++ b/pootle/static/css/user.css
@@ -188,7 +188,7 @@
 
 .lightbox-body.user-edit
 {
-  font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 #user-edit

--- a/pootle/static/css/user.css
+++ b/pootle/static/css/user.css
@@ -61,7 +61,7 @@
 #user-stats .user-score,
 #user-stats .user-position
 {
-    color: #5A8295;
+    color: #5a8295;
 }
 
 #user-meta .admin,

--- a/pootle/static/css/welcome.css
+++ b/pootle/static/css/welcome.css
@@ -12,8 +12,8 @@
 
 #welcome-page #content
 {
-  background: url(../images/bg.png) 0px 0px repeat-x;
-  margin: 0;
+    background: url(../images/bg.png) 0px 0px repeat-x;
+    margin: 0;
 }
 
 #welcome-page .top
@@ -58,8 +58,7 @@
     width: 960px;
 }
 
-@media
-only screen and (max-width: 960px)
+@media only screen and (max-width: 960px)
 {
     #welcome-page .columns-inner
     {
@@ -72,8 +71,7 @@ only screen and (max-width: 960px)
     width: 480px;
 }
 
-@media
-only screen and (max-width: 480px)
+@media only screen and (max-width: 480px)
 {
     #welcome-page .column
     {

--- a/pootle/static/css/welcome.css
+++ b/pootle/static/css/welcome.css
@@ -12,7 +12,7 @@
 
 #welcome-page #content
 {
-    background: url(../images/bg.png) 0px 0px repeat-x;
+    background: url(../images/bg.png) 0 0 repeat-x;
     margin: 0;
 }
 

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -22,6 +22,7 @@
     "eslint-plugin-react": "^4.2.0",
     "style-loader": "^0.8.0",
     "stylelint": "^7.1.0",
+    "stylelint-config-standard": "^12.0.0",
     "webpack": "^1.9.8"
   },
   "dependencies": {

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -7,7 +7,8 @@
     "url": "git://github.com/translate/pootle.git"
   },
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "stylelint": "stylelint --config=stylelint.json ../css/**/*.css **/*.css"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
@@ -20,6 +21,7 @@
     "eslint-config-airbnb": "~6.2.0",
     "eslint-plugin-react": "^4.2.0",
     "style-loader": "^0.8.0",
+    "stylelint": "^7.1.0",
     "webpack": "^1.9.8"
   },
   "dependencies": {

--- a/pootle/static/js/shared/components/lightbox.css
+++ b/pootle/static/js/shared/components/lightbox.css
@@ -15,8 +15,8 @@
 {
     position: fixed;
     z-index: 498;
-    top: 0px;
-    left: 0px;
+    top: 0;
+    left: 0;
 
     height: 100%;
     width: 100%;

--- a/pootle/static/js/shared/components/lightbox.css
+++ b/pootle/static/js/shared/components/lightbox.css
@@ -8,124 +8,124 @@
 
 .lightbox-lock
 {
-  overflow: hidden;
+    overflow: hidden;
 }
 
 .lightbox-bg
 {
-  position: fixed;
-  z-index: 498;
-  top: 0px;
-  left: 0px;
+    position: fixed;
+    z-index: 498;
+    top: 0px;
+    left: 0px;
 
-  height: 100%;
-  width: 100%;
+    height: 100%;
+    width: 100%;
 
-  background: rgba(11, 11, 11, 0.8);
+    background: rgba(11, 11, 11, 0.8);
 
-  outline: medium none;
+    outline: medium none;
 }
 
 .lightbox-container
 {
-  box-sizing: border-box;
-  position: absolute;
-  z-index: 499;
-  left: 0;
-  top: 0;
+    box-sizing: border-box;
+    position: absolute;
+    z-index: 499;
+    left: 0;
+    top: 0;
 
-  height: 100%;
-  width: 100%;
+    height: 100%;
+    width: 100%;
 
-  padding: 0;
-  text-align: center;
+    padding: 0;
+    text-align: center;
 
-  overflow-x: hidden;
-  overflow-y: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .lightbox-container::before
 {
-  content: '';
-  display: inline-block;
-  height: 100%;
-  vertical-align: middle;
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
 }
 
 .lightbox-body
 {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin: 0 auto;
-  text-align: left;
-  padding: 2em 3em;
-  min-width: 255px;
-  font-size: 100%;
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 auto;
+    text-align: left;
+    padding: 2em 3em;
+    min-width: 255px;
+    font-size: 100%;
 }
 
 .lightbox-header
 {
-  margin-bottom: 2em;
+    margin-bottom: 2em;
 }
 
 .lightbox-content
 {
-  margin: 1em 0;
+    margin: 1em 0;
 }
 
 .lightbox-footer
 {
-  margin-top: 2em;
-  text-align: right;
+    margin-top: 2em;
+    text-align: right;
 }
 
 html[dir="rtl"] .lightbox-footer
 {
-  text-align: left;
+    text-align: left;
 }
 
 .lightbox-footer .btn + .btn
 {
-  margin-left: 0.5em;
+    margin-left: 0.5em;
 }
 
 html[dir="rtl"] .lightbox-footer .btn + .btn
 {
-  margin-left: 0;
-  margin-right: 0.5em;
+    margin-left: 0;
+    margin-right: 0.5em;
 }
 
 .lightbox-close
 {
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 44px;
-  height: 44px;
-  line-height: 44px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 44px;
+    height: 44px;
+    line-height: 44px;
 
-  text-decoration: none;
-  text-align: center;
-  background-color: transparent;
-  color: rgba(0, 0, 0, 0.5);
+    text-decoration: none;
+    text-align: center;
+    background-color: transparent;
+    color: rgba(0, 0, 0, 0.5);
 
-  font-style: normal;
-  font-size: 28px;
-  font-family: "Arial", monospace;
+    font-style: normal;
+    font-size: 28px;
+    font-family: "Arial", monospace;
 
-  border: 0;
-  cursor: pointer;
+    border: 0;
+    cursor: pointer;
 }
 
 html[dir="rtl"] .lightbox-close
 {
-  right: auto;
-  left: 0;
+    right: auto;
+    left: 0;
 }
 
 .lightbox-close:hover,
 .lightbox-close:focus
 {
-  color: rgba(0, 0, 0, 1);
+    color: rgba(0, 0, 0, 1);
 }

--- a/pootle/static/js/stylelint.json
+++ b/pootle/static/js/stylelint.json
@@ -1,6 +1,8 @@
 # Configuration: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#rules
 # Example: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/example-config.md
+# Default config: https://github.com/stylelint/stylelint-config-standard
 {
+  "extends": "stylelint-config-standard",
   "ignoreFiles": [
     "../css/magnific-popup.css",
     "../css/react-select.css",
@@ -10,6 +12,14 @@
     "node_modules"
   ],
   "rules": {
-    "indentation": 4
+    "block-opening-brace-space-before": null,
+    "block-opening-brace-newline-before": "always",
+    "declaration-empty-line-before": null,
+    "indentation": 4,
+    "max-empty-lines": 2,
+    "rule-non-nested-empty-line-before": ["always", {
+        "except": ["after-single-line-comment"],
+        "ignore": ["after-comment"]
+        }]
   }
 }

--- a/pootle/static/js/stylelint.json
+++ b/pootle/static/js/stylelint.json
@@ -1,0 +1,15 @@
+# Configuration: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#rules
+# Example: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/example-config.md
+{
+  "ignoreFiles": [
+    "../css/magnific-popup.css",
+    "../css/react-select.css",
+    "../css/select2.css",
+    "../css/sprite.css",
+    "../css/tipsy.css",
+    "node_modules"
+  ],
+  "rules": {
+    "indentation": 4
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -68,5 +68,5 @@ commands=
     python setup.py sdist
     make docs
     python setup.py build_mo
-    make jslint
+    make lint-js
     pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle

--- a/tox.ini
+++ b/tox.ini
@@ -69,4 +69,5 @@ commands=
     make docs
     python setup.py build_mo
     make lint-js
+    make lint-css
     pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle


### PR DESCRIPTION
This adds stylelint to do CSS linting (and replaced #4930 which tried using csslint)

This also uses the stylelint-standard-config and implements the linting suggested. Minor deviations from this guide are added to follow our suggested style and comment anomalies.