### PR TITLE
Req: update django-redis to v4.5.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-assets==0.12
 django-contact-form==1.2
 django-contrib-comments==1.7.3
 django-overextends==0.4.2
-django-redis==4.4.4
+django-redis==4.5.0
 django-rq>=0.9.0,<=0.9.2
 django-sortedm2m==1.3.2
 django-statici18n==1.2.1


### PR DESCRIPTION
Brings Django 1.10 compatability. Drops a number of deprecated features.