### PR TITLE
Tests: do not trigger DB creation if `--reuse-db` was specified

### DIFF
--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -85,7 +85,7 @@ def tests_use_migration(request, tests_use_db):
 @pytest.fixture(autouse=True, scope='session')
 def setup_db_if_needed(request, tests_use_db):
     """Sets up the site DB only if tests requested to use the DB (autouse)."""
-    if tests_use_db:
+    if tests_use_db and not request.config.getvalue('reuse_db'):
         return request.getfuncargvalue('post_db_setup')
 
 


### PR DESCRIPTION
This provides a nice improvement while running tests in development, as it
avoids re-creating the DB for every single test session.

When there are schema changes, in order to recreate the DB one needs to specify
the `--reuse-db --recreate-db` flags.

Fixes #4633.