### PR TITLE
[WIP] Bugfix: report changes after IME composition end in Chrome

### DIFF
--- a/pootle/static/js/editor/components/RawFontTextarea.js
+++ b/pootle/static/js/editor/components/RawFontTextarea.js
@@ -262,6 +262,8 @@ const RawFontTextarea = React.createClass({
 
   handleComposition(e) {
     if (e.type === 'compositionend') {
+      // XXX: calling change handler to work around Chrome's changed behavior
+      this._handleChange(e.target.value);
       this.isComposing = false;
     } else {
       this.isComposing = true;


### PR DESCRIPTION
Chrome 53 changed the order in which composition events are fired with respect to the input event, which affects the way we determine the end of IME composition.

Since at the moment there is no possibility to use the `isComposing` property across browsers, we need to work around this by calling the change handler manually after composition is over.

Refs.
https://chromium.googlesource.com/chromium/src/+/afce9d93e76f2ff81baaa088a4ea25f67d1a76b3%5E%21/
Refs. https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/isComposing