### PR TITLE
Move priority from unit to store

### DIFF
--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -73,3 +73,7 @@ STATES_NAMES = {
     UNTRANSLATED: "untranslated",
     FUZZY: "fuzzy",
     TRANSLATED: "translated"}
+
+# Default store priority - used by vfolders atm
+#  - valid range = 0 < n <= 999.99
+DEFAULT_PRIORITY = 1.0

--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 #: will be used against the DB.
 ALLOWED_SORTS = {
     'units': {
-        'priority': '-priority',
+        'priority': '-store__priority',
         'oldest': 'submitted_on',
         'newest': '-submitted_on',
     },

--- a/pootle/apps/pootle_store/migrations/0017_store_priority.py
+++ b/pootle/apps/pootle_store/migrations/0017_store_priority.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0016_blank_last_sync_revision'),
+        ('virtualfolder', '0003_case_sensitive_schema'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='store',
+            name='priority',
+            field=models.FloatField(default=1, db_index=True, validators=[django.core.validators.MinValueValidator(0)]),
+        ),
+    ]

--- a/pootle/apps/pootle_store/migrations/0018_move_priority_to_store.py
+++ b/pootle/apps/pootle_store/migrations/0018_move_priority_to_store.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def move_priority_from_unit_to_store(apps, schema_editor):
+    Unit = apps.get_model("pootle_store.Unit")
+    Store = apps.get_model("pootle_store.Store")
+    priorities = dict(
+        Unit.objects.exclude(priority=1.0).values_list("store_id", "priority"))
+    _prios = {}
+    for store_id, priority in priorities.items():
+        _prios[priority] = _prios.get(priority, [])
+        _prios[priority].append(store_id)
+    Store.objects.all().update(priority=1.0)
+    for prio, stores in _prios.items():
+        Store.objects.filter(id__in=stores).update(priority=prio)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0017_store_priority'),
+    ]
+
+    operations = [
+        migrations.RunPython(move_priority_from_unit_to_store),
+    ]

--- a/pootle/apps/pootle_store/migrations/0019_remove_unit_priority.py
+++ b/pootle/apps/pootle_store/migrations/0019_remove_unit_priority.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pootle_store', '0018_move_priority_to_store'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='unit',
+            name='priority',
+        ),
+    ]

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -236,11 +236,6 @@ class Unit(models.Model, base.TranslationUnit):
                                     db_index=True, related_name='reviewed')
     reviewed_on = models.DateTimeField(db_index=True, null=True)
 
-    # this is calculated from virtualfolders if installed and linked
-    priority = models.FloatField(
-        db_index=True, default=1,
-        validators=[MinValueValidator(0)])
-
     objects = UnitManager()
     simple_objects = models.Manager()
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1178,6 +1178,11 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
                                              blank=True)
     obsolete = models.BooleanField(default=False)
 
+    # this is calculated from virtualfolders if installed and linked
+    priority = models.FloatField(
+        db_index=True, default=1,
+        validators=[MinValueValidator(0)])
+
     objects = StoreManager()
     simple_objects = models.Manager()
 

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -430,9 +430,9 @@ class UnitEditJSON(PootleUnitJSON):
 
     def get_context_data(self, *args, **kwargs):
         priority = (
-            self.object.priority if 'virtualfolder' in settings.INSTALLED_APPS
-            else None
-        )
+            self.store.priority
+            if 'virtualfolder' in settings.INSTALLED_APPS
+            else None)
         return {
             'unit': self.object,
             'form': self.get_unit_edit_form(),

--- a/pootle/apps/virtualfolder/migrations/0002_set_unit_priorities.py
+++ b/pootle/apps/virtualfolder/migrations/0002_set_unit_priorities.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.core.exceptions import FieldError
 from django.db import models, migrations
 
 
-def forwards(apps, schema_editor):
-
+def forwards_units(apps, schema_editor):
     Unit = apps.get_model("pootle_store", "Unit")
     VirtualFolder = apps.get_model("virtualfolder", "VirtualFolder")
     db_alias = schema_editor.connection.alias
@@ -34,6 +34,18 @@ def forwards(apps, schema_editor):
         if new_priority != 1.0:
             if priority != new_priority:
                 Unit.objects.filter(pk=pk).update(priority=new_priority)
+
+
+def forwards(apps, schema_editor):
+    # as we have no real way of controlling whether this will be
+    # run before or after priority was moved to store, we need to
+    # test the field exists
+    try:
+        apps.get_model("pootle_store.Unit").objects.filter(priority=1)
+    except FieldError:
+        pass
+    else:
+        return forwards_units(apps, schema_editor)
 
 
 class Migration(migrations.Migration):

--- a/tests/views/get_edit_unit.py
+++ b/tests/views/get_edit_unit.py
@@ -46,7 +46,7 @@ def test_get_edit_unit(project0_nongnu, client, request_users, settings):
     assert result["sources"] == {src_lang.code: unit.source}
 
     assert response.context["unit"] == unit
-    assert response.context["priority"] == unit.priority
+    assert response.context["priority"] == store.priority
     assert response.context["store"] == store
     assert response.context["directory"] == directory
     assert response.context["project"] == project


### PR DESCRIPTION
in the current implementation (of vfolders) all units in a store have the same priority.

moving priority to store makes this a lot less expensive, and will allow us to more easily shift vfolder assocs from unit to store