### PR TITLE
Add index_together on unit__store with revision and mtime

### DIFF
--- a/pootle/apps/pootle_store/migrations/0014_add_unit_index_togethers.py
+++ b/pootle/apps/pootle_store/migrations/0014_add_unit_index_togethers.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0013_set_store_filetype_again'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='unit',
+            index_together=set([('store', 'revision'), ('store', 'index'), ('store', 'mtime')]),
+        ),
+    ]

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -246,7 +246,10 @@ class Unit(models.Model, base.TranslationUnit):
     class Meta(object):
         unique_together = ('store', 'unitid_hash')
         get_latest_by = 'mtime'
-        index_together = [["store", "index"]]
+        index_together = [
+            ["store", "index"],
+            ["store", "revision"],
+            ["store", "mtime"]]
 
     # # # # # # # # # # # # # #  Properties # # # # # # # # # # # # # # # # # #
 


### PR DESCRIPTION
this seems to give significant performance boosts to queries involivng unit revision in a store - eg get_max_unit_revision - as units are also sometimes sorted my mtime this is added tooo