### PR TITLE
Tests: ensure we're running sqlite in memory

### DIFF
--- a/tests/database.py
+++ b/tests/database.py
@@ -1,0 +1,17 @@
+import pytest
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+
+@pytest.mark.django_db
+def test_backend_db():
+    """Ensure that we are always testing sqlite on fast in memory DB"""
+    from django.db import connection, connections
+
+    if connection.vendor == "sqlite":
+        assert connections.databases["default"]["NAME"] == ":memory:"


### PR DESCRIPTION
sqlite in memory database is much faster to run than filebased.  This test is a canary and will fail if somehow the test environment changes to make it file based again.