### PR TITLE
Add tests for timezone utilities

### DIFF
--- a/pootle/apps/pootle_app/management/commands/contributors.py
+++ b/pootle/apps/pootle_app/management/commands/contributors.py
@@ -19,15 +19,18 @@ from pootle.core.utils.timezone import make_aware
 from . import PootleCommand
 
 
-def get_aware_datetime(dt_string):
+def get_aware_datetime(dt_string, tz=None):
     """Return an aware datetime parsed from a datetime or date string.
 
-    Datetime or date string can be any format parsable by dateutil.parser.parse
+    :param dt_string: datetime or date string can be any format parsable by
+        dateutil.parser.parse.
+    :param tz: timezone in which `dt_string` should be
+        considered.
     """
     if not dt_string:
         return None
     try:
-        return make_aware(parse_datetime(dt_string))
+        return make_aware(parse_datetime(dt_string), tz=tz)
     except ValueError:
         raise ArgumentTypeError('The provided datetime/date string is not '
                                 'valid: "%s"' % dt_string)

--- a/pootle/core/utils/timezone.py
+++ b/pootle/core/utils/timezone.py
@@ -19,6 +19,10 @@ if settings.USE_TZ:
 
 
 def make_aware(value):
+    """Makes a `datetime` timezone-aware.
+
+    :param value: `datetime` object to make timezone-aware.
+    """
     if getattr(settings, 'USE_TZ', False) and timezone.is_naive(value):
         tz = timezone.get_default_timezone()
         value = timezone.make_aware(value, tz)
@@ -27,6 +31,10 @@ def make_aware(value):
 
 
 def make_naive(value):
+    """Makes a `datetime` naive, i.e. not aware of timezones.
+
+    :param value: `datetime` object to make timezone-aware.
+    """
     if getattr(settings, 'USE_TZ', False) and timezone.is_aware(value):
         tz = timezone.get_default_timezone()
         value = timezone.make_naive(value, tz)
@@ -35,4 +43,8 @@ def make_naive(value):
 
 
 def aware_datetime(*args, **kwargs):
+    """Creates a `datetime` object and makes it timezone-aware.
+
+    :param args: arguments passed to `datetime` constructor.
+    """
     return make_aware(datetime.datetime(*args, **kwargs))

--- a/pootle/core/utils/timezone.py
+++ b/pootle/core/utils/timezone.py
@@ -18,26 +18,32 @@ if settings.USE_TZ:
     datetime_min = timezone.make_aware(datetime_min, timezone.utc)
 
 
-def make_aware(value):
+def make_aware(value, tz=None):
     """Makes a `datetime` timezone-aware.
 
     :param value: `datetime` object to make timezone-aware.
+    :param tz: `tzinfo` object with the timezone information the given value
+        needs to be converted to. By default, site's own default timezone will
+        be used.
     """
     if getattr(settings, 'USE_TZ', False) and timezone.is_naive(value):
-        tz = timezone.get_default_timezone()
-        value = timezone.make_aware(value, tz)
+        use_tz = tz if tz is not None else timezone.get_default_timezone()
+        value = timezone.make_aware(value, timezone=use_tz)
 
     return value
 
 
-def make_naive(value):
+def make_naive(value, tz=None):
     """Makes a `datetime` naive, i.e. not aware of timezones.
 
     :param value: `datetime` object to make timezone-aware.
+    :param tz: `tzinfo` object with the timezone information the given value
+        needs to be converted to. By default, site's own default timezone will
+        be used.
     """
     if getattr(settings, 'USE_TZ', False) and timezone.is_aware(value):
-        tz = timezone.get_default_timezone()
-        value = timezone.make_naive(value, tz)
+        use_tz = tz if tz is not None else timezone.get_default_timezone()
+        value = timezone.make_naive(value, timezone=use_tz)
 
     return value
 
@@ -46,5 +52,9 @@ def aware_datetime(*args, **kwargs):
     """Creates a `datetime` object and makes it timezone-aware.
 
     :param args: arguments passed to `datetime` constructor.
+    :param tz: timezone in which the `datetime` should be constructed. Note that
+        this bypasses passing `tzinfo` to the `datetime` constructor, as it is
+        known not to play well with DST (unless only UTC is used).
     """
-    return make_aware(datetime.datetime(*args, **kwargs))
+    tz = kwargs.pop('tz', None)
+    return make_aware(datetime.datetime(*args, **kwargs), tz=tz)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,6 +23,7 @@ jsonfield==1.0.3
 lxml>=3.5,<=3.6.4
 python-dateutil==2.5.3
 python-levenshtein==0.12.0
+pytz==2016.6.1
 rq>=0.5.0,<=0.6.0
 scandir==1.3
 

--- a/tests/commands/contributors.py
+++ b/tests/commands/contributors.py
@@ -12,6 +12,7 @@ from dateutil.parser import parse as parse_datetime
 from email.utils import formataddr
 
 import pytest
+import pytz
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -23,17 +24,21 @@ from pytest_pootle.fixtures.contributors import CONTRIBUTORS_WITH_EMAIL
 
 def test_contributors_get_aware_datetime():
     """Get an aware datetime from a valid string."""
-    iso_datetime = make_aware(parse_datetime("2016-01-24T23:15:22+0000"))
+    iso_datetime = make_aware(parse_datetime("2016-01-24T23:15:22+0000"),
+                              tz=pytz.utc)
 
     # Test ISO 8601 datetime.
-    assert iso_datetime == get_aware_datetime("2016-01-24T23:15:22+0000")
+    assert iso_datetime == get_aware_datetime("2016-01-24T23:15:22+0000",
+                                              tz=pytz.utc)
 
     # Test git-like datetime.
-    assert iso_datetime == get_aware_datetime("2016-01-24 23:15:22 +0000")
+    assert iso_datetime == get_aware_datetime("2016-01-24 23:15:22 +0000",
+                                              tz=pytz.utc)
 
     # Test just an ISO 8601 date.
-    iso_datetime = make_aware(parse_datetime("2016-01-24T00:00:00+0000"))
-    assert iso_datetime == get_aware_datetime("2016-01-24")
+    iso_datetime = make_aware(parse_datetime("2016-01-24T00:00:00+0000"),
+                              tz=pytz.utc)
+    assert iso_datetime == get_aware_datetime("2016-01-24", tz=pytz.utc)
 
     # Test None.
     assert get_aware_datetime(None) is None

--- a/tests/core/utils/timezone.py
+++ b/tests/core/utils/timezone.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from datetime import datetime
+
+import pytz
+
+from django.utils import timezone
+
+from pootle.core.utils.timezone import make_aware, make_naive, aware_datetime
+
+
+def test_make_aware(settings):
+    """Tests datetimes can be made aware of timezones."""
+    settings.USE_TZ = True
+
+    datetime_object = datetime(2016, 1, 2, 21, 52, 25)
+    assert timezone.is_naive(datetime_object)
+    datetime_aware = make_aware(datetime_object)
+    assert timezone.is_aware(datetime_aware)
+
+
+def test_make_aware_default_tz(settings):
+    """Tests datetimes are made aware of the configured timezone."""
+    settings.USE_TZ = True
+
+    datetime_object = datetime(2016, 1, 2, 21, 52, 25)
+    assert timezone.is_naive(datetime_object)
+    datetime_aware = make_aware(datetime_object)
+    assert timezone.is_aware(datetime_aware)
+
+    # Not comparing `tzinfo` directly because that depends on the combination of
+    # actual date+times
+    assert datetime_aware.tzinfo.zone == timezone.get_default_timezone().zone
+
+
+def test_make_aware_use_tz_false(settings):
+    """Tests datetimes are left intact if `USE_TZ` is not in effect."""
+    settings.USE_TZ = False
+
+    datetime_object = datetime(2016, 1, 2, 21, 52, 25)
+    assert timezone.is_naive(datetime_object)
+    datetime_aware = make_aware(datetime_object)
+    assert timezone.is_naive(datetime_aware)
+
+
+def test_make_naive(settings):
+    """Tests datetimes can be made naive of timezones."""
+    settings.USE_TZ = True
+
+    datetime_object = datetime(2016, 1, 2, 21, 52, 25, tzinfo=pytz.utc)
+    assert timezone.is_aware(datetime_object)
+    naive_datetime = make_naive(datetime_object)
+    assert timezone.is_naive(naive_datetime)
+
+
+def test_make_naive_default_tz(settings):
+    """Tests datetimes are made naive of the configured timezone."""
+    settings.USE_TZ = True
+
+    datetime_object = timezone.make_aware(datetime(2016, 1, 2, 21, 52, 25),
+                                          timezone=pytz.timezone('Europe/Helsinki'))
+    assert timezone.is_aware(datetime_object)
+    naive_datetime = make_naive(datetime_object)
+    assert timezone.is_naive(naive_datetime)
+
+    # Conversion from a Helsinki aware datetime to a naive datetime in Amsterdam
+    # should decrement 1 hour (UTC+2 vs. UTC+1)
+    assert naive_datetime.hour == (datetime_object.hour - 1) % 24
+
+
+def test_make_naive_use_tz_false(settings):
+    """Tests datetimes are left intact if `USE_TZ` is not in effect."""
+    settings.USE_TZ = False
+
+    datetime_object = datetime(2016, 1, 2, 21, 52, 25, tzinfo=pytz.utc)
+    assert timezone.is_aware(datetime_object)
+    naive_datetime = make_naive(datetime_object)
+    assert timezone.is_aware(naive_datetime)
+
+
+def test_aware_datetime(settings):
+    """Tests the creation of a timezone-aware datetime."""
+    datetime_object = aware_datetime(2016, 1, 2, 21, 52, 25)
+    assert timezone.is_aware(datetime_object)
+    assert datetime_object.tzinfo.zone == settings.TIME_ZONE

--- a/tests/core/utils/timezone.py
+++ b/tests/core/utils/timezone.py
@@ -39,6 +39,19 @@ def test_make_aware_default_tz(settings):
     assert datetime_aware.tzinfo.zone == timezone.get_default_timezone().zone
 
 
+def test_make_aware_explicit_tz(settings):
+    """Tests datetimes are made aware of the given timezone."""
+    settings.USE_TZ = True
+
+    given_timezone = pytz.timezone('Asia/Bangkok')
+    datetime_object = datetime(2016, 1, 2, 21, 52, 25)
+    assert timezone.is_naive(datetime_object)
+    datetime_aware = make_aware(datetime_object, tz=given_timezone)
+    assert timezone.is_aware(datetime_aware)
+
+    assert datetime_aware.tzinfo.zone == given_timezone.zone
+
+
 def test_make_aware_use_tz_false(settings):
     """Tests datetimes are left intact if `USE_TZ` is not in effect."""
     settings.USE_TZ = False
@@ -74,6 +87,21 @@ def test_make_naive_default_tz(settings):
     assert naive_datetime.hour == (datetime_object.hour - 1) % 24
 
 
+def test_make_naive_explicit_tz(settings):
+    """Tests datetimes are made naive of the given timezone."""
+    settings.USE_TZ = True
+
+    datetime_object = timezone.make_aware(datetime(2016, 1, 2, 21, 52, 25),
+                                          timezone=pytz.timezone('Europe/Helsinki'))
+    assert timezone.is_aware(datetime_object)
+    naive_datetime = make_naive(datetime_object, tz=pytz.timezone('Asia/Bangkok'))
+    assert timezone.is_naive(naive_datetime)
+
+    # Conversion from a Helsinki aware datetime to a naive datetime in Bangkok
+    # should increment 5 hours (UTC+2 vs. UTC+7)
+    assert naive_datetime.hour == (datetime_object.hour + 5) % 24
+
+
 def test_make_naive_use_tz_false(settings):
     """Tests datetimes are left intact if `USE_TZ` is not in effect."""
     settings.USE_TZ = False
@@ -89,3 +117,10 @@ def test_aware_datetime(settings):
     datetime_object = aware_datetime(2016, 1, 2, 21, 52, 25)
     assert timezone.is_aware(datetime_object)
     assert datetime_object.tzinfo.zone == settings.TIME_ZONE
+
+
+def test_aware_datetime_explicit_tz():
+    """Tests the creation of a explicitly provided timezone-aware datetime."""
+    new_datetime = aware_datetime(2016, 1, 2, 21, 52, 25, tz=pytz.utc)
+    assert timezone.is_aware(new_datetime)
+    assert new_datetime.tzinfo.zone == pytz.utc.zone

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,6 +13,12 @@ import os
 
 SECRET_KEY = "test_secret_key"
 
+# Ideally this setting would be set in a per-test basis, unfortunately some code
+# such as `django.utils.timezone.get_default_timezone` read from this setting
+# and at the same time are behind a `lru_cache` decorator, which makes it
+# impossible to alter the value at runtime because decorators are applied at
+# function definition time.
+TIME_ZONE = 'Europe/Amsterdam'
 
 ROOT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 POOTLE_TRANSLATION_DIRECTORY = os.path.join(ROOT_DIR, 'pytest_pootle', 'data', 'po')


### PR DESCRIPTION
This PR mostly adds tests and docstrings for timezone utilities. When doing so I needed to bring in the pytz library for sanity, which I'm adding in the base requirements also because Django strongly recommends it.

At the same there is a minor enhancement to the existing functions to allow passing timezones explicitly and hence override the default of using `django.utils.timezone.get_default_timezone` (I'm happy to move this to another PR if necessary).