### PR TITLE
Validate directory name

### DIFF
--- a/pootle/apps/pootle_app/migrations/0007_add_directory_name_validation.py
+++ b/pootle/apps/pootle_app/migrations/0007_add_directory_name_validation.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import pootle_app.models.directory
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_app', '0006_change_administrate_permission_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='directory',
+            name='name',
+            field=models.CharField(max_length=255, validators=[pootle_app.models.directory.validate_no_slashes]),
+        ),
+    ]

--- a/pootle/apps/pootle_app/migrations/0008_allow_blank_directory_name_and_parent.py
+++ b/pootle/apps/pootle_app/migrations/0008_allow_blank_directory_name_and_parent.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import pootle_app.models.directory
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_app', '0007_add_directory_name_validation'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='directory',
+            name='name',
+            field=models.CharField(blank=True, max_length=255, validators=[pootle_app.models.directory.validate_no_slashes]),
+        ),
+        migrations.AlterField(
+            model_name='directory',
+            name='parent',
+            field=models.ForeignKey(related_name='child_dirs', blank=True, to='pootle_app.Directory', null=True),
+        ),
+    ]

--- a/pootle/apps/pootle_app/migrations/0009_set_default_directory_pootle_path.py
+++ b/pootle/apps/pootle_app/migrations/0009_set_default_directory_pootle_path.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_app', '0008_allow_blank_directory_name_and_parent'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='directory',
+            name='pootle_path',
+            field=models.CharField(default=b'/', unique=True, max_length=255, db_index=True),
+        ),
+    ]

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -53,7 +53,7 @@ class Directory(models.Model, CachedTreeItem):
     # any changes to the `pootle_path` field may require updating the schema
     # see migration 0005_case_sensitive_schema.py
     pootle_path = models.CharField(max_length=255, null=False, db_index=True,
-                                   unique=True)
+                                   unique=True, default='/')
     obsolete = models.BooleanField(default=False)
 
     is_dir = True
@@ -130,6 +130,9 @@ class Directory(models.Model, CachedTreeItem):
         super(Directory, self).__init__(*args, **kwargs)
 
     def clean(self):
+        if self.parent is not None:
+            self.pootle_path = self.parent.pootle_path + self.name + '/'
+
         if self.name == '' and self.parent is not None:
             raise ValidationError('Name can be empty only for root directory.')
 
@@ -138,11 +141,6 @@ class Directory(models.Model, CachedTreeItem):
                                   'directory.')
 
     def save(self, *args, **kwargs):
-        if self.parent is not None:
-            self.pootle_path = self.parent.pootle_path + self.name + '/'
-        else:
-            self.pootle_path = '/'
-
         # Force validation of fields.
         self.full_clean()
 

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -46,10 +46,10 @@ class Directory(models.Model, CachedTreeItem):
 
     # any changes to the `name` field may require updating the schema
     # see migration 0005_case_sensitive_schema.py
-    name = models.CharField(max_length=255, null=False,
+    name = models.CharField(max_length=255, null=False, blank=True,
                             validators=[validate_no_slashes])
     parent = models.ForeignKey('Directory', related_name='child_dirs',
-                               null=True, db_index=True)
+                               null=True, blank=True, db_index=True)
     # any changes to the `pootle_path` field may require updating the schema
     # see migration 0005_case_sensitive_schema.py
     pootle_path = models.CharField(max_length=255, null=False, db_index=True,

--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -129,6 +129,14 @@ class Directory(models.Model, CachedTreeItem):
     def __init__(self, *args, **kwargs):
         super(Directory, self).__init__(*args, **kwargs)
 
+    def clean(self):
+        if self.name == '' and self.parent is not None:
+            raise ValidationError('Name can be empty only for root directory.')
+
+        if self.parent is None and self.name != '':
+            raise ValidationError('Parent can be unset only for root '
+                                  'directory.')
+
     def save(self, *args, **kwargs):
         if self.parent is not None:
             self.pootle_path = self.parent.pootle_path + self.name + '/'

--- a/tests/models/directory.py
+++ b/tests/models/directory.py
@@ -29,6 +29,18 @@ def test_directory_create_name_with_slashes_or_backslashes(root):
 
 
 @pytest.mark.django_db
+def test_directory_create_bad(root):
+    """Test directory cannot be created with name and no parent or without name
+    but no parent.
+    """
+    with pytest.raises(ValidationError):
+        Directory.objects.create(name="name", parent=None)
+
+    with pytest.raises(ValidationError):
+        Directory.objects.create(name="", parent=root)
+
+
+@pytest.mark.django_db
 def test_delete_mark_obsolete_resurrect_sync(project0_nongnu, subdir0):
     """Tests that the in-DB Directory are marked as obsolete
     after the on-disk file ceased to exist and that the on-disk file and

--- a/tests/models/directory.py
+++ b/tests/models/directory.py
@@ -11,8 +11,21 @@ import shutil
 
 import pytest
 
+from django.core.exceptions import ValidationError
+
 from pootle_app.models.directory import Directory
 from pootle_store.models import Store, Unit
+
+
+@pytest.mark.django_db
+def test_directory_create_name_with_slashes_or_backslashes(root):
+    """Test Directories are not created with (back)slashes on their name."""
+
+    with pytest.raises(ValidationError):
+        Directory.objects.create(name="slashed/name", parent=root)
+
+    with pytest.raises(ValidationError):
+        Directory.objects.create(name="backslashed\\name", parent=root)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Proper directory validation will prevent creating potentially broken directories. Checking for (back)slashes in directory name and that name is empty and parent is unset only for root directory. Adjusting the schema so the special case for root directory has no name and no parent is accepted.