### PR TITLE
Cleanup and some plugin boilerplate for urls, data, and vfolders

### DIFF
--- a/pootle/apps/pootle_store/urls.py
+++ b/pootle/apps/pootle_store/urls.py
@@ -11,11 +11,12 @@ from django.conf.urls import url
 from . import views
 
 
-urlpatterns = [
-    # permalinks
-    url(r'^unit/(?P<uid>[0-9]+)/?$',
-        views.permalink_redirect,
-        name='pootle-unit-permalink'),
+get_units_urlpatterns = [
+    url(r'^xhr/units/?$',
+        views.get_units,
+        name='pootle-xhr-units')]
+
+unit_xhr_urlpatterns = [
 
     # XHR
     url(r'^xhr/stats/checks/?$',
@@ -24,10 +25,6 @@ urlpatterns = [
     url(r'^xhr/stats/?$',
         views.get_stats,
         name='pootle-xhr-stats'),
-
-    url(r'^xhr/units/?$',
-        views.get_units,
-        name='pootle-xhr-units'),
 
     url(r'^xhr/units/(?P<uid>[0-9]+)/?$',
         views.submit,
@@ -56,3 +53,10 @@ urlpatterns = [
         views.toggle_qualitycheck,
         name='pootle-xhr-units-checks-toggle'),
 ]
+
+urlpatterns = (
+    [url(r'^unit/(?P<uid>[0-9]+)/?$',
+         views.permalink_redirect,
+         name='pootle-unit-permalink')]
+    + get_units_urlpatterns
+    + unit_xhr_urlpatterns)

--- a/pootle/apps/virtualfolder/delegate.py
+++ b/pootle/apps/virtualfolder/delegate.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.plugin.delegate import Getter
+
+
+path_matcher = Getter()

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -30,6 +30,7 @@ data_updater = Getter()
 serializers = Provider(providing_args=["instance"])
 deserializers = Provider(providing_args=["instance"])
 subcommands = Provider()
+url_patterns = Provider()
 
 # view.context_data
 context_data = Provider(providing_args=["view", "context"])

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -25,6 +25,7 @@ format_syncers = Provider()
 filetype_tool = Getter()
 tp_tool = Getter()
 data_tool = Getter()
+data_updater = Getter()
 
 serializers = Provider(providing_args=["instance"])
 deserializers = Provider(providing_args=["instance"])

--- a/pootle/urls.py
+++ b/pootle/urls.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.views.generic import TemplateView
 
+from pootle.core.delegate import url_patterns
+
 
 urlpatterns = [
     # Allauth

--- a/pootle/urls.py
+++ b/pootle/urls.py
@@ -13,7 +13,13 @@ from django.views.generic import TemplateView
 from pootle.core.delegate import url_patterns
 
 
-urlpatterns = [
+urlpatterns = []
+
+# Allow url handlers to be overriden by plugins
+for delegate_urls in url_patterns.gather().values():
+    urlpatterns += delegate_urls
+
+urlpatterns += [
     # Allauth
     url(r'^accounts/', include('accounts.urls')),
     url(r'^accounts/', include('allauth.urls')),

--- a/pytest_pootle/fixtures/models/project.py
+++ b/pytest_pootle/fixtures/models/project.py
@@ -111,3 +111,48 @@ def project0_nongnu(project0_directory, project0, settings):
         os.makedirs(project_dir)
     for tp in project0.translationproject_set.all():
         tp.save()
+
+
+@pytest.fixture
+def project_dir_resources0(project0, subdir0):
+    """Returns a ProjectResource object for a Directory"""
+
+    from pootle_app.models import Directory
+    from pootle_project.models import ProjectResource
+
+    resources = Directory.objects.live().filter(
+        name=subdir0.name,
+        parent__translationproject__project=project0)
+    return ProjectResource(
+        resources,
+        ("/projects/%s/%s"
+         % (project0.code,
+            subdir0.name)))
+
+
+@pytest.fixture
+def project_store_resources0(project0, subdir0):
+    """Returns a ProjectResource object for a Store"""
+
+    from pootle_project.models import ProjectResource
+    from pootle_store.models import Store
+
+    store = subdir0.child_stores.live().first()
+    resources = Store.objects.live().filter(
+        name=store.name,
+        parent__name=subdir0.name,
+        translation_project__project=project0)
+
+    return ProjectResource(
+        resources,
+        ("/projects/%s/%s/%s"
+         % (project0.code,
+            subdir0.name,
+            store.name)))
+
+
+@pytest.fixture
+def project_set():
+    from pootle_project.models import Project, ProjectSet
+
+    return ProjectSet(Project.objects.exclude(disabled=True))

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -573,6 +573,11 @@ def store0(tp0):
 
 
 @pytest.fixture
+def store1(tp1):
+    return tp1.stores.get(name="store1.po")
+
+
+@pytest.fixture
 def ordered_po(test_fs, tp0):
     """Create a store with ordered units."""
     from pytest_pootle.factories import StoreDBFactory

--- a/pytest_pootle/fixtures/models/translation_project.py
+++ b/pytest_pootle/fixtures/models/translation_project.py
@@ -92,6 +92,16 @@ def tp0(language0, project0):
 
 
 @pytest.fixture
+def tp1(language1, project1):
+    """Returns the tp created by language1 and project1 fixtures."""
+    from pootle_translationproject.models import TranslationProject
+
+    return TranslationProject.objects.get(
+        language=language1,
+        project=project1)
+
+
+@pytest.fixture
 def no_tp_tool_(request):
     start_receivers = tp_tool.receivers
     tp_tool.receivers = []

--- a/pytest_pootle/fixtures/models/vfolder.py
+++ b/pytest_pootle/fixtures/models/vfolder.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+
+@pytest.fixture
+def vfolder0():
+    from virtualfolder.models import VirtualFolder
+
+    return VirtualFolder.objects.first()


### PR DESCRIPTION
Adds

- ~~migration for vfolders to ensure that previously valid vfolders are renamed~~
- boilerplate delegate declarations for pootle_data and vfolders
- some useful fixtures from the test env

removing migration in favour of addressing - #5217 