### PR TITLE
Migrations in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files=*.py
-addopts=--nomigrations --tb=short tests
+addopts=--tb=short tests
 norecursedirs=.git _build tmp* requirements commands/*
 markers=
     cmd: Django admin commands.


### PR DESCRIPTION
- remove the `--nomigrations` flag
- add a fixture to run migrations if db is used in tests

this makes it easier to test migrations, and makes the test env closer to the env that users actually have