### PR TITLE
Add requires.io directive markers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,10 @@ Pootle
    :target: https://coveralls.io/github/translate/pootle?branch=master
    :alt: Test Coverage
 
+.. image:: https://img.shields.io/requires/github/translate/pootle.svg?style=flat-square
+   :target: https://requires.io/github/translate/pootle/requirements/?branch=master
+   :alt: Requirements
+
 
 `Pootle <http://pootle.translatehouse.org/>`_ is an online translation and
 localization tool.  It works to lower the barrier of entry, providing tools to

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Base requirements
 
-Django>=1.8.13,<1.9
+Django>=1.8.13,<1.9  # rq.filter: >=1.8,<1.9
 
 # Django apps
 django-allauth==0.27.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ django-transaction-hooks==0.2
 cssmin==0.2.0
 diff-match-patch==20121119
 dirsync==2.2.2
-elasticsearch>=1.0.0,<2.0.0
+elasticsearch>=1.0.0,<2.0.0  # rq.filter: >=1.0,<2.0
 jsonfield==1.0.3
 lxml>=3.5,<=3.6.4
 python-dateutil==2.5.3


### PR DESCRIPTION
Using [directives](https://requires.io/features/#rq-directives) allows requires.io to limit its checking to a specific range.

We're using this to:

* Limit our Django to LTS 1.8
* Keep Elasticsearch on 1.x which supports the version we actually deploy against

Now requires.io is fully useful in that green means everything is fine.

https://requires.io/github/dwaynebailey/pootle/requirements/?branch=cleanup%2Frequireio-directives