### PR TITLE
Tests: fix encoding issue

### DIFF
--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -72,7 +72,7 @@ def create_store(pootle_path=None, store_revision=None, units=None):
                                "revision": store_revision})
     string_store = STRING_STORE % {"x_pootle_headers": x_pootle_headers,
                                    "units": units}
-    io_store = io.BytesIO(string_store.encode())
+    io_store = io.BytesIO(string_store.encode('utf-8'))
     return getclass(io_store)(io_store.read())
 
 


### PR DESCRIPTION
Reading from a store with non-ASCII characters would fail with:
```
pytest_pootle/fixtures/views.py:411: in tp_uploads
    updated_store = create_store(store.pootle_path, 0, updated_units)
pytest_pootle/utils.py:75: in create_store
    io_store = io.BytesIO(string_store.encode())
E   UnicodeEncodeError: 'ascii' codec can't encode character u'\xb4' in position
1867: ordinal not in range(128)
```