### PR TITLE
Have the checker retrieval in a single place

### DIFF
--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -250,13 +250,6 @@ def clean_plurr_placeholder(string):
     return plurr_plural_suffix_regex.sub('', string)
 
 
-def get_checker(unit):
-    if settings.POOTLE_QUALITY_CHECKER:
-        return import_func(settings.POOTLE_QUALITY_CHECKER)()
-
-    return unit.store.translation_project.checker
-
-
 def get_category_id(code):
     return CATEGORY_IDS.get(code)
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -47,7 +47,7 @@ from pootle.core.utils import dateformat
 from pootle.core.utils.aggregate import max_column
 from pootle.core.utils.timezone import datetime_min, make_aware
 from pootle_format.models import Format
-from pootle_misc.checks import check_names, get_checker
+from pootle_misc.checks import check_names
 from pootle_misc.util import import_func
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
@@ -664,7 +664,7 @@ class Unit(models.Model, base.TranslationUnit):
 
             return False
 
-        checker = get_checker(self)
+        checker = self.store.translation_project.checker
         qc_failures = checker.run_filters(self, categorised=True)
         checks_to_add = []
         for name in qc_failures.iterkeys():

--- a/pootle/core/checks/checker.py
+++ b/pootle/core/checks/checker.py
@@ -9,14 +9,12 @@
 import logging
 import time
 
-from django.conf import settings
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.lru_cache import lru_cache
 
 from pootle.core.mixins.treeitem import CachedMethods
 from pootle_misc.checks import run_given_filters
-from pootle_misc.util import import_func
 from pootle_store.constants import OBSOLETE
 from pootle_store.models import QualityCheck, Store, Unit
 from pootle_store.unit import UnitProxy
@@ -220,12 +218,11 @@ class QualityCheckUpdater(object):
         """Return the site QualityChecker or the QualityCheck associated with
         the a Unit's TP otherwise.
         """
-        if settings.POOTLE_QUALITY_CHECKER:
-            return import_func(settings.POOTLE_QUALITY_CHECKER)()
         try:
             return TranslationProject.objects.get(id=tp_pk).checker
         except TranslationProject.DoesNotExist:
             # There seems to be a risk of dangling Stores with no TP
+            logger.error("Missing TP (pk '%s'). No checker retrieved.", tp_pk)
             return None
 
     def expire_store_cache(self, store_pk=None):


### PR DESCRIPTION
Now all checker retrieval is in TranslationProject.checker. This
also allows to pass the target language to the checkers.

Fixes #5209.