### PR TITLE
Reintroduce editor value's state

### DIFF
--- a/pootle/static/js/editor/components/Editor.js
+++ b/pootle/static/js/editor/components/Editor.js
@@ -26,6 +26,7 @@ const Editor = React.createClass({
     style: React.PropTypes.object,
     targetNplurals: React.PropTypes.number.isRequired,
     textareaComponent: React.PropTypes.func,
+    values: React.PropTypes.array,
   },
 
   getDefaultProps() {
@@ -59,7 +60,8 @@ const Editor = React.createClass({
             id={getAreaId(i)}
             initialValue={this.props.initialValues[i]}
             isDisabled={this.props.isDisabled}
-            onChange={this.props.onChange}
+            onChange={(value) => this.props.onChange(i, value)}
+            value={this.props.values[i]}
             {...extraProps}
           />
         </EditingArea>

--- a/pootle/static/js/editor/components/RawFontTextarea.js
+++ b/pootle/static/js/editor/components/RawFontTextarea.js
@@ -106,7 +106,7 @@ const RawFontTextarea = React.createClass({
 
   handleChange() {
     this.saveSnapshot(this.previousSnapshot);
-    this.props.onChange();
+    this.props.onChange(this.rawFont.getValue());
   },
 
   handleUndo(e) {
@@ -122,7 +122,7 @@ const RawFontTextarea = React.createClass({
       undone: [...prevState.undone, this.rawFont.getSnapshot()],
     }), () => {
       this.previousSnapshot = this.rawFont.setSnapshot(newSnapshot);
-      this.props.onChange();
+      this.props.onChange(this.rawFont.getValue());
     });
   },
 
@@ -139,7 +139,7 @@ const RawFontTextarea = React.createClass({
       undone: prevState.undone.slice(0, -1),
     }), () => {
       this.previousSnapshot = this.rawFont.setSnapshot(newSnapshot);
-      this.props.onChange();
+      this.props.onChange(this.rawFont.getValue());
     });
   },
 

--- a/pootle/static/js/editor/containers/EditorContainer.js
+++ b/pootle/static/js/editor/containers/EditorContainer.js
@@ -12,7 +12,6 @@ import { qAll } from 'utils/dom';
 
 import Editor from '../components/Editor';
 import RawFontTextarea from '../components/RawFontTextarea';
-import { sym2raw } from '../utils/font';
 
 
 const EditorContainer = React.createClass({
@@ -50,6 +49,12 @@ const EditorContainer = React.createClass({
     };
   },
 
+  getInitialState() {
+    return {
+      values: this.props.initialValues,
+    };
+  },
+
   getChildContext() {
     return {
       currentLocaleCode: this.props.currentLocaleCode,
@@ -71,9 +76,15 @@ const EditorContainer = React.createClass({
   },
 
   getStateValues() {
-    return this.areas.map(
-      (element) => sym2raw(element.value, { isRawMode: this.props.isRawMode })
-    );
+    return this.state.values;
+  },
+
+  handleChange(i, value) {
+    const newValues = this.state.values.slice();
+    newValues[i] = value;
+    this.setState({
+      values: newValues,
+    }, this.props.onChange);
   },
 
   render() {
@@ -85,8 +96,9 @@ const EditorContainer = React.createClass({
         targetNplurals={this.props.targetNplurals}
         textareaComponent={this.props.textareaComponent}
         initialValues={this.props.initialValues}
-        onChange={this.props.onChange}
+        onChange={this.handleChange}
         sourceValues={this.props.sourceValues}
+        values={this.state.values}
       />
     );
   },


### PR DESCRIPTION
While we removed it motivated by the fact that the RawFontTextarea wasn't reading from it, it's a legitimate use-case other components willing to read from the state without manually resourcing to querying the DOM in an ad-hoc manner.