### PR TITLE
Highlight spaces around [NBSP] and [TAB]

### DIFF
--- a/pootle/static/js/editor/utils/font.js
+++ b/pootle/static/js/editor/utils/font.js
@@ -193,7 +193,7 @@ export function raw2sym(value, { isRawMode = false } = {}) {
   // in raw mode, replace all spaces;
   // otherwise, replace two or more spaces in a row
   let newValue = isRawMode ?
-    value.replace(/ /g, spaceReplacer) :
+    value.replace(/ +/g, spaceReplacer) :
     value.replace(/ {2,}/g, spaceReplacer);
   // leading line spaces
   newValue = newValue.replace(/\n /g, leadingSpaceReplacer);

--- a/pootle/static/js/editor/utils/font.js
+++ b/pootle/static/js/editor/utils/font.js
@@ -153,6 +153,11 @@ function leadingSpaceReplacer(match) {
 }
 
 
+function surroundingSpaceReplacer(match) {
+  return match.substring(0).replace(/ +/g, spaceReplacer);
+}
+
+
 function trailingSpaceReplacer(match) {
   return spaceReplacer(match.substring(1)) + CHARACTERS.LF;
 }
@@ -194,6 +199,10 @@ export function raw2sym(value, { isRawMode = false } = {}) {
   newValue = newValue.replace(/\n /g, leadingSpaceReplacer);
   // trailing line spaces
   newValue = newValue.replace(/ \n/g, trailingSpaceReplacer);
+  // space before TAB or NBSP
+  newValue = newValue.replace(/ [\t\u00A0]/g, surroundingSpaceReplacer);
+  // space after TAB or NBSP
+  newValue = newValue.replace(/[\t\u00A0] /g, surroundingSpaceReplacer);
   // single leading document space
   newValue = newValue.replace(/^ /, spaceReplacer);
   // single trailing document space

--- a/pootle/static/js/editor/utils/font.test.js
+++ b/pootle/static/js/editor/utils/font.test.js
@@ -63,6 +63,16 @@ describe('raw2sym (regular mode)', () => {
         `${SYMBOLS.SPACE}${SYMBOLS.SPACE}${SYMBOLS.SPACE}${SYMBOLS.SPACE}`
       ),
     },
+    {
+      description: 'whitespace around [NBSP]',
+      input: `foo ${CHARACTERS.NBSP} bar`,
+      expected: `foo${SYMBOLS.SPACE}${SYMBOLS.NBSP}${SYMBOLS.SPACE}bar`,
+    },
+    {
+      description: 'whitespace around [TAB]',
+      input: `foo ${CHARACTERS.TAB} bar`,
+      expected: `foo${SYMBOLS.SPACE}${SYMBOLS.TAB}${SYMBOLS.SPACE}bar`,
+    },
 
     {
       description: 'new line at end of line',


### PR DESCRIPTION
This PR implements highlighting spaces around the [NBSP] and [TAB] symbols. An extra optimization for handling spaces is included as well.

Fixes #5297.