### PR TITLE
HTML highlight: allow `$` string between delimiters

### DIFF
--- a/pootle/static/js/editor/utils/highlight.js
+++ b/pootle/static/js/editor/utils/highlight.js
@@ -7,6 +7,7 @@
  */
 
 import { BASE_MAP_REVERSE_HL, RE_BASE_REVERSE } from './font';
+import { escapeRegexReplacementSymbols } from './search';
 
 
 /* eslint-disable no-irregular-whitespace */
@@ -64,9 +65,10 @@ export function highlightHtml(text, className = '') {
     let replaced = submap[match];
 
     if (replaced === undefined) {
+      const remainder = match.slice(1, match.length - 1);
       replaced = htmlHl.replace(
         /%s/,
-        highlightHtml(match.slice(1, match.length - 1))
+        escapeRegexReplacementSymbols(highlightHtml(remainder))
       );
     }
 

--- a/pootle/static/js/editor/utils/highlight.test.js
+++ b/pootle/static/js/editor/utils/highlight.test.js
@@ -134,6 +134,16 @@ describe('highlightHtml', () => {
         `&amp;nbsp;${HL_START}&lt;/i&gt;${HL_END}${HL_START}&lt;/b&gt;${HL_END}`
       ),
     },
+    {
+      description: 'HTML tags which contain $ between delimiters',
+      input: "<a href='$url$'>",
+      expected: `${HL_START}&lt;a href='$url$'&gt;${HL_END}`,
+    },
+    {
+      description: 'HTML tags which contain %s between delimiters',
+      input: '<a href="%s">',
+      expected: `${HL_START}&lt;a href="%s"&gt;${HL_END}`,
+    },
   ];
 
   tests.forEach((test) => {

--- a/pootle/static/js/editor/utils/search.js
+++ b/pootle/static/js/editor/utils/search.js
@@ -21,6 +21,17 @@ export function escapeUnsafeRegexSymbols(s) {
 }
 
 
+/**
+ * Escape unsafe regular expression replacement symbols: $
+ *
+ * When providing a replacement string for a regular expression, the dollar
+ * character plays a special role. We escape it here.
+ */
+export function escapeRegexReplacementSymbols(s) {
+  return s.replace(/\$/g, '$$$$');
+}
+
+
 /*
  * Make regular expression using every word in input string.
  *


### PR DESCRIPTION
In its previous shape, highlighting would be screwed due to the special meaning
of the dollar sign in regular expression replacement strings: they are treated
as replacement patterns.