### PR TITLE
Remove django-debug-toolbar for dev

### DIFF
--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -137,23 +137,6 @@ ASSETS_AUTO_BUILD = True
 INSTALLED_APPS += ['django_extensions']
 
 
-#
-# Django debug toolbar
-#
-# Check its README for further configuration options:
-# https://github.com/django-debug-toolbar/django-debug-toolbar/blob/master/README.rst
-INSTALLED_APPS += ['debug_toolbar']
-
-MIDDLEWARE_CLASSES += [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
-
-DEBUG_TOOLBAR_CONFIG = {
-    # Toolbar options
-    'SHOW_COLLAPSED': True,
-    # Panel options
-    'INTERCEPT_REDIRECTS': False,
-}
 
 
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@
 -r _docs.txt
 -r _lint.txt
 
-django-debug-toolbar>=1.4
 django-extensions
 glue>=0.2.8.1
 ipython


### PR DESCRIPTION
There were some problems concerning the particular django extension
while trying to run the dev build. I think it is better to remove
this since we could easily use other tools such as (i)pdb for debugging
. Removal of this will also make running the dev build easier.