### PR TITLE
[WIP] Clear cache signals

### DIFF
--- a/pootle/apps/pootle_store/apps.py
+++ b/pootle/apps/pootle_store/apps.py
@@ -19,3 +19,4 @@ class PootleStoreConfig(AppConfig):
     def ready(self):
         importlib.import_module("pootle_store.getters")
         importlib.import_module("pootle_store.providers")
+        importlib.import_module("pootle_store.receivers")

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -38,6 +38,7 @@ from pootle.core.log import (
 from pootle.core.mixins import CachedMethods, CachedTreeItem
 from pootle.core.models import Revision
 from pootle.core.search import SearchBroker
+from pootle.core.signals import clear_cache
 from pootle.core.storage import PootleFileSystemStorage
 from pootle.core.url_helpers import (
     get_all_pootle_paths, get_editor_filter, split_pootle_path)
@@ -432,7 +433,7 @@ class Unit(models.Model, base.TranslationUnit):
 
         # update cache only if we are updating a single unit
         if self.store.state >= PARSED:
-            clear_cache.send(self.store)
+            clear_cache.send(self.store.__class__, instance=self.store)
 
     def get_absolute_url(self):
         return self.store.get_absolute_url()

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -432,8 +432,7 @@ class Unit(models.Model, base.TranslationUnit):
 
         # update cache only if we are updating a single unit
         if self.store.state >= PARSED:
-            self.store.mark_dirty(CachedMethods.MTIME)
-            self.store.update_dirty_cache()
+            clear_cache.send(self.store)
 
     def get_absolute_url(self):
         return self.store.get_absolute_url()

--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.dispatch import receiver
+
+from pootle.core.mixins import CachedMethods
+from pootle.core.signals import clear_cache
+from pootle_store.models import Store
+
+
+@receiver(clear_cache, sender=Store)
+def clear_cache_handler(**kwargs):
+    kwargs["instance"].mark_dirty(CachedMethods.MTIME)
+    kwargs["instance"].update_dirty_cache()

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.utils.functional import cached_property
 
+from pootle.core.contextmanagers import expires_cache
 from pootle.core.log import log
 from pootle.core.models import Revision
 
@@ -250,7 +251,8 @@ class StoreUpdater(object):
             else:
                 self.target_store.state = old_state
             has_changed = any(x > 0 for x in changes.values())
-            self.target_store.save(update_cache=has_changed)
+            with expires_cache(expire=has_changed):
+                self.target_store.save()
             if has_changed:
                 log(u"[update] %s units in %s [revision: %d]"
                     % (get_change_str(changes),
@@ -331,7 +333,8 @@ class StoreUpdater(object):
                 logging.info(u"[update] unsynced %d units in %s "
                              "[revision: %d]", update_unsynced,
                              self.target_store.pootle_path, update_revision)
-        self.target_store.save(update_cache=False)
+        with expires_cache(False):
+            self.target_store.save()
         return changed
 
     def update_units(self, update):

--- a/pootle/core/contextmanagers.py
+++ b/pootle/core/contextmanagers.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from contextlib import contextmanager
+
+from pootle.core.signals import clear_cache
+
+
+@contextmanager
+def expires_cache(expire=False):
+    if not expire:
+        handlers = clear_cache.receivers
+        clear_cache.receivers = []
+    yield
+    if not expire:
+        clear_cache.receivers = handlers

--- a/pootle/core/signals.py
+++ b/pootle/core/signals.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.dispatch import Signal
+
+
+clear_cache = Signal(providing_args=["instance", "parent", "children"])


### PR DESCRIPTION
Puts clear_cache calls into signal receivers

This allows the signal to be overridden in the event that you dont want to clear cache - and a contextmanager is provided for this purpose