### PR TITLE
babel-loader: do not process .babelrc file

### DIFF
--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -148,6 +148,7 @@ var config = {
         test: /\.js$/,
         loader: 'babel-loader',
         query: {
+          babelrc: false,
           cacheDirectory: true,
           presets: [
             require.resolve('babel-preset-es2015'),


### PR DESCRIPTION
The purpose of _.babelrc_ for us is to allow the Mocha test runner to understand
ES2015 files via the `babel-register` hook. This process is independendent of
webpack's bundling, which in turn would read _.babelrc_ for further processing
in the `babel-loader`.

Using the rewire Babel plugin in that context breaks builds (rewire is only
meant for testing!), so we disallow reading _.babelrc_ from webpack's
`babel-loader` altogether hence avoiding potential conflicts in the build
process.