### PR TITLE
Use revision get

### DIFF
--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -213,7 +213,7 @@ class StoreUpdater(object):
         units = self.target_store.unit_set.filter(**filter_by)
         count = units.count()
         if count:
-            units.update(revision=Revision.incr())
+            units.update(revision=Revision.get())
         return count
 
     def units(self, uids):

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -272,7 +272,7 @@ def test_update_set_last_sync_revision(ru_update_set_last_sync_revision_po):
     # than store.last_sync_revision to allow to keep this change during
     # update from a file
     dbunit = store.units[item_index]
-    assert dbunit.revision == store.last_sync_revision + 1
+    assert dbunit.revision == store.last_sync_revision
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
atm increment_unsynced_units increments the unit revision rather than making it the same as the last unit to be edited - which we set it to from incrementing per unit. Im thinking this makes revisions unhelpful for a store as these units appear to have been revised more recently