### PR TITLE
In memory testing on travis

### DIFF
--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -24,7 +24,7 @@ if os.environ.get("TRAVIS"):
             'PORT': '',
             'ATOMIC_REQUESTS': True,
             'TEST': {
-                'NAME': 'test_pootle',
+                'NAME': '',
             }
         }
     }

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,4 +4,5 @@ factory_boy>=2.5.2
 pytest==3.0.2
 pytest-catchlog==1.2.2
 pytest-cov==2.3.1
-pytest-django==3.0.0
+# pytest-django==3.0.0
+-e git+https://github.com/phlax/pytest-django@transaction_hooks_sqlite#egg=pytest-django


### PR DESCRIPTION
Pytest-django3 broke support for in-memory testing with transaction_hooks

This PR uses my branch of pytest-django and updates the travis db name as required.

Ill PR to pytest-django - but in the meantime this speeds up testing massively