### PR TITLE
Add PTL.unitApiRoot var

### DIFF
--- a/pootle/core/views/base.py
+++ b/pootle/core/views/base.py
@@ -88,7 +88,8 @@ class PootleDetailView(GatherContextMixin, DetailView):
             'resource_path_parts': get_path_parts(self.resource_path),
             'translate_url': self.translate_url,
             'export_url': self.export_url,
-            'browse_url': self.browse_url}
+            'browse_url': self.browse_url,
+            'unit_api_root': "/xhr/units/"}
 
 
 class PootleJSON(PootleJSONMixin, PootleDetailView):

--- a/pootle/static/js/shared/api/UnitAPI.js
+++ b/pootle/static/js/shared/api/UnitAPI.js
@@ -8,10 +8,11 @@
 
 import fetch from 'utils/fetch';
 
+window.PTL = window.PTL || {};
 
 const UnitAPI = {
 
-  apiRoot: '/xhr/units/',
+  apiRoot: PTL.unitApiRoot,
 
   fetchUnits(body) {
     return fetch({

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -31,6 +31,7 @@
       MARKUP_FILTER: '{{ settings.POOTLE_MARKUP_FILTER }}',
       SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|to_js }},
     };
+    PTL.unitApiRoot = '{{ unit_api_root }}';
     </script>
 
     {% assets "js_vendor" %}


### PR DESCRIPTION
this allows plugins - eg virtualfolders - to set the /xhr/units url dynamically and therefore use their own views in the editor