### PR TITLE
StoreSyncer: fix bogus logic

### DIFF
--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -256,7 +256,8 @@ class StoreSyncer(object):
     def update_newer(self, last_revision):
         return (
             not self.store.file.exists()
-            or (last_revision >= self.store.last_sync_revision))
+            or last_revision > self.store.last_sync_revision
+        )
 
     @cached_property
     def dbid_index(self):


### PR DESCRIPTION
Optimizations were not kicking in because the logic would lead to process all
stores regardless of the last sync revision, therefore hitting the disk for
every single store and badly degrading performance.

Fixes #5178.