### PR TITLE
Requirements: pin the stuff we build with, ensure that stuff we use is py3 and Dj1.9

### DIFF
--- a/requirements/_docs.txt
+++ b/requirements/_docs.txt
@@ -1,3 +1,3 @@
 # Documentation
 
-sphinx
+sphinx==1.4.8

--- a/requirements/_lint.txt
+++ b/requirements/_lint.txt
@@ -1,7 +1,7 @@
 # Linting tools
 
-flake8!=2.5.3
-isort>=4.2.3
+flake8==3.0.4
+isort==4.2.5
 pycodestyle==2.0.0
 pydocstyle==1.1.1
-pylint
+pylint==1.6.4

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -8,4 +8,4 @@ mysqlclient>=1.3.3
 # psycopg2>=2.4.5
 
 # Logging
-raven
+raven>=5.27.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@
 -r _docs.txt
 -r _lint.txt
 
-django-debug-toolbar>=1.4
-django-extensions
-glue>=0.2.8.1
-ipython
+django-debug-toolbar==1.6
+django-extensions==1.7.4
+glue==0.11.1
+ipython==5.1.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,6 @@
 # Testing
 
-factory_boy>=2.5.2
+factory_boy==2.7.0
 pytest==3.0.3
 pytest-catchlog==1.2.2
 pytest-cov==2.3.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,13 +4,13 @@
 -r _docs.txt
 -r _lint.txt
 
-tox>=2.3
+tox>=2.3.1
 
 # Databases
 mysqlclient>=1.3.3
 psycopg2>=2.4.5
 
 # Test coverage
-codecov
-coverage
-coveralls
+codecov>=2.0.5
+coverage>=4.2
+coveralls>=1.1


### PR DESCRIPTION
A few objectives here:

1. Pin anything we use in test, lint and dev - we don't want meta stuff breaking our dev cycle.  We can update linting and testing tools once we know the updates have no adverse consequences.  requires.io will pick up anything out of date pretty quickly.
2. Set a minimum version for tools we use that aren't versioned at all.  We have a few where for Django 1.9 support we actually do have a minimum.  In some places we've just set currently used version as the new minimum.
3. Ensure that all the packages we use are Python 3 compatible, thus eliminating that as a blockage.  Only cssmin has no Python 3 support at the moment.