### PR TITLE
Editor: highlight space before punctuation

### DIFF
--- a/pootle/static/js/editor/utils/font.js
+++ b/pootle/static/js/editor/utils/font.js
@@ -197,6 +197,8 @@ export function raw2sym(value, { isRawMode = false } = {}) {
   newValue = newValue.replace(/ [\t\u00A0]/g, surroundingSpaceReplacer);
   // space after TAB or NBSP
   newValue = newValue.replace(/[\t\u00A0] /g, surroundingSpaceReplacer);
+  // space before punctuation
+  newValue = newValue.replace(/ [:!?]/g, surroundingSpaceReplacer);
   // single leading document space
   newValue = newValue.replace(/^ /, spaceReplacer);
   // single trailing document space

--- a/pootle/static/js/editor/utils/font.test.js
+++ b/pootle/static/js/editor/utils/font.test.js
@@ -75,6 +75,22 @@ describe('raw2sym (regular mode)', () => {
     },
 
     {
+      description: 'whitespace before punctuation (!)',
+      input: 'foo ! Bar',
+      expected: `foo${SYMBOLS.SPACE}! Bar`,
+    },
+    {
+      description: 'whitespace before punctuation (?)',
+      input: 'foo ? Bar',
+      expected: `foo${SYMBOLS.SPACE}? Bar`,
+    },
+    {
+      description: 'whitespace before punctuation (:)',
+      input: 'foo : Bar',
+      expected: `foo${SYMBOLS.SPACE}: Bar`,
+    },
+
+    {
       description: 'new line at end of line',
       input: `one${CHARACTERS.LF}`,
       expected: `one${SYMBOLS.LF}${CHARACTERS.LF}`,


### PR DESCRIPTION
This addresses issue #5303 

Where we have `[sp][?!:]` in the editor the [sp] will get special highlighting.  This ensures that space before punctuation more clearly shows the space that is present.
