### PR TITLE
[FYI] Req: bump django-contrib-comments to v 1.7.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ Django>=1.8.13,<1.9  # rq.filter: >=1.8,<1.9
 django-allauth==0.27.0
 django-assets==0.12
 django-contact-form==1.2
-django-contrib-comments==1.7.2
+django-contrib-comments==1.7.3
 django-overextends==0.4.2
 django-redis==4.4.4
 django-rq>=0.8.0,<=0.9.2


### PR DESCRIPTION
Translations and admin registration, shouldn't impact Pootle.

**Note** I think all version bumps should go through PRs so there is a heads up to all and so that you have to go through Travis.  For more invasive upgrades, I suggest that they get staged, here thinking about RQ,  Django, etc.