### PR TITLE
Reset sender_receivers_cache in suppress_signal contextmanager

### DIFF
--- a/pootle/core/contextmanagers.py
+++ b/pootle/core/contextmanagers.py
@@ -14,10 +14,12 @@ from pootle.core.signals import update_data
 @contextmanager
 def suppress_signal(signal):
     handlers = signal.receivers
+    receiver_cache = signal.sender_receivers_cache.copy()
     signal.receivers = []
     try:
         yield
     finally:
+        signal.sender_receivers_cache = receiver_cache
         signal.receivers = handlers
 
 

--- a/tests/core/contextmanagers.py
+++ b/tests/core/contextmanagers.py
@@ -18,10 +18,12 @@ from pootle_store.models import Store
 @pytest.fixture
 def no_update_data_(request):
     receivers = update_data.receivers
+    receivers_cache = update_data.sender_receivers_cache.copy()
     update_data.receivers = []
 
     def _reset_update_data():
         update_data.receivers = receivers
+        update_data.sender_receivers_cache = receivers_cache
 
     request.addfinalizer(_reset_update_data)
 


### PR DESCRIPTION
This prevents the cache getting polluted while the signal is being suppressed

also updates related test to do similar
