### PR TITLE
Export view: fix highlighting of raw font

### DIFF
--- a/pootle/templates/editor/export_view.html
+++ b/pootle/templates/editor/export_view.html
@@ -1,4 +1,4 @@
-{% load core assets i18n locale store_tags %}
+{% load core assets i18n locale staticfiles store_tags %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
 <head>
@@ -8,8 +8,13 @@
     {% if language %}{{ language.name }}{% else %}{% trans "All Languages" %}{% endif %} | 
     {{ settings.POOTLE_TITLE }}</title>
   <style type="text/css">
+    @font-face {
+      font-family: 'Raw';
+      src: url('{% static "fonts/raw.woff" %}') format('woff');
+    }
+
     html {
-      font-family: sans-serif;
+      font-family: 'Raw', sans-serif;
       font-size: 15px;
       background-color: #fff;
       color: #130f30;


### PR DESCRIPTION
The font wasn't being loaded in the export view page hence default symbols
would be displayed instead of our custom ones.

--

To check this out, open up an export view page with units containing special characters that need to be highlighted. Previously a system default font would be used, with the PR the raw font symbols should be displayed.