### PR TITLE
Relative times: minor refactoring

### DIFF
--- a/pootle/static/js/helpers.js
+++ b/pootle/static/js/helpers.js
@@ -8,7 +8,7 @@
 
 import $ from 'jquery';
 
-import utils from './utils';
+import { relativeTime } from 'utils/time';
 
 
 function updateInputState($checkboxes, $input) {
@@ -25,7 +25,7 @@ const helpers = {
   /* Updates relative dates */
   updateRelativeDates() {
     $('.js-relative-date').each((i, e) => {
-      $(e).text(utils.relativeDate(Date.parse($(e).attr('datetime'))));
+      $(e).text(relativeTime($(e).attr('datetime')));
     });
   },
 

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-react": "^4.2.0",
     "expect": "^1.14.0",
     "lodash": "^2.4.1",
+    "lolex": "^1.5.1",
     "mocha": "^3.0.2",
     "style-loader": "^0.8.0",
     "stylelint": "^7.1.0",

--- a/pootle/static/js/setup.test.js
+++ b/pootle/static/js/setup.test.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import { before } from 'mocha';
+
+
+before(() => {
+  global.gettext = string => string;
+
+  global.ngettext = (singular, plural, count) => (
+    (count === 1) ? singular : plural
+  );
+
+  global.interpolate = (string, args) => (
+    string.replace(/%\(\w+\)s/g, (match) => String(args[match.slice(2, -2)]))
+  );
+});

--- a/pootle/static/js/shared/components/TimeSince.js
+++ b/pootle/static/js/shared/components/TimeSince.js
@@ -9,8 +9,7 @@
 import React, { PropTypes } from 'react';
 import { PureRenderMixin } from 'react-addons-pure-render-mixin';
 
-// FIXME: avoid relative import
-import { relativeDate } from '../../utils';
+import { relativeTime } from 'utils/time';
 
 
 const TimeSince = React.createClass({
@@ -70,8 +69,6 @@ const TimeSince = React.createClass({
   },
 
   render() {
-    const displayTime = relativeDate(Date.parse(this.props.dateTime));
-
     return (
       <time
         className="extra-item-meta"
@@ -79,7 +76,7 @@ const TimeSince = React.createClass({
         dateTime={this.props.dateTime}
         {...this.props}
       >
-        {displayTime}
+        {relativeTime(this.props.dateTime)}
       </time>
     );
   },

--- a/pootle/static/js/shared/utils/time.js
+++ b/pootle/static/js/shared/utils/time.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import { nt, t } from './i18n';
+
+
+/**
+ * A version of `Math.trunc` which returns absolute values.
+ *
+ * @param {Number} number - the number to truncate.
+ * @return {Number} - positive integer
+ */
+function absTrunc(number) {
+  const truncated = Math.trunc(number);
+  return truncated < 0 ? truncated * -1 : truncated;
+}
+
+
+/**
+ * Calculates the time difference from `isoDateTime` to the current date as
+ * provide by the client.
+ *
+ * Note the difference calculation doesn't intend to be smart about leap years
+ * and number of days per month, but rather a simple and naive implementation.
+ *
+ * @param {String} isoDateTime - a date and time combination in ISO 8601 format
+ * as understood by browsers' `Date.parse()`.
+ * @return {Object} - An object with the delta difference specified in seconds,
+ * minutes, hours, days, weeks and months. The `isFuture` boolean
+ * property indicates whether the difference refers to a future time.
+ * When the value passed is invalid or cannot be parsed, every property in the
+ * object will be `null`.
+ */
+export function timeDelta(isoDateTime) {
+  const providedTime = isoDateTime && Date.parse(isoDateTime);
+  if (!providedTime || isNaN(providedTime)) {
+    return {
+      isFuture: null,
+      seconds: null,
+      minutes: null,
+      hours: null,
+      days: null,
+      weeks: null,
+      months: null,
+      years: null,
+    };
+  }
+
+  const now = (new Date()).valueOf();
+  const delta = providedTime - now;
+
+  const isFuture = delta > 0;
+
+  const seconds = absTrunc(delta / 1000);
+  const minutes = absTrunc(seconds / 60);
+  const hours = absTrunc(minutes / 60);
+  const days = absTrunc(hours / 24);
+  const weeks = absTrunc(days / 7);
+  const months = absTrunc(days / 30);  // naive: assuming 30 days per month
+  const years = absTrunc(days / 365);  // naive: assuming 365 days per year
+
+  return {
+    isFuture,
+    seconds,
+    minutes,
+    hours,
+    days,
+    weeks,
+    months,
+    years,
+  };
+}
+
+
+export function relativeTimeMessage({
+  minutes, hours, days, weeks, months, years,
+}) {
+  if (years > 0) {
+    if (years === 1) {
+      return t('A year ago');
+    }
+    return nt('%(count)s year ago', '%(count)s years ago',
+              years, { count: years });
+  }
+
+  if (months > 0) {
+    if (months === 1) {
+      return t('A month ago');
+    }
+    return nt('%(count)s month ago', '%(count)s months ago',
+              months, { count: months });
+  }
+
+  if (weeks > 0) {
+    if (weeks === 1) {
+      return t('A week ago');
+    }
+    return nt('%(count)s week ago', '%(count)s weeks ago',
+              weeks, { count: weeks });
+  }
+
+  if (days > 0) {
+    if (days === 1) {
+      return t('Yesterday');
+    }
+    return nt('%(count)s day ago', '%(count)s days ago',
+              days, { count: days });
+  }
+
+  if (hours > 0) {
+    if (hours === 1) {
+      return t('An hour ago');
+    }
+    return nt('%(count)s hour ago', '%(count)s hours ago',
+              hours, { count: hours });
+  }
+
+  if (minutes > 0) {
+    if (minutes === 1) {
+      return t('A minute ago');
+    }
+    return nt('%(count)s minute ago', '%(count)s minutes ago',
+              minutes, { count: minutes });
+  }
+
+  return t('A few seconds ago');
+}
+
+
+/**
+ * Generate a human-readable relative time message.
+ *
+ * @param {String} isoDateTime - a date and time combination in ISO 8601 format
+ * as understood by browsers' `Date.parse()`.
+ * @return {String} - Message referring to the relative time. Returns an empty
+ * string if the provided date time is invalid or cannot be parsed.
+ */
+export function relativeTime(isoDateTime) {
+  const {
+    isFuture, minutes, hours, days, weeks, months, years,
+  } = timeDelta(isoDateTime);
+
+  if (isFuture === null) {
+    return '';
+  }
+
+  return relativeTimeMessage({ minutes, hours, days, weeks, months, years });
+}

--- a/pootle/static/js/shared/utils/time.test.js
+++ b/pootle/static/js/shared/utils/time.test.js
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import expect from 'expect';
+import lolex from 'lolex';
+import { describe, it } from 'mocha';
+
+import { relativeTime, relativeTimeMessage, timeDelta } from './time';
+
+
+describe('timeDelta', () => {
+  it('returns an empty structure for invalid datetimes', () => {
+    const undefinedDelta = {
+      isFuture: null,
+      seconds: null,
+      minutes: null,
+      hours: null,
+      days: null,
+      weeks: null,
+      months: null,
+      years: null,
+    };
+    expect(timeDelta('')).toEqual(undefinedDelta);
+    expect(timeDelta(null)).toEqual(undefinedDelta);
+    expect(timeDelta(undefined)).toEqual(undefinedDelta);
+    expect(timeDelta('Invalid')).toEqual(undefinedDelta);
+    expect(timeDelta('2016-14-12')).toEqual(undefinedDelta);
+    expect(timeDelta('2016-12-12 25:02:11')).toEqual(undefinedDelta);
+  });
+
+  describe('positive duration', () => {
+    const tests = [
+      {
+        unit: 'seconds',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2016-07-07T00:00:44+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 44,
+          minutes: 0,
+          hours: 0,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'seconds (TZ-aware)',
+        now: '2016-07-07T00:00:00+02:00',
+        args: ['2016-07-06T22:00:44+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 44,
+          minutes: 0,
+          hours: 0,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'minutes',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2016-07-07T00:59:00+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 3540,
+          minutes: 59,
+          hours: 0,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'minutes (TZ-aware)',
+        now: '2016-07-07T00:00:00+02:00',
+        args: ['2016-07-06T22:59:00+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 3540,
+          minutes: 59,
+          hours: 0,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'hours',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2016-07-07T23:00:44+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 82844,
+          minutes: 1380,
+          hours: 23,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'hours (TZ-aware)',
+        now: '2016-07-07T00:00:00+02:00',
+        args: ['2016-07-07T21:00:44+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 82844,
+          minutes: 1380,
+          hours: 23,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'days',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2016-07-13T23:59:59+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 604799,
+          minutes: 10079,
+          hours: 167,
+          days: 6,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'days (TZ-aware)',
+        now: '2016-07-07T00:00:00+02:00',
+        args: ['2016-07-13T21:59:59+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 604799,
+          minutes: 10079,
+          hours: 167,
+          days: 6,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'weeks',
+        now: '2016-06-27T23:59:59+00:00',
+        args: ['2016-07-07T00:00:00+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 777601,
+          minutes: 12960,
+          hours: 216,
+          days: 9,
+          weeks: 1,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'weeks (TZ-aware)',
+        now: '2016-06-27T21:59:59+00:00',
+        args: ['2016-07-07T00:00:00+02:00'],
+        expected: {
+          isFuture: true,
+          seconds: 777601,
+          minutes: 12960,
+          hours: 216,
+          days: 9,
+          weeks: 1,
+          months: 0,
+          years: 0,
+        },
+      },
+      {
+        unit: 'months',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2016-10-07T23:59:59+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 8035199,
+          minutes: 133919,
+          hours: 2231,
+          days: 92,
+          weeks: 13,
+          months: 3, // 1 month ~30 days
+          years: 0,
+        },
+      },
+      {
+        unit: 'months (TZ-aware)',
+        now: '2016-07-07T00:00:00+02:00',
+        args: ['2016-10-07T21:59:59+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 8035199,
+          minutes: 133919,
+          hours: 2231,
+          days: 92,
+          weeks: 13,
+          months: 3, // 1 month ~30 days
+          years: 0,
+        },
+      },
+      {
+        unit: 'years',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2017-07-07T00:00:59+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 31536059,
+          minutes: 525600,
+          hours: 8760,
+          days: 365,
+          weeks: 52,
+          months: 12,
+          years: 1,
+        },
+      },
+      {
+        unit: 'years (TZ-aware)',
+        now: '2016-07-07T00:00:00+00:00',
+        args: ['2017-07-07T00:00:59+00:00'],
+        expected: {
+          isFuture: true,
+          seconds: 31536059,
+          minutes: 525600,
+          hours: 8760,
+          days: 365,
+          weeks: 52,
+          months: 12,
+          years: 1,
+        },
+      },
+    ];
+
+    tests.forEach((test) => {
+      it(`calculates ${test.unit} of difference`, () => {
+        lolex.install(Date.parse(test.now));
+        expect(timeDelta(...test.args)).toEqual(test.expected);
+      });
+    });
+  });
+
+  describe('negative duration (times in the future)', () => {
+    const tests = [
+      {
+        unit: 'seconds',
+        now: '2016-07-07T00:00:44+00:00',
+        args: ['2016-07-07T00:00:00+00:00'],
+        expected: {
+          isFuture: false,
+          seconds: 44,
+          minutes: 0,
+          hours: 0,
+          days: 0,
+          weeks: 0,
+          months: 0,
+          years: 0,
+        },
+      },
+    ];
+
+    tests.forEach((test) => {
+      it(`calculates ${test.unit} of difference`, () => {
+        lolex.install(Date.parse(test.now));
+        expect(timeDelta(...test.args)).toEqual(test.expected);
+      });
+    });
+  });
+});
+
+
+describe('relativeTime', () => {
+  it('returns an empty string for undefined time deltas', () => {
+    expect(relativeTime('')).toEqual('');
+    expect(relativeTime(null)).toEqual('');
+    expect(relativeTime(undefined)).toEqual('');
+    expect(relativeTime('Invalid')).toEqual('');
+    expect(relativeTime('2016-14-12')).toEqual('');
+    expect(relativeTime('2016-12-12 25:02:11')).toEqual('');
+  });
+});
+
+
+describe('relativeTimeMessage', () => {
+  const tests = [
+    {
+      unit: 'immediately due times',
+      delta: {
+        seconds: 0,
+        minutes: 0,
+        hours: 0,
+        days: 0,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: 'A few seconds ago',
+    },
+    {
+      unit: 'a minute of difference',
+      delta: {
+        seconds: 22,
+        minutes: 1,
+        hours: 0,
+        days: 0,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: 'A minute ago',
+    },
+    {
+      unit: 'minutes of difference',
+      delta: {
+        seconds: 2,
+        minutes: 29,
+        hours: 0,
+        days: 0,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: '29 minutes ago',
+    },
+    {
+      unit: 'an hour of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 1,
+        days: 0,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: 'An hour ago',
+    },
+    {
+      unit: 'hours of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 0,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: '23 hours ago',
+    },
+    {
+      unit: 'a day of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 1,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: 'Yesterday',
+    },
+    {
+      unit: 'days of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 6,
+        weeks: 0,
+        months: 0,
+        years: 0,
+      },
+      expected: '6 days ago',
+    },
+    {
+      unit: 'a week of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 8,
+        weeks: 1,
+        months: 0,
+        years: 0,
+      },
+      expected: 'A week ago',
+    },
+    {
+      unit: 'weeks of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 8,
+        weeks: 3,
+        months: 0,
+        years: 0,
+      },
+      expected: '3 weeks ago',
+    },
+    {
+      unit: 'a month of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 8,
+        weeks: 3,
+        months: 1,
+        years: 0,
+      },
+      expected: 'A month ago',
+    },
+    {
+      unit: 'months of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 8,
+        weeks: 3,
+        months: 4,
+        years: 0,
+      },
+      expected: '4 months ago',
+    },
+    {
+      unit: 'a year of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 8,
+        weeks: 3,
+        months: 4,
+        years: 1,
+      },
+      expected: 'A year ago',
+    },
+    {
+      unit: 'years of difference',
+      delta: {
+        seconds: 9,
+        minutes: 2,
+        hours: 23,
+        days: 8,
+        weeks: 3,
+        months: 4,
+        years: 6,
+      },
+      expected: '6 years ago',
+    },
+  ];
+
+  tests.forEach((test) => {
+    it(`covers ${test.unit}`, () => {
+      expect(relativeTimeMessage(test.delta)).toEqual(test.expected);
+    });
+  });
+});

--- a/pootle/static/js/utils.js
+++ b/pootle/static/js/utils.js
@@ -167,44 +167,6 @@ export function highlightRWNodes(selector) {
 }
 
 
-/* Returns a string representing a relative datetime */
-export function relativeDate(date) {
-  const delta = Date.now() - date;
-  const seconds = Math.round(Math.abs(delta) / 1000);
-  const minutes = Math.round(seconds / 60);
-  const hours = Math.round(minutes / 60);
-  const days = Math.round(hours / 24);
-  const weeks = Math.round(days / 7);
-  const years = Math.round(days / 365);
-  let fmt;
-  let count;
-
-  if (years > 0) {
-    fmt = years === 1 ? gettext('A year ago') : ngettext('%s year ago', '%s years ago', years);
-    count = [years];
-  } else if (weeks > 0) {
-    fmt = weeks === 1 ? gettext('A week ago') : ngettext('%s week ago', '%s weeks ago', weeks);
-    count = [weeks];
-  } else if (days > 0) {
-    fmt = days === 1 ? gettext('Yesterday') : ngettext('%s day ago', '%s days ago', days);
-    count = [days];
-  } else if (hours > 0) {
-    fmt = hours === 1 ? gettext('An hour ago') : ngettext('%s hour ago', '%s hours ago', hours);
-    count = [hours];
-  } else if (minutes > 0) {
-    fmt = minutes === 1 ?
-      gettext('A minute ago') : ngettext('%s minute ago', '%s minutes ago', minutes);
-    count = [minutes];
-  }
-
-  if (fmt) {
-    return interpolate(fmt, count);
-  }
-
-  return gettext('A few seconds ago');
-}
-
-
 /* Converts the elements matched by `selector` into selectable inputs.
  *
  * `onChange` function will be fired when the select choice changes.
@@ -255,7 +217,6 @@ export default {
   getHash,
   getParsedHash,
   makeSelectableInput,
-  relativeDate,
   strCmp,
   updateHashPart,
 };


### PR DESCRIPTION
The implementation for relative times has been split into pieces that can be
tested on their own and likewise tests have been added for these.

Now time deltas are calculated independently, and the display messages are only
a reflectiong of this data, hence allowing to implement any type of messaging
which involves relative times.