### PR TITLE
Use mysqlclient for MySQL database backend

### DIFF
--- a/docs/developers/releasing.rst
+++ b/docs/developers/releasing.rst
@@ -306,7 +306,7 @@ the new release using:
     $ mkvirtualenv test-pootle-release
     (test-pootle-release)$ pip install --upgrade pip
     (test-pootle-release)$ pip install dist/Pootle-$version.tar.bz2
-    (test-pootle-release)$ pip install MySQL-python
+    (test-pootle-release)$ pip install mysqlclient
     (test-pootle-release)$ pootle init
 
 

--- a/docs/releases/2.8.0.rst
+++ b/docs/releases/2.8.0.rst
@@ -17,6 +17,7 @@ Changes in Requirements
 
 - Django>=1.9.9,<1.10
 - zlib1g-dev required for lxml
+- MySQL support uses mysqlclient instead of MySQLdb
 
 
 Major Changes
@@ -37,6 +38,8 @@ information.
 Details of changes
 ==================
 
+- MySQL now uses the mysqlclient database driver instead of MySQLdb, this is
+  Django's preferred database driver.
 - Undertook a security audit
 - Improved editor performance
 - JavaScript fixes addressing performance and memory leaks in the editor

--- a/docs/server/mysql_installation.rst
+++ b/docs/server/mysql_installation.rst
@@ -48,18 +48,18 @@ Debian-based system:
 
 .. _mysql_installation#install-bindings:
 
-Installing MySQL Python bindings
---------------------------------
+Installing MySQL Python driver
+------------------------------
 
 Once you have
 :ref:`set up and activated your virtual environment <installation#setup-environment>`,
-you will need to install the MySQL bindings.
+you will need to install the MySQL driver.
 
 You can do so as follows:
 
 .. code-block:: console
 
-  (env) $ pip install MySQL-python
+  (env) $ pip install mysqlclient
 
 
 .. _mysql_installation#init-config:

--- a/docs/server/optimization.rst
+++ b/docs/server/optimization.rst
@@ -21,11 +21,8 @@ Database Backends
 You should really switch to a real database backend in production environments.
 Adjust the :setting:`DATABASES` setting accordingly.
 
-`MySQL-python <http://mysql-python.sourceforge.net/>`_
-  MySQL adapter for Python.
-
-`Psycopg2 <http://initd.org/psycopg/>`_
-  PostgreSQL adapter for Python.
+* :doc:`MySQL <mysql_installation>`
+* :doc:`PostgreSQL <postgresql_installation>`
 
 
 Web Servers

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -3,7 +3,7 @@
 -r base.txt
 
 # Database
-MySQL-python>=1.2.1p2
+mysqlclient>=1.3.3
 # Uncomment for PostgreSQL
 # psycopg2>=2.4.5
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 tox>=2.3
 
 # Databases
-MySQL-python>=1.2.1p2
+mysqlclient>=1.3.3
 psycopg2>=2.4.5
 
 # Test coverage


### PR DESCRIPTION
This is the recommended driver for MySQL since at least Django 1.7.  See
https://docs.djangoproject.com/en/1.9/ref/databases/#mysql-db-api-drivers

This brings with it Python 3 support which will be relevant sometime
soon.