### PR TITLE
Add cached template loader in tests (and make tests DEBUG=False)

### DIFF
--- a/tests/misc/state.py
+++ b/tests/misc/state.py
@@ -12,6 +12,13 @@ import pytest
 from pootle.core.state import State, ItemState
 
 
+def test_settings(settings):
+    assert not settings.DEBUG
+    assert (
+        settings.TEMPLATES[0]["OPTIONS"]["loaders"][0][0]
+        == 'django.template.loaders.cached.Loader')
+
+
 class DummyContext(object):
 
     def __str__(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -107,3 +107,5 @@ try:
         INSTALLED_APPS = INSTALLED_APPS + ["pootle_fs"]
 except NameError:
     INSTALLED_APPS = ["pootle_fs"]
+
+DEBUG = False

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -108,4 +108,4 @@ try:
 except NameError:
     INSTALLED_APPS = ["pootle_fs"]
 
-DEBUG = False
+# DEBUG = False


### PR DESCRIPTION
in the words of the django manual - this should give a "drastic" improvement in performance

EDIT:

seems like it was only not being used in tests (or if DEBUG=True) - ive changed the PR to instead use DEBUG=False in tests/settings