### PR TITLE
Update unit source componet

### DIFF
--- a/pootle/static/js/editor/components/UnitSource.js
+++ b/pootle/static/js/editor/components/UnitSource.js
@@ -19,9 +19,18 @@ const UnitSource = React.createClass({
   propTypes: {
     id: React.PropTypes.number.isRequired,
     values: React.PropTypes.array.isRequired,
+    getPluralFormName: React.PropTypes.func,
     hasPlurals: React.PropTypes.bool.isRequired,
     sourceLocaleCode: React.PropTypes.string,
     sourceLocaleDir: React.PropTypes.string,
+  },
+
+  getPluralFormName(index) {
+    if (this.props.getPluralFormName !== undefined) {
+      return this.props.getPluralFormName(index);
+    }
+
+    return t('Plural form %(index)s', { index });
   },
 
   createItem(sourceValue, index) {
@@ -29,13 +38,12 @@ const UnitSource = React.createClass({
       lang: this.props.sourceLocaleCode,
       dir: this.props.sourceLocaleDir,
     };
-
     return (
       <div key={`source-value-${index}`}>
         {this.props.hasPlurals &&
          <div
            className="plural-form-label"
-         >{t('Plural form %(index)s', { index })}</div>
+         >{ this.getPluralFormName(index) }</div>
         }
         <div
           className="translation-text js-translation-text"

--- a/pootle/static/js/editor/components/UnitSource.js
+++ b/pootle/static/js/editor/components/UnitSource.js
@@ -14,6 +14,19 @@ import { t } from 'utils/i18n';
 import { highlightRW } from '../../utils';
 
 
+const InnerDiv = ({ sourceValue }) => (
+  <div
+    dangerouslySetInnerHTML={
+      { __html: highlightRW(sourceValue) }
+    }
+  />
+);
+
+InnerDiv.propTypes = {
+  sourceValue: React.PropTypes.string.isRequired,
+};
+
+
 const UnitSource = React.createClass({
 
   propTypes: {
@@ -23,6 +36,13 @@ const UnitSource = React.createClass({
     hasPlurals: React.PropTypes.bool.isRequired,
     sourceLocaleCode: React.PropTypes.string,
     sourceLocaleDir: React.PropTypes.string,
+    innerComponent: React.PropTypes.func,
+  },
+
+  getDefaultProps() {
+    return {
+      innerComponent: InnerDiv,
+    };
   },
 
   getPluralFormName(index) {
@@ -48,9 +68,10 @@ const UnitSource = React.createClass({
         <div
           className="translation-text js-translation-text"
           data-string={sourceValue}
-          dangerouslySetInnerHTML={{ __html: highlightRW(sourceValue) }}
           {...props}
-        ></div>
+        >
+          <this.props.innerComponent sourceValue={sourceValue} />
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
- Use inner component to allow overriding;
- Provide callback for customising pluralform names;

These changes make `UnitSource` pluggable and reusable.
We will use it in `L20nSource` component to show custom named plural forms and `<pre />` tag instead of raw font formatted `<div/>`.
