### PR TITLE
Cleanup: only clear caches/set revision in tests when required

### DIFF
--- a/pytest_pootle/fixtures/revision.py
+++ b/pytest_pootle/fixtures/revision.py
@@ -9,13 +9,10 @@
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def revision(request, clear_cache):
+@pytest.fixture
+def revision(clear_cache):
     """Sets up the cached revision counter for each test call."""
     from pootle.core.models import Revision
     from pootle_store.models import Unit
 
-    if request.node.get_marker("django_db"):
-        Revision.set(Unit.max_revision())
-    else:
-        Revision.initialize()
+    Revision.set(Unit.max_revision())

--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -78,7 +78,7 @@ def translations_directory(request):
     request.addfinalizer(rm_tmp_dir)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def clear_cache():
     """Currently tests only use one cache so this clears all"""
 

--- a/tests/models/revision.py
+++ b/tests/models/revision.py
@@ -15,7 +15,7 @@ from .unit import _update_translation
 
 
 @pytest.mark.django_db
-def test_max_revision(project0_nongnu, store0):
+def test_max_revision(revision, project0_nongnu, store0):
     """Tests `max_revision()` gets the latest revision."""
     store0.sync()
 

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -278,7 +278,7 @@ def test_view_user_choice(client):
 
 
 @pytest.mark.django_db
-def test_uploads_tp(tp_uploads):
+def test_uploads_tp(revision, tp_uploads):
     tp_, request_, response, kwargs_, errors = tp_uploads
     assert response.status_code == 200
     assert errors.keys() == response.context['upload_form'].errors.keys()


### PR DESCRIPTION
currently every test  clears redis and resets revision, although its not required to do this for the majority of tests