### PR TITLE
Add virtualfolder data

### DIFF
--- a/pootle/apps/virtualfolder/migrations/0015_vfdata.py
+++ b/pootle/apps/virtualfolder/migrations/0015_vfdata.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_statistics', '0004_fill_translated_wordcount'),
+        ('pootle_store', '0019_remove_unit_priority'),
+        ('virtualfolder', '0014_remove_location'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='VFData',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('max_unit_mtime', models.DateTimeField(db_index=True, null=True, blank=True)),
+                ('max_unit_revision', models.IntegerField(default=0, null=True, db_index=True, blank=True)),
+                ('critical_checks', models.IntegerField(default=0, db_index=True)),
+                ('pending_suggestions', models.IntegerField(default=0, db_index=True)),
+                ('total_words', models.IntegerField(default=0, db_index=True)),
+                ('translated_words', models.IntegerField(default=0, db_index=True)),
+                ('fuzzy_words', models.IntegerField(default=0, db_index=True)),
+                ('last_created_unit', models.OneToOneField(related_name='last_created_for_vfdata', null=True, blank=True, to='pootle_store.Unit')),
+                ('last_submission', models.OneToOneField(related_name='vfdata_stats_data', null=True, blank=True, to='pootle_statistics.Submission')),
+                ('last_updated_unit', models.OneToOneField(related_name='last_updated_for_vfdata', null=True, blank=True, to='pootle_store.Unit')),
+                ('vf', models.OneToOneField(related_name='data', to='virtualfolder.VirtualFolder')),
+            ],
+            options={
+                'db_table': 'pootle_vf_data',
+            },
+        ),
+    ]

--- a/pootle/apps/virtualfolder/models.py
+++ b/pootle/apps/virtualfolder/models.py
@@ -18,6 +18,7 @@ from pootle.core.url_helpers import (get_all_pootle_paths, get_editor_filter,
                                      split_pootle_path)
 from pootle.i18n.gettext import ugettext_lazy as _
 from pootle_app.models import Directory
+from pootle_data.abstracts import AbstractPootleData
 from pootle_language.models import Language
 from pootle_project.models import Project
 from pootle_store.models import Store
@@ -272,3 +273,17 @@ class VirtualFolderTreeItem(models.Model, CachedTreeItem):
                 if p.count('/') > 3]
 
     # # # /TreeItem
+
+
+class VFData(AbstractPootleData):
+
+    class Meta(object):
+        db_table = "pootle_vf_data"
+
+    vf = models.OneToOneField(
+        "virtualfolder.VirtualFolder",
+        db_index=True,
+        related_name="data")
+
+    def __unicode__(self):
+        return unicode(self.vf)

--- a/tests/models/virtualfolder.py
+++ b/tests/models/virtualfolder.py
@@ -16,7 +16,7 @@ from pytest_pootle.factories import VirtualFolderDBFactory
 
 from pootle_language.models import Language
 from pootle_store.models import Store
-from virtualfolder.models import VirtualFolder, VirtualFolderTreeItem
+from virtualfolder.models import VirtualFolder, VirtualFolderTreeItem, VFData
 
 
 @pytest.mark.django_db
@@ -251,3 +251,11 @@ def test_vfolder_membership_new_store(tp0):
     assert Store.objects.get(pk=normal_store.pk).priority == 1.0
     vf0.delete()
     assert Store.objects.get(pk=wierd_store.pk).priority == 1.0
+
+
+@pytest.mark.pootle_vfolders
+@pytest.mark.django_db
+def test_vfdata_repr(vfolder0):
+    assert (
+        repr(VFData(vf=vfolder0))
+        == "<VFData: %s>" % vfolder0.name)


### PR DESCRIPTION
Adds 
- a data table for storing site-wide virtualfolder stats
- an m2m table for matched vfolders <> stores
- project and lang fk fields
