### PR TITLE
Adjust StoreDataTool.get_max_unit_revision

### DIFF
--- a/pootle/apps/pootle_data/utils.py
+++ b/pootle/apps/pootle_data/utils.py
@@ -11,6 +11,7 @@ from collections import Counter
 from translate.filters.decorators import Category
 
 from django.db import models
+from django.db.models import Max
 from django.utils.functional import cached_property
 
 from pootle_statistics.models import SubmissionTypes
@@ -77,7 +78,8 @@ class StoreDataTool(object):
         return (
             unit.revision
             if unit is not None
-            else self.last_updated_unit.revision)
+            else self.store.unit_set.aggregate(
+                result=Max("revision"))['result'])
 
     @cached_property
     def checks(self):

--- a/tests/pootle_data/data_utils.py
+++ b/tests/pootle_data/data_utils.py
@@ -112,7 +112,7 @@ def test_data_store_util_suggestion_count(store0, member):
 @pytest.mark.django_db
 def test_data_store_util_max_unit_revision(store0):
     max_revision = 0
-    for unit in store0.units.all():
+    for unit in store0.unit_set.all():
         if unit.revision > max_revision:
             max_revision = unit.revision
     assert (


### PR DESCRIPTION
As obsolete units can have a higher revision than the the last `updated` unit, this PR adds a last `changed` unit to include obsolete units, and retrieve the correct max_unit_revision