### PR TITLE
Bag of raw font fixes

### DIFF
--- a/pootle/static/js/editor/components/RawFontTextarea.js
+++ b/pootle/static/js/editor/components/RawFontTextarea.js
@@ -93,6 +93,10 @@ const RawFontTextarea = React.createClass({
     );
   },
 
+  componentDidUpdate() {
+    this.rawFont.focus();
+  },
+
   componentWillUnmount() {
     this.mousetrap.unbind(UNDO_SHORTCUT);
     this.mousetrap.unbind(REDO_SHORTCUT);

--- a/pootle/static/js/editor/components/RawFontTextarea.js
+++ b/pootle/static/js/editor/components/RawFontTextarea.js
@@ -61,7 +61,8 @@ const RawFontTextarea = React.createClass({
     this.mousetrap.bind(REDO_SHORTCUT, this.handleRedo);
 
     const { isRawMode } = this.props;
-    this.rawFont = new RawFontAware(this._textareaNode, { isRawMode });
+    const isRtlMode = this.context.currentLocaleDir === 'rtl' && !isRawMode;
+    this.rawFont = new RawFontAware(this._textareaNode, { isRawMode, isRtlMode });
     this.previousSnapshot = this.rawFont.setSnapshot({
       value: this.props.initialValue,
     });
@@ -69,7 +70,10 @@ const RawFontTextarea = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     if (this.props.isRawMode !== nextProps.isRawMode) {
-      this.rawFont.setMode({ isRawMode: nextProps.isRawMode });
+      const isRtlMode = (
+        this.context.currentLocaleDir === 'rtl' && !nextProps.isRawMode
+      );
+      this.rawFont.setMode({ isRtlMode, isRawMode: nextProps.isRawMode });
       this.rawFont.update();
     }
   },

--- a/pootle/static/js/editor/components/RawFontTextarea.js
+++ b/pootle/static/js/editor/components/RawFontTextarea.js
@@ -83,8 +83,9 @@ const RawFontTextarea = React.createClass({
     // If this implementation ever becomes a measured cause of slowness and the
     // undo/redo stack also grows, consider using immutable data structures.
     return (
-      !_.isEqual(this.state.done, nextState.done) &&
-      !_.isEqual(this.state.undone, nextState.undone)
+      this.isRawMode !== nextProps.isRawMode ||
+      (!_.isEqual(this.state.done, nextState.done) &&
+       !_.isEqual(this.state.undone, nextState.undone))
     );
   },
 

--- a/pootle/static/js/editor/containers/EditorContainer.js
+++ b/pootle/static/js/editor/containers/EditorContainer.js
@@ -62,12 +62,7 @@ const EditorContainer = React.createClass({
     };
   },
 
-  componentWillMount() {
-    this.shouldOverride = false;
-  },
-
   componentDidMount() {
-    this.shouldOverride = false;
     this.areas = qAll('.js-translation-area');
   },
 

--- a/pootle/static/js/editor/utils/RawFontAware.js
+++ b/pootle/static/js/editor/utils/RawFontAware.js
@@ -28,8 +28,8 @@ function triggerEvent(element, eventName) {
 }
 
 
-function getValue(element, { isRawMode = false } = {}) {
-  return sym2raw(element.value, { isRawMode });
+function getValue(element) {
+  return sym2raw(element.value);
 }
 
 
@@ -43,7 +43,7 @@ export function setValue(
     triggerEvent(element, 'input');
   }
 
-  return getValue(element, { isRawMode });
+  return getValue(element);
 }
 
 
@@ -59,12 +59,12 @@ function update(
   const sBefore = value.substring(0, adjustedStart);
   const sAfter = value.substring(end);
   const sBeforeNormalized = raw2sym(
-    sym2raw(sBefore + valueToInsert, { isRawMode }),
+    sym2raw(sBefore + valueToInsert),
     { isRawMode }
   );
   const offset = sBeforeNormalized.length - sBefore.length - (end - adjustedStart);
   const newValue = raw2sym(
-    sym2raw(sBefore + valueToInsert + sAfter, { isRawMode }),
+    sym2raw(sBefore + valueToInsert + sAfter),
     { isRawMode }
   );
   if (value === newValue) {
@@ -89,7 +89,7 @@ export function insertAtCaret(
   element, value, { isRawMode = false, triggerChange = false } = {}
 ) {
   update(element, value, { isRawMode, triggerChange });
-  return getValue(element, { isRawMode });
+  return getValue(element);
 }
 
 
@@ -181,7 +181,7 @@ export class RawFontAware {
   }
 
   sym2raw(value) {
-    return sym2raw(value, { isRawMode: this.isRawMode });
+    return sym2raw(value);
   }
 
   onMouseDown() {

--- a/pootle/static/js/editor/utils/RawFontAware.js
+++ b/pootle/static/js/editor/utils/RawFontAware.js
@@ -144,6 +144,10 @@ export class RawFontAware {
     this.isRtlMode = isRtlMode;
   }
 
+  focus() {
+    this.element.focus();
+  }
+
   getValue() {
     return getValue(this.element);
   }

--- a/pootle/static/js/editor/utils/RawFontAware.js
+++ b/pootle/static/js/editor/utils/RawFontAware.js
@@ -110,6 +110,8 @@ export class RawFontAware {
   destroy() {
     const { element } = this;
 
+    this.clearDeferTimer();
+
     element.removeEventListener('input', this.onInput);
     element.removeEventListener('keydown', this.onKeyDown);
     element.removeEventListener('mousedown', this.onMouseDown);
@@ -120,6 +122,18 @@ export class RawFontAware {
     element.removeEventListener('compositionend', this.onCompositionEnd);
 
     this.element = null;
+  }
+
+  clearDeferTimer() {
+    if (this.deferTimer) {
+      clearTimeout(this.deferTimer);
+      this.deferTimer = undefined;
+    }
+  }
+
+  defer(f) {
+    this.clearDeferTimer();
+    this.deferTimer = setTimeout(f, 0);
   }
 
   setMode({ isRawMode = false } = {}) {
@@ -166,9 +180,9 @@ export class RawFontAware {
     // Request selection adjustment after the mousedown event is processed
     // (because now selectionStart/End are not updated yet, even though the
     // caret is already repositioned).
-    setTimeout(() => {
+    this.defer(() => {
       this.adjustSelection();
-    }, 0);
+    });
   }
 
   onMouseUp() {
@@ -186,9 +200,9 @@ export class RawFontAware {
     );
 
     // Request selection adjustment after the keydown event is processed
-    setTimeout(() => {
+    this.defer(() => {
       this.adjustSelection(moveRight);
-    }, 0);
+    });
 
     let start = target.selectionStart;
     let end = target.selectionEnd;
@@ -269,11 +283,11 @@ export class RawFontAware {
     // event is processed, and will only run updateTextarea() if it wasn't
     // processed by the native `input` event (on browsers other than Chrome).
     this.requestUpdate = true;
-    setTimeout(() => {
+    this.defer(() => {
       if (self.requestUpdate) {
         this.update();
       }
-    }, 0);
+    });
   }
 
   adjustSelection(moveRight) {

--- a/pootle/static/js/editor/utils/RawFontAware.js
+++ b/pootle/static/js/editor/utils/RawFontAware.js
@@ -284,7 +284,7 @@ export class RawFontAware {
     // processed by the native `input` event (on browsers other than Chrome).
     this.requestUpdate = true;
     this.defer(() => {
-      if (self.requestUpdate) {
+      if (this.requestUpdate) {
         this.update();
       }
     });

--- a/pootle/static/js/editor/utils/font.js
+++ b/pootle/static/js/editor/utils/font.js
@@ -137,7 +137,6 @@ const SYM_FULL = Object.keys(_.invert(FULL_MAP)).join('');
 
 
 const RE_RAW_BASE = new RegExp(`[${RAW_BASE}]`, 'g');
-const RE_SYM_BASE = new RegExp(`[${SYM_BASE}]`, 'g');
 
 const RE_RAW_FULL = new RegExp(`[${RAW_FULL}]`, 'g');
 const RE_SYM_FULL = new RegExp(`[${SYM_FULL}]`, 'g');
@@ -171,11 +170,6 @@ function mapSymbol(symbol, source, target) {
 
 function replaceFullSymbol(match) {
   return mapSymbol(match, SYM_FULL, RAW_FULL);
-}
-
-
-function replaceBaseSymbol(match) {
-  return mapSymbol(match, SYM_BASE, RAW_BASE);
 }
 
 
@@ -218,7 +212,7 @@ export function raw2sym(value, { isRawMode = false } = {}) {
 }
 
 
-export function sym2raw(value, { isRawMode = false } = {}) {
+export function sym2raw(value) {
   // LF + newlines to regular newlines
   let newValue = value.replace(/\u240A\n/g, CHARACTERS.LF);
   // orphaned LF to newlines as well
@@ -226,9 +220,7 @@ export function sym2raw(value, { isRawMode = false } = {}) {
   // space dots to regular spaces
   newValue = newValue.replace(/\u2420/g, CHARACTERS.SPACE);
   // other symbols
-  newValue = isRawMode ?
-    newValue.replace(RE_SYM_FULL, replaceFullSymbol) :
-    newValue.replace(RE_SYM_BASE, replaceBaseSymbol);
+  newValue = newValue.replace(RE_SYM_FULL, replaceFullSymbol);
 
   return newValue;
 }

--- a/pootle/static/js/editor/utils/font.test.js
+++ b/pootle/static/js/editor/utils/font.test.js
@@ -175,7 +175,7 @@ describe('raw2sym (raw mode)', () => {
   describe('round-tripping', () => {
     tests.forEach((test) => {
       it(`roundtrips ${test.description}`, () => {
-        expect(sym2raw(raw2sym(test.input, { isRawMode: true }), { isRawMode: true }))
+        expect(sym2raw(raw2sym(test.input, { isRawMode: true })))
           .toEqual(test.input);
       });
     });


### PR DESCRIPTION
This PR includes a bag of multiple fixes for the editor.
* Fixes some ugly race condition in Firefox.
* The height of the textarea inputs when switching to/from raw mode is now reset properly.
* The back/forward movement using keyboard keys when [LF] symbols are involved in the RTL context is now fixed.
* When performing operations affecting the contents of the textarea, the focus is properly restored.
* Going back and forth between raw and regular modes ensures there are no symbol leftovers in the latter mode.