### PR TITLE
[WIP] Denormalize Store.get_max_unit_revision

### DIFF
--- a/pootle/apps/pootle_app/project_tree.py
+++ b/pootle/apps/pootle_app/project_tree.py
@@ -193,7 +193,7 @@ def create_or_resurrect_store(f, parent, name, translation_project):
         store.obsolete = False
         store.file_mtime = datetime_min
         if store.last_sync_revision is None:
-            store.last_sync_revision = store.get_max_unit_revision()
+            store.last_sync_revision = store.revision
 
         store_log(user='system', action=STORE_RESURRECTED,
                   path=store.pootle_path, store=store.id)

--- a/pootle/apps/pootle_fs/files.py
+++ b/pootle/apps/pootle_fs/files.py
@@ -88,7 +88,7 @@ class FSFile(object):
         return (
             self.store_exists
             and (
-                self.store.get_max_unit_revision()
+                self.store.revision
                 != self.store_fs.last_sync_revision))
 
     @cached_property
@@ -149,7 +149,7 @@ class FSFile(object):
         self.store_fs.resolve_conflict = None
         self.store_fs.staged_for_merge = False
         self.store_fs.last_sync_hash = self.latest_hash
-        self.store_fs.last_sync_revision = self.store.get_max_unit_revision()
+        self.store_fs.last_sync_revision = self.store.revision
         self.store_fs.save()
         logger.debug("File synced: %s", self.path)
 

--- a/pootle/apps/pootle_store/apps.py
+++ b/pootle/apps/pootle_store/apps.py
@@ -19,3 +19,4 @@ class PootleStoreConfig(AppConfig):
     def ready(self):
         importlib.import_module("pootle_store.getters")
         importlib.import_module("pootle_store.providers")
+        importlib.import_module("pootle_store.receivers")

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -131,7 +131,7 @@ class StoreDiff(object):
         self.target_store = target_store
         self.source_store = source_store
         self.source_revision = source_revision
-        self.target_revision = self.get_target_revision()
+        self.target_revision = self.target_store.revision
 
     @property
     def diff_class(self):
@@ -141,9 +141,6 @@ class StoreDiff(object):
         if differ:
             return differ
         return diffs["default"]
-
-    def get_target_revision(self):
-        return self.target_store.get_max_unit_revision()
 
     @cached_property
     def active_target_units(self):

--- a/pootle/apps/pootle_store/migrations/0014_store_revision.py
+++ b/pootle/apps/pootle_store/migrations/0014_store_revision.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0013_set_store_filetype_again'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='store',
+            name='revision',
+            field=models.IntegerField(default=0, db_index=True, blank=True),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0015_set_store_revisions.py
+++ b/pootle/apps/pootle_store/migrations/0015_set_store_revisions.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from pootle_store.revision import StoreRevision
+
+
+def set_store_revisions(apps, schema_editor):
+    Store = apps.get_model("pootle_store.Store")
+    for store in Store.objects.all():
+        StoreRevision(store).update()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0014_store_revision'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_store_revisions),
+    ]

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1159,6 +1159,9 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
     last_sync_revision = models.IntegerField(db_index=True, null=True)
     obsolete = models.BooleanField(default=False)
 
+    revision = models.IntegerField(
+        null=False, default=0, db_index=True, blank=True)
+
     objects = StoreManager()
     simple_objects = models.Manager()
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1500,9 +1500,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         if self.file and hasattr(self.file.store, 'header'):
             return self.file.store.header()
 
-    def get_max_unit_revision(self):
-        return max_column(self.unit_set.all(), 'revision', 0)
-
     # # # TreeItem
     def can_be_updated(self):
         return not self.obsolete

--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Unit
+
+
+@receiver(post_save, sender=Unit)
+def unit_postsave_handler(**kwargs):
+    """Update the revision of the store when unit changes
+    """
+    instance = kwargs["instance"]
+    if instance.revision > instance.store.revision:
+        instance.store.revision = instance.revision
+        instance.store.save()

--- a/pootle/apps/pootle_store/revision.py
+++ b/pootle/apps/pootle_store/revision.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.utils.aggregate import max_column
+
+
+class StoreRevision(object):
+
+    def __init__(self, store):
+        self.store = store
+
+    def get_max_unit_revision(self):
+        return max_column(
+            self.store.unit_set.all(), 'revision', 0)
+
+    def update(self):
+        current_revision = self.get_max_unit_revision()
+        if current_revision != self.store.revision:
+            self.store.revision = current_revision
+            self.store.save()

--- a/pootle/apps/pootle_store/store/serialize.py
+++ b/pootle/apps/pootle_store/store/serialize.py
@@ -33,10 +33,6 @@ class StoreSerialization(object):
         return self.store.pootle_path
 
     @cached_property
-    def max_unit_revision(self):
-        return self.store.get_max_unit_revision()
-
-    @cached_property
     def serializers(self):
         available_serializers = serializers.gather(
             self.store.translation_project.project.__class__)
@@ -51,7 +47,7 @@ class StoreSerialization(object):
             # FIXME We need those headers on import
             # However some formats just don't support setting metadata
             store.updateheader(add=True, X_Pootle_Path=self.pootle_path)
-            store.updateheader(add=True, X_Pootle_Revision=self.max_unit_revision)
+            store.updateheader(add=True, X_Pootle_Revision=self.store.revision)
         return str(store)
 
     def pipeline(self, data):
@@ -65,11 +61,11 @@ class StoreSerialization(object):
         cache = caches["exports"]
         ret = cache.get(
             self.pootle_path,
-            version=self.max_unit_revision)
+            version=self.store.revision)
         if not ret:
             ret = self.pipeline(self.tostring())
             cache.set(
                 self.pootle_path,
                 ret,
-                version=self.max_unit_revision)
+                version=self.store.revision)
         return ret

--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -266,7 +266,7 @@ class StoreSyncer(object):
 
     def sync(self, update_structure=False, conservative=True,
              user=None, only_newer=True):
-        last_revision = self.store.get_max_unit_revision()
+        last_revision = self.store.revision
 
         # TODO only_newer -> not force
         if only_newer and not self.update_newer(last_revision):

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -253,7 +253,7 @@ class StoreUpdater(object):
                 log(u"[update] %s units in %s [revision: %d]"
                     % (get_change_str(changes),
                        self.target_store.pootle_path,
-                       self.target_store.get_max_unit_revision()))
+                       self.target_store.revision))
         return update_revision, changes
 
     def update_from_diff(self, store, store_revision,
@@ -305,7 +305,7 @@ class StoreUpdater(object):
             return changed
 
         if overwrite:
-            store_revision = self.target_store.get_max_unit_revision()
+            store_revision = self.target_store.revision
         else:
             store_revision = self.target_store.last_sync_revision or 0
 

--- a/pootle/apps/pootle_translationproject/utils.py
+++ b/pootle/apps/pootle_translationproject/utils.py
@@ -187,7 +187,7 @@ class TPTool(object):
 
     def update_store(self, source, target):
         """Update a target Store from a given source Store"""
-        source_revision = target.get_max_unit_revision() + 1
+        source_revision = target.revision + 1
         differ = StoreDiff(target, source, source_revision)
         diff = differ.diff()
         if diff is None:

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -123,7 +123,7 @@ def _setup_store_test(store, member, member2, test):
                  (DEFAULT_STORE_UNITS_1 + DEFAULT_STORE_UNITS_2)]
 
     for units in setup:
-        store_revision = store.get_max_unit_revision()
+        store_revision = store.revision
         print "setup store: %s %s" % (store_revision, units)
         update_store(store, store_revision=store_revision, units=units,
                      user=member)
@@ -143,7 +143,7 @@ def _setup_store_test(store, member, member2, test):
         resolve_conflict = POOTLE_WINS
 
     if store_revision == "MAX":
-        store_revision = store.get_max_unit_revision()
+        store_revision = store.revision
 
     elif store_revision == "MID":
         revisions = [unit.revision for unit in units_before]

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -135,7 +135,7 @@ def get_translated_storefile(store, pootle_path=None):
     path = pootle_path if pootle_path is not None else store.pootle_path
     filestore.updateheader(add=True, X_Pootle_Path=path)
     filestore.updateheader(add=True,
-                           X_Pootle_Revision=store.get_max_unit_revision())
+                           X_Pootle_Revision=store.revision)
 
     return filestore
 
@@ -148,7 +148,7 @@ def add_store_fs(store, fs_path, synced=False):
             store=store,
             path=fs_path,
             last_sync_hash=uuid4().hex,
-            last_sync_revision=store.get_max_unit_revision())
+            last_sync_revision=store.revision)
     return StoreFS.objects.create(
         store=store,
         path=fs_path)

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -70,7 +70,7 @@ def _store_as_string(store):
         ttk.updateheader(
             add=True, X_Pootle_Path=store.pootle_path)
         ttk.updateheader(
-            add=True, X_Pootle_Revision=store.get_max_unit_revision())
+            add=True, X_Pootle_Revision=store.revision)
     return str(ttk)
 
 
@@ -179,7 +179,7 @@ def test_update_unit_order(project0_nongnu, ordered_po, ordered_update_ttk):
         [unit.unitid for unit in ordered_po.units]
     )
     assert old_unit_list == updated_unit_list
-    current_revision = ordered_po.get_max_unit_revision()
+    current_revision = ordered_po.revision
 
     ordered_po.update(
         ordered_update_ttk,
@@ -226,7 +226,7 @@ def test_update_set_last_sync_revision(ru_update_set_last_sync_revision_po):
 
     # Store is already parsed and store.last_sync_revision should be equal to
     # max unit revision
-    assert store.last_sync_revision == store.get_max_unit_revision()
+    assert store.last_sync_revision == store.revision
 
     # store.last_sync_revision is not changed after empty update
     saved_last_sync_revision = store.last_sync_revision
@@ -517,7 +517,7 @@ def test_store_file_diff(store_diff_tests):
         == [(x.source, x.target) for x in diff.source_store.units[1:]]
         == [(v['source'], v['target']) for v in diff.source_units.values()])
     assert diff.active_target_units == [x.source for x in store.units]
-    assert diff.target_revision == store.get_max_unit_revision()
+    assert diff.target_revision == store.revision
     assert (
         diff.target_units
         == {unit["source_f"]: unit
@@ -988,7 +988,7 @@ def test_store_diff(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
     # no changes
     assert not differ.diff()
     assert differ.target_store == target_store
@@ -1008,7 +1008,7 @@ def test_store_diff_delete_target_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision())
+        target_store.revision)
     result = differ.diff()
     assert result["add"][0][0].source_f == remove_unit.source_f
     assert len(result["add"]) == 1
@@ -1041,7 +1041,7 @@ def test_store_diff_delete_source_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision())
+        target_store.revision)
     result = differ.diff()
     to_remove = target_store.units.get(unitid=remove_unit.unitid)
     assert result["obsolete"] == [to_remove.pk]
@@ -1055,7 +1055,7 @@ def test_store_diff_delete_source_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() - 1)
+        target_store.revision - 1)
     assert not differ.diff()
 
 
@@ -1073,7 +1073,7 @@ def test_store_diff_delete_obsoleted_target_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
     assert not differ.diff()
 
 
@@ -1088,7 +1088,7 @@ def test_store_diff_obsoleted_target_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
     result = differ.diff()
     assert result["update"][0] == set([obsolete_unit.pk])
     assert len(result["update"][1]) == 1
@@ -1098,7 +1098,7 @@ def test_store_diff_obsoleted_target_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() - 1)
+        target_store.revision - 1)
     assert not differ.diff()
 
 
@@ -1114,7 +1114,7 @@ def test_store_diff_update_target_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
     result = differ.diff()
     assert result["update"][0] == set([update_unit.pk])
     assert result["update"][1] == {}
@@ -1147,7 +1147,7 @@ def test_store_diff_update_source_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
     result = differ.diff()
     assert result["update"][0] == set([target_unit.pk])
     assert result["update"][1] == {}
@@ -1179,7 +1179,7 @@ def test_store_diff_custom(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
 
     assert isinstance(
         differ.diffable, CustomDiffableStore)
@@ -1199,7 +1199,7 @@ def test_store_diff_delete_obsoleted_source_unit(diffable_stores):
     differ = StoreDiff(
         target_store,
         source_store,
-        target_store.get_max_unit_revision() + 1)
+        target_store.revision + 1)
     assert not differ.diff()
 
 

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -24,6 +24,7 @@ from pootle_app.models.permissions import PermissionSet, check_user_permission
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_store.constants import FUZZY, TRANSLATED
+from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
 
 
@@ -113,7 +114,7 @@ def _test_after_evil_user_updated(store, evil_member):
 
 def _test_user_purging(store, member, evil_member, purge):
 
-    first_revision = store.get_max_unit_revision()
+    first_revision = store.revision
     unit = store.units[0]
 
     # Get intitial change times
@@ -128,7 +129,8 @@ def _test_user_purging(store, member, evil_member, purge):
     _make_evil_member_updates(store, evil_member)
 
     # Revision has increased
-    latest_revision = store.get_max_unit_revision()
+    store = Store.objects.get(pk=store.pk)
+    latest_revision = store.revision
     assert latest_revision > first_revision
 
     unit = store.units[0]
@@ -149,7 +151,8 @@ def _test_user_purging(store, member, evil_member, purge):
     purge(evil_member)
 
     # Revision has increased again.
-    assert store.get_max_unit_revision() > latest_revision
+    store = Store.objects.get(pk=store.pk)
+    assert store.revision > latest_revision
 
     unit = store.units[0]
 

--- a/tests/pootle_fs/files.py
+++ b/tests/pootle_fs/files.py
@@ -20,6 +20,7 @@ from pootle_fs.files import FSFile
 from pootle_project.models import Project
 from pootle_statistics.models import SubmissionTypes
 from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
+from pootle_store.revision import StoreRevision
 
 
 @pytest.mark.django_db
@@ -243,10 +244,12 @@ def test_wrap_store_fs_on_sync(store_fs_file_store):
     fs_file.fetch()
     fs_file.pull()
     fs_file.on_sync()
-    fs_file.store_fs.resolve_conflict = None
-    fs_file.store_fs.staged_for_merge = False
-    fs_file.store_fs.last_sync_hash = fs_file.latest_hash
-    fs_file.store_fs.last_sync_revision = fs_file.store.get_max_unit_revision()
+    assert fs_file.store_fs.resolve_conflict is None
+    assert fs_file.store_fs.staged_for_merge is False
+    assert fs_file.store_fs.last_sync_hash == fs_file.latest_hash
+    assert (
+        fs_file.store_fs.last_sync_revision
+        == StoreRevision(fs_file.store).get_max_unit_revision())
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
It would speed a lot of operations up if we didnt need to keep doing Store.get_max_unit_revision.

This PR denorms the max revision onto store, and provides signal handlers for updating

In cases where you dont want to update the revision on the store until you have completed updating units - it will ensure that this is possible