### PR TITLE
[Django 1.9] fix admin permissions page

### DIFF
--- a/pootle/apps/pootle_app/views/admin/permissions.py
+++ b/pootle/apps/pootle_app/views/admin/permissions.py
@@ -57,11 +57,11 @@ def admin_permissions(request, current_directory, template, ctx):
     base_queryset = User.objects.filter(is_active=1).exclude(
         id__in=current_directory.permission_sets.values_list('user_id',
                                                              flat=True),)
-    querysets = [(None, base_queryset.filter(
+    choice_groups = [(None, base_queryset.filter(
         username__in=('nobody', 'default')
     ))]
 
-    querysets.append((
+    choice_groups.append((
         _('All Users'),
         base_queryset.exclude(username__in=('nobody',
                                             'default')).order_by('username'),
@@ -81,7 +81,7 @@ def admin_permissions(request, current_directory, template, ctx):
         )
         user = GroupedModelChoiceField(
             label=_('Username'),
-            querysets=querysets,
+            choice_groups=choice_groups,
             queryset=User.objects.all(),
             required=True,
             widget=forms.Select(attrs={

--- a/pootle/apps/pootle_misc/forms.py
+++ b/pootle/apps/pootle_misc/forms.py
@@ -16,13 +16,13 @@ from pootle.i18n.gettext import ugettext_lazy as _
 class GroupedModelChoiceIterator(ModelChoiceIterator):
     def __init__(self, field):
         self.field = field
-        self.querysets = field.querysets
+        self.choice_groups = field.choice_groups
 
     def __iter__(self):
         if self.field.empty_label is not None:
             yield (u'', self.field.empty_label)
 
-        for title, queryset in self.querysets:
+        for title, queryset in self.choice_groups:
             if title is not None:
                 yield (title, [self.choice(choice) for choice in queryset])
             else:
@@ -33,12 +33,12 @@ class GroupedModelChoiceIterator(ModelChoiceIterator):
 class GroupedModelChoiceField(forms.ModelChoiceField):
     """A `ModelChoiceField` with grouping capabilities.
 
-    :param querysets: List of tuples including the `title` and `queryset` of
+    :param choice_groups: List of tuples including the `title` and `queryset` of
         each individual choice group.
     """
 
-    def __init__(self, querysets, *args, **kwargs):
-        self.querysets = querysets
+    def __init__(self, choice_groups, *args, **kwargs):
+        self.choice_groups = choice_groups
         super(GroupedModelChoiceField, self).__init__(*args, **kwargs)
 
     def _get_choices(self):


### PR DESCRIPTION
This PR fixes the permissions administration pages. Since the switch to Django 1.9 it wasn't possible to access these as generators were being used in `GroupedModelChoiceField`. Converting these to iterators solves the problem.

Fixes #5336.