### PR TITLE
Allow whitespace as part of special characters

### DIFF
--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -8,6 +8,7 @@
 
 import re
 import urlparse
+from collections import OrderedDict
 
 from django import forms
 from django.contrib.auth import get_user_model
@@ -39,6 +40,13 @@ class LanguageForm(forms.ModelForm):
             )
 
         return self.cleaned_data["code"]
+
+    def clean_specialchars(self):
+        """Ensures inputted characters are unique."""
+        chars = self.cleaned_data['specialchars']
+        return u''.join(
+            OrderedDict((char, None) for char in list(chars)).keys()
+        )
 
 
 class ProjectForm(forms.ModelForm):

--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -24,6 +24,8 @@ LANGCODE_RE = re.compile("^[a-z]{2,}([_-]([a-z]{2,}|[0-9]{3}))*(@[a-z0-9]+)?$",
 
 class LanguageForm(forms.ModelForm):
 
+    specialchars = forms.CharField(strip=False)
+
     class Meta(object):
         model = Language
         fields = ('id', 'code', 'fullname', 'specialchars', 'nplurals',

--- a/tests/forms/language.py
+++ b/tests/forms/language.py
@@ -32,3 +32,23 @@ def test_clean_specialchars_whitespace(specialchars):
     form = LanguageForm(form_data)
     assert form.is_valid()
     assert ' ' in form.cleaned_data['specialchars']
+
+
+@pytest.mark.parametrize('specialchars, count_char', [
+    (' abcde     ', ' '),
+    (' aaaaaaaaaa', 'a'),
+    ('āéĩøøøøøøü', u'ø'),
+])
+@pytest.mark.django_db
+def test_clean_specialchars_unique(specialchars, count_char):
+    """Tests special characters are unique."""
+    form_data = {
+        'code': 'foo',
+        'fullname': 'Foo',
+        'checkstyle': 'foo',
+        'nplurals': '2',
+        'specialchars': specialchars,
+    }
+    form = LanguageForm(form_data)
+    assert form.is_valid()
+    assert form.cleaned_data['specialchars'].count(count_char) == 1

--- a/tests/forms/language.py
+++ b/tests/forms/language.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle_app.forms import LanguageForm
+
+
+@pytest.mark.parametrize('specialchars', [
+    ' abcde ',
+    ' ab cd',
+    ' abcde',
+    'abcde ',
+    ' a b c d e ',
+    ' a b c d e ',
+])
+@pytest.mark.django_db
+def test_clean_specialchars_whitespace(specialchars):
+    """Tests whitespace is accepted in special characters."""
+    form_data = {
+        'code': 'foo',
+        'fullname': 'Foo',
+        'checkstyle': 'foo',
+        'nplurals': '2',
+        'specialchars': specialchars,
+    }
+    form = LanguageForm(form_data)
+    assert form.is_valid()
+    assert ' ' in form.cleaned_data['specialchars']


### PR DESCRIPTION
With this PR, whitespace is now allowed as part of special characters. As a bonus, it also validates for uniqueness of inputted characters.

Refs. #5291.