### PR TITLE
l10n: allow placeable reordering

### DIFF
--- a/pootle/locale/templates/pootle_js.pot
+++ b/pootle/locale/templates/pootle_js.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pootle 2.8.0\n"
 "Report-Msgid-Bugs-To: https://github.com/translate/pootle/issues/new\n"
-"POT-Creation-Date: 2016-09-29 10:42+0100\n"
+"POT-Creation-Date: 2016-09-29 13:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -251,7 +251,7 @@ msgstr ""
 #: static/js/admin/components/User/UserForm.js:81
 #: static/js/auth/components/SignInForm.js:104
 #: static/js/auth/components/SignUpForm.js:101
-#: static/js/auth/components/SocialVerification.js:100
+#: static/js/auth/components/SocialVerification.js:99
 #: static/js/auth/components/PasswordResetForm.js:117
 msgid "Password"
 msgstr ""
@@ -415,18 +415,18 @@ msgid "Sign up as a new user"
 msgstr ""
 
 #: static/js/auth/components/SignInForm.js:113
-#: static/js/auth/components/SocialVerification.js:108
+#: static/js/auth/components/SocialVerification.js:107
 msgid "I forgot my password"
 msgstr ""
 
 #: static/js/auth/components/SignInForm.js:124
-#: static/js/auth/components/SocialVerification.js:119
+#: static/js/auth/components/SocialVerification.js:118
 #: static/js/auth/containers/Auth.js:83
 msgid "Sign In"
 msgstr ""
 
 #: static/js/auth/components/SignInPanel.js:47
-#: static/js/auth/components/SocialVerification.js:73
+#: static/js/auth/components/SocialVerification.js:74
 msgid "Signed in. Redirecting..."
 msgstr ""
 
@@ -509,10 +509,12 @@ msgid "Contributors, 30 Days"
 msgstr ""
 
 #: static/js/browser/components/TopContributorsTable.js:17
+#, python-format
 msgid "+%(score)s"
 msgstr ""
 
 #: static/js/browser/components/TopContributorsTable.js:31
+#, python-format
 msgid "#%(position)s"
 msgstr ""
 
@@ -619,6 +621,7 @@ msgstr ""
 
 #: static/js/editor/components/Editor.js:64
 #: static/js/editor/components/UnitSource.js:38
+#, python-format
 msgid "Plural form %(index)s"
 msgstr ""
 
@@ -639,6 +642,7 @@ msgid "Reject"
 msgstr ""
 
 #: static/js/editor/components/UploadTimeSince.js:34
+#, python-format
 msgid "%(timeSince)s via file upload"
 msgstr ""
 
@@ -745,50 +749,62 @@ msgstr ""
 
 #: static/js/shared/components/UserEvent.js:97
 #: static/js/shared/components/UserEvent.js:118
+#, python-format
 msgid "%(user)s removed translation for %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:99
+#, python-format
 msgid "%(user)s accepted suggestion for %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:101
+#, python-format
 msgid "%(user)s uploaded file"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:103
+#, python-format
 msgid "%(user)s muted %(check)s for %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:105
+#, python-format
 msgid "%(user)s unmuted %(check)s for %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:107
+#, python-format
 msgid "%(user)s added suggestion for %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:109
+#, python-format
 msgid "%(user)s rejected suggestion for %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:112
+#, python-format
 msgid "%(user)s translated %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:114
+#, python-format
 msgid "%(user)s edited %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:116
+#, python-format
 msgid "%(user)s pre-translated %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:120
+#, python-format
 msgid "%(user)s reviewed %(sourceString)s"
 msgstr ""
 
 #: static/js/shared/components/UserEvent.js:122
+#, python-format
 msgid "%(user)s marked as needs work %(sourceString)s"
 msgstr ""
 
@@ -801,6 +817,7 @@ msgid "A year ago"
 msgstr ""
 
 #: static/js/shared/utils/relativeTime.js:20
+#, python-format
 msgid "%(count)s year ago"
 msgid_plural "%(count)s years ago"
 msgstr[0] ""
@@ -811,6 +828,7 @@ msgid "A month ago"
 msgstr ""
 
 #: static/js/shared/utils/relativeTime.js:28
+#, python-format
 msgid "%(count)s month ago"
 msgid_plural "%(count)s months ago"
 msgstr[0] ""
@@ -821,6 +839,7 @@ msgid "A week ago"
 msgstr ""
 
 #: static/js/shared/utils/relativeTime.js:36
+#, python-format
 msgid "%(count)s week ago"
 msgid_plural "%(count)s weeks ago"
 msgstr[0] ""
@@ -831,6 +850,7 @@ msgid "Yesterday"
 msgstr ""
 
 #: static/js/shared/utils/relativeTime.js:44
+#, python-format
 msgid "%(count)s day ago"
 msgid_plural "%(count)s days ago"
 msgstr[0] ""
@@ -841,6 +861,7 @@ msgid "An hour ago"
 msgstr ""
 
 #: static/js/shared/utils/relativeTime.js:52
+#, python-format
 msgid "%(count)s hour ago"
 msgid_plural "%(count)s hours ago"
 msgstr[0] ""
@@ -851,6 +872,7 @@ msgid "A minute ago"
 msgstr ""
 
 #: static/js/shared/utils/relativeTime.js:60
+#, python-format
 msgid "%(count)s minute ago"
 msgid_plural "%(count)s minutes ago"
 msgstr[0] ""
@@ -954,9 +976,10 @@ msgstr ""
 #: static/js/auth/components/SocialVerification.js:81
 #, python-format
 msgid ""
-"We found a user with <span>%s</span> email in our system. Please provide the "
-"password to finish the sign in procedure. This is a one-off procedure, which "
-"will establish a link between your Pootle and %s accounts."
+"We found a user with <span>%(email)s</span> email in our system. Please "
+"provide the password to finish the sign in procedure. This is a one-off "
+"procedure, which will establish a link between your Pootle and %(provider)s "
+"accounts."
 msgstr ""
 
 #: static/js/browser.js:267

--- a/pootle/static/js/auth/components/SocialVerification.js
+++ b/pootle/static/js/auth/components/SocialVerification.js
@@ -9,6 +9,7 @@
 import assign from 'object-assign';
 import React from 'react';
 
+import { t } from 'utils/i18n';
 import FormElement from 'components/FormElement';
 import FormMixin from 'mixins/FormMixin';
 
@@ -76,14 +77,12 @@ const SocialVerification = React.createClass({
     const { errors } = this.state;
     const { formData } = this.state;
 
-    const verificationMsg = interpolate(
-      gettext(
-        'We found a user with <span>%s</span> email in our system. Please ' +
-        'provide the password to finish the sign in procedure. This is a ' +
-        'one-off procedure, which will establish a link between your ' +
-        'Pootle and %s accounts.'
-      ),
-      [this.props.email, this.props.providerName]
+    const verificationMsg = t(
+      'We found a user with <span>%(email)s</span> email in our system. ' +
+      'Please provide the password to finish the sign in procedure. This ' +
+      'is a one-off procedure, which will establish a link between your ' +
+      'Pootle and %(provider)s accounts.',
+      { email: this.props.email, provider: this.props.providerName }
     );
 
     return (

--- a/pootle/tools/createpootlepot
+++ b/pootle/tools/createpootlepot
@@ -50,7 +50,7 @@ django-admin.py makemessages -v $VERBOSITY $ignore --ignore static/js -e py,txt,
 # first we extract using JavaScript just to get the ones that do actually work.
 find static/js -name "*.js" |  egrep -v "(node_modules|\.bundle\.js)" | xargs xgettext --keyword=tct --keyword=t --keyword=nt:1,2 --output=$DJANGO_JS_POT --language=JavaScript --from-code=utf-8 --add-comments=Translators
 sed -i"" -e "s/charset=CHARSET/charset=UTF-8/" $DJANGO_JS_POT
-find static/js -name "*.js" |  egrep -v "(node_modules|\.bundle\.js)" | xargs xgettext --join-existing --output=$DJANGO_JS_POT --language=Python --from-code=utf-8 --add-comments=Translators
+find static/js -name "*.js" |  egrep -v "(node_modules|\.bundle\.js)" | xargs xgettext --join-existing --output=$DJANGO_JS_POT --language=Python --from-code=utf-8 --add-comments=Translators --keyword=tct --keyword=t --keyword=nt:1,2
 
 # Extract localisable content from HTML pages used by JS
 xgettext --join-existing --output=$DJANGO_JS_POT --language=Python --from-code=utf-8 --add-comments=Translators $(find templates -name "*.html")


### PR DESCRIPTION
One string that's using %s for two placeables and is causing gettext warning, apart from not allowing translators to reorder in a very unlikely event.