### PR TITLE
Provide default for ACCOUNT_SESSION_REMEMBER

### DIFF
--- a/docs/releases/2.8.0.rst
+++ b/docs/releases/2.8.0.rst
@@ -149,6 +149,9 @@ Changes in settings
   This restricts how many units are shown in export views.
 - :setting:`POOTLE_SEARCH_BACKEND` was added, to allow configuring the search
   backend to be used.
+- Changed the default value for `ACCOUNT_SESSION_REMEMBER
+  <https://django-allauth.readthedocs.io/en/latest/configuration.html>`_ so now
+  sessions are always remembered.  
 
 
 Credits

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -123,6 +123,9 @@ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 # Automatically sign users in upon password reset completion
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 
+# True to always remember user session. False to not remember. None to ask user.
+ACCOUNT_SESSION_REMEMBER = True
+
 # Whether user sign up is enabled
 POOTLE_SIGNUP_ENABLED = True
 


### PR DESCRIPTION
This forces sessions to be remembered, so users don't have to log in every time they restart the browser.

This gets back the behavior we had before moving to allauth.

Fixes #5130.