### PR TITLE
Debug tests

### DIFF
--- a/pootle/core/debug.py
+++ b/pootle/core/debug.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import logging
+import time
+from contextlib import contextmanager
+
+
+logger = logging.getLogger("POOTLE_DEBUG")
+
+
+def log_timing(start, timed=None, debug_logger=None):
+    debug_logger = debug_logger or logger
+    timing = time.time() - start
+    if timed:
+        msg = (
+            "Timing for %s: %s seconds"
+            % (timed, timing))
+    else:
+        msg = (
+            "Timing: %s seconds"
+            % timing)
+    debug_logger.debug(msg)
+
+
+def log_new_queries(queries, debug_logger=None):
+    from django.db import connection
+
+    debug_logger = debug_logger or logger
+    new_queries = list(connection.queries[queries:])
+    for query in new_queries:
+        debug_logger.debug(query["time"])
+        debug_logger.debug("\t%s", query["sql"])
+
+
+@contextmanager
+def timings(timed=None, debug_logger=None):
+    start = time.time()
+    yield
+    log_timing(
+        start,
+        timed,
+        debug_logger or logger)
+
+
+@contextmanager
+def debug_sql(debug_logger=None):
+    from django.conf import settings
+    from django.db import connection
+
+    debug = settings.DEBUG
+    settings.DEBUG = True
+    queries = len(connection.queries)
+    yield
+    log_new_queries(
+        queries,
+        debug_logger)
+    settings.DEBUG = debug

--- a/pytest_pootle/fixtures/debug.py
+++ b/pytest_pootle/fixtures/debug.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import functools
+import logging
+import time
+from datetime import datetime
+
+import pytest
+
+from pytest_pootle import utils
+
+
+logger = logging.getLogger("POOTLE_DEBUG")
+
+
+@pytest.fixture(scope="session")
+def log_timings(request, timings):
+    logger.debug("TESTS START: %s", datetime.now())
+    return functools.partial(
+        utils.log_test_timing,
+        logger,
+        timings)
+
+
+@pytest.fixture(scope="session")
+def timings(request):
+    debug_tests = request.config.getoption("--debug-tests")
+
+    if not debug_tests:
+        return
+    if debug_tests != "-":
+        logger.addHandler(logging.FileHandler(debug_tests))
+    timings = dict(start=time.time(), tests={})
+    request.addfinalizer(
+        functools.partial(
+            utils.log_test_report,
+            logger,
+            timings))
+    return timings

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -6,8 +6,10 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import functools
 import os
 import shutil
+import time
 from pkgutil import iter_modules
 
 import pytest
@@ -29,6 +31,27 @@ def _load_fixtures(*modules):
         for loader_, name, is_pkg in iter_modules(path, prefix):
             if not is_pkg:
                 yield name
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--debug-tests",
+        action="store",
+        default="",
+        help="Debug tests to a given file")
+
+
+@pytest.fixture(autouse=True)
+def test_timing(request, settings, log_timings):
+    if not request.config.getoption("--debug-tests"):
+        return
+    settings.DEBUG = True
+    start = time.time()
+    request.addfinalizer(
+        functools.partial(
+            log_timings,
+            request.node.name,
+            start))
 
 
 @pytest.fixture

--- a/tests/core/debug_tools.py
+++ b/tests/core/debug_tools.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import re
+import time
+
+from pootle.core.debug import (
+    debug_sql, log_new_queries, log_timing, timings)
+
+import pytest
+
+
+def test_debug_timing_logger(caplog):
+    start = time.time()
+
+    log_timing(start)
+    message = caplog.records[0].message
+    assert message.startswith("Timing: ")
+    assert message.endswith(" seconds")
+
+    log_timing(start, timed="Foo")
+    message = caplog.records[1].message
+    assert message.startswith("Timing for Foo: ")
+    assert message.endswith(" seconds")
+
+
+def test_debug_timing_contextmanager(caplog):
+    with timings():
+        pass
+    message = caplog.records[0].message
+    assert message.startswith("Timing: ")
+    assert message.endswith(" seconds")
+
+    with timings(timed="Foo"):
+        pass
+    message = caplog.records[1].message
+    assert message.startswith("Timing for Foo: ")
+    assert message.endswith(" seconds")
+
+
+@pytest.mark.django_db
+def test_debug_sql_logger(caplog, settings):
+    from pootle_project.models import Project
+
+    from django.db import connection
+
+    settings.DEBUG = True
+
+    queries = len(connection.queries)
+
+    log_new_queries(queries)
+    assert caplog.records == []
+
+    # trigger some sql and log
+    Project.objects.count()
+    log_new_queries(queries)
+
+    timing = caplog.records[0].message
+    sql = caplog.records[1].message
+
+    # match the timing, sql
+    assert re.match("^\d+?\.\d+?$", timing)
+    assert "SELECT COUNT" in sql
+    assert "pootle_app_project" in sql
+
+
+@pytest.mark.django_db
+def test_debug_sql_contextmanager(caplog, settings):
+    from pootle_project.models import Project
+
+    with debug_sql():
+        pass
+    assert caplog.records == []
+
+    # should work even when debug is False
+    settings.DEBUG = False
+
+    # trigger some sql and log
+    with debug_sql():
+        Project.objects.count()
+
+    timing = caplog.records[0].message
+    sql = caplog.records[1].message
+
+    # match the timing, sql
+    assert re.match("^\d+?\.\d+?$", timing)
+    assert "SELECT COUNT" in sql
+    assert "pootle_app_project" in sql
+
+    # settings shold be correct
+    assert settings.DEBUG is False

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ whitelist_externals=
     bash
     pylint
     pootle
+    py.test
 setenv=
     DATABASE_BACKEND=sqlite
 commands=
@@ -71,3 +72,6 @@ commands=
     make lint-js
     make lint-css
     pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle
+    py.test --cov-report= --cov=. -v -s -k test_debug_timing --debug-tests -
+    python {toxinidir}/run_coveralls.py
+    codecov -e TOXENV


### PR DESCRIPTION
This adds debugging fixtures and a cli option to specify a file to log to - also a context manager for debugging sql calls.

It logs query counts and timings for each tests - and does some very basic slow query analysis

test can be debugged as:

```
py.test --debug-tests my.log
```

you can use the context manager so:

```python
from pootle.core.debug import debug_sql
with debug_sql():
   do_something_with_sql_calls()
```
there is also a timings contextmanager - which can be used as:

```python
from pootle.core.debug import timings

with timings("name of thing being timed"):
    do_something_you_want_timings_from()

```


the contextmanagers can be used outside of tests - but in combination with `--debug-tests` will log to the same file