### PR TITLE
Editor container updates

### DIFF
--- a/pootle/static/js/editor/components/Editor.js
+++ b/pootle/static/js/editor/components/Editor.js
@@ -18,6 +18,7 @@ import { getAreaId } from '../utils';
 const Editor = React.createClass({
 
   propTypes: {
+    getPluralFormName: React.PropTypes.func,
     initialValues: React.PropTypes.array,
     isDisabled: React.PropTypes.bool,
     isRawMode: React.PropTypes.bool,
@@ -36,6 +37,14 @@ const Editor = React.createClass({
     };
   },
 
+  getPluralFormName(index) {
+    if (this.props.getPluralFormName !== undefined) {
+      return this.props.getPluralFormName(index);
+    }
+
+    return t('Plural form %(index)s', { index });
+  },
+
   render() {
     const editingAreas = [];
 
@@ -52,7 +61,7 @@ const Editor = React.createClass({
         >
           {(this.props.targetNplurals > 1) &&
             <div className="subheader">
-              { t('Plural form %(index)s', { index: i }) }
+              { this.getPluralFormName(i) }
             </div>
           }
           <this.props.textareaComponent

--- a/pootle/static/js/editor/formats/FormatAdaptor.js
+++ b/pootle/static/js/editor/formats/FormatAdaptor.js
@@ -6,12 +6,12 @@
  * AUTHORS file for copyright and authorship information.
  */
 
-import Editor from '../components/Editor';
+import EditorContainer from '../containers/EditorContainer';
 import UnitSource from '../components/UnitSource';
 
 
 const FormatAdaptor = {
-  editorComponent: Editor,
+  editorComponent: EditorContainer,
   unitSourceComponent: UnitSource,
 };
 

--- a/pootle/static/js/editor/index.js
+++ b/pootle/static/js/editor/index.js
@@ -12,7 +12,6 @@ import React from 'react';
 import ReactRenderer from 'utils/ReactRenderer';
 import { q, qAll } from 'utils/dom';
 
-import EditorContainer from './containers/EditorContainer';
 import { loadFormatAdaptor } from './formats/FormatLoader';
 import { hasCRLF, normalize, denormalize } from './utils/normalizer';
 import { insertAtCaret, setValue } from './utils/RawFontAware';
@@ -53,9 +52,8 @@ const ReactEditor = {
     }
 
     this.editorInstance = ReactRenderer.render(
-      <EditorContainer
+      <this.formatAdaptor.editorComponent
         onChange={this.handleChange}
-        editorComponent={this.formatAdaptor.editorComponent}
         {...this.props}
         {...extraProps}
       />,


### PR DESCRIPTION
This PR:
- makes EditorContainer component customisable via FormatAdaptor;
- cleans up unused lines from EditorContainer component;
- allows customising plural form name in Editor component;

It's necessary to reduce related changes in next PR #5224.