### PR TITLE
Update to pytest 3.0.1

### DIFF
--- a/pootle/settings/25-logging.conf
+++ b/pootle/settings/25-logging.conf
@@ -68,7 +68,7 @@ LOGGING = {
         'action': {
             'handlers': ['log_action', 'console'],
             'level': 'INFO',
-            'propagate': False,
+            'propagate': True,
         },
         'django.db.backends': {
             'handlers': ['console'],

--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -23,6 +23,9 @@ if os.environ.get("TRAVIS"):
             'HOST': '',
             'PORT': '',
             'ATOMIC_REQUESTS': True,
+            'TEST': {
+                'NAME': 'test_pootle',
+            }
         }
     }
 

--- a/pytest_pootle/fixtures/mock.py
+++ b/pytest_pootle/fixtures/mock.py
@@ -8,10 +8,10 @@
 
 """Monkeypatching fixtures."""
 
-from _pytest.monkeypatch import monkeypatch
+from _pytest.monkeypatch import MonkeyPatch
 
 
-mp = monkeypatch()
+mp = MonkeyPatch()
 
 
 class FakeJob(object):

--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -26,11 +26,19 @@ def setup_db_if_needed(request):
 
 
 @pytest.fixture(scope='session')
-def post_db_setup(translations_directory, _django_db_setup,
-                  _django_cursor_wrapper, request):
+def tests_use_db(request):
+    return bool(
+        [item for item in request.node.items
+         if item.get_marker('django_db')])
+
+
+@pytest.fixture(autouse=True, scope='session')
+def post_db_setup(translations_directory, django_db_setup, django_db_blocker,
+                  tests_use_db, request):
     """Sets up the site DB for the test session."""
-    with _django_cursor_wrapper:
-        PootleTestEnv(request).setup()
+    if tests_use_db:
+        with django_db_blocker.unblock():
+            PootleTestEnv(request).setup()
 
 
 @pytest.fixture

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,7 @@
 # Testing
 
 factory_boy>=2.5.2
-pytest<3.0.0
+pytest==3.0.1
 pytest-catchlog
 pytest-cov
 pytest-django>=2.8,<2.9

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,4 +4,4 @@ factory_boy>=2.5.2
 pytest==3.0.1
 pytest-catchlog
 pytest-cov
-pytest-django>=2.8,<2.9
+pytest-django==3.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,5 +3,5 @@
 factory_boy>=2.5.2
 pytest==3.0.1
 pytest-catchlog
-pytest-cov
+pytest-cov==2.3.1
 pytest-django==3.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,6 +2,6 @@
 
 factory_boy>=2.5.2
 pytest==3.0.1
-pytest-catchlog
+pytest-catchlog==1.2.2
 pytest-cov==2.3.1
 pytest-django==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 python_files=*.py
 addopts=--nomigrations --tb=short tests
 norecursedirs=.git _build tmp* requirements commands/*

--- a/tests/commands/clear_stats.py
+++ b/tests/commands/clear_stats.py
@@ -16,5 +16,5 @@ from django.core.management import call_command
 def test_clear_stats(caplog):
     call_command('clear_stats', '--project=project0', '--language=language0',
                  '--verbosity=2')
-    infologs = [l.message for l in caplog.records() if l.levelname == "INFO"]
+    infologs = [l.message for l in caplog.records if l.levelname == "INFO"]
     assert "clear_stats over /language0/project0/" in "".join(infologs)

--- a/tests/core/utils/stats.py
+++ b/tests/core/utils/stats.py
@@ -11,7 +11,7 @@ import pytest
 from pootle.core.utils.stats import get_top_scorers_data
 
 
-class TestUser(object):
+class MockUser(object):
     def __init__(self, email, display_name, username):
         self.email = email
         self.display_name = display_name
@@ -24,7 +24,7 @@ TEST_TOP_SCORERS = [
         suggested=0,
         translated=1,
         reviewed=0,
-        user=TestUser(
+        user=MockUser(
             email='test0@poot.le',
             display_name='Test0',
             username='test0',
@@ -35,7 +35,7 @@ TEST_TOP_SCORERS = [
         suggested=1,
         translated=2,
         reviewed=1,
-        user=TestUser(
+        user=MockUser(
             email='test1@poot.le',
             display_name='Test1',
             username='test1',

--- a/tests/misc/lang_mapper.py
+++ b/tests/misc/lang_mapper.py
@@ -30,7 +30,7 @@ def test_lang_mapper_bad_preset(po_directory, english, caplog):
     assert mapper.lang_mappings == {}
     assert (
         "Unrecognised lang mapping preset"
-        in ''.join([l.message for l in caplog.records()]))
+        in ''.join([l.message for l in caplog.records]))
 
 
 @pytest.mark.django_db

--- a/tests/pootle_fs/matcher.py
+++ b/tests/pootle_fs/matcher.py
@@ -280,7 +280,7 @@ def test_matcher_matches_missing_langs(settings, caplog):
     assert list(matcher.matches(None, None)) == []
     assert (
         "Could not import files for languages: language0, language1"
-        in caplog.text())
+        in caplog.text)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Changes include:
* Update to pytest 3.0.1 and pytest-django 3.0.0
* Updates to supporting test infrastructure: pytest-cov and pytest-caplog
* Fixes to get tests running
* Cleanups for deprecated features