### PR TITLE
Canonical url

### DIFF
--- a/pootle/apps/pootle_app/apps.py
+++ b/pootle/apps/pootle_app/apps.py
@@ -11,6 +11,8 @@ Pootle App Config
 See https://docs.djangoproject.com/en/1.9/ref/applications/
 """
 
+import importlib
+
 from django.apps import AppConfig
 from django.core import checks
 
@@ -25,3 +27,4 @@ class PootleConfig(AppConfig):
 
     def ready(self):
         checks.register(deprecation.check_deprecated_settings, "settings")
+        importlib.import_module("pootle_app.getters")

--- a/pootle/apps/pootle_app/getters.py
+++ b/pootle/apps/pootle_app/getters.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.delegate import site
+from pootle.core.plugin import getter
+
+from .site import PootleSite
+
+
+pootle_site = PootleSite()
+
+
+@getter(site)
+def get_site(**kwargs_):
+    return pootle_site

--- a/pootle/apps/pootle_app/site.py
+++ b/pootle/apps/pootle_app/site.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from urlparse import urlparse
+
+from django.conf import settings
+from django.contrib.sites.models import Site as ContribSite
+
+
+class PootleSite(object):
+
+    @property
+    def use_insecure_http(self):
+        if not self.uses_sites:
+            return urlparse(settings.POOTLE_CANONICAL_URL).scheme == "http"
+        return (
+            getattr(settings, "USE_INSECURE_HTTP", False)
+            and True or False)
+
+    @property
+    def use_http_port(self):
+        if not self.uses_sites:
+            return urlparse(settings.POOTLE_CANONICAL_URL).port or 80
+        return getattr(settings, "USE_HTTP_PORT", 80)
+
+    @property
+    def uses_sites(self):
+        return (
+            "django.contrib.sites" not in settings.INSTALLED_APPS
+            or not settings.POOTLE_CANONICAL_URL)
+
+    @property
+    def contrib_site(self):
+        if self.uses_sites:
+            return ContribSite.objects.get_current()
+
+    @property
+    def domain(self):
+        if self.uses_sites:
+            return self.contrib_site.domain
+        return urlparse(settings.POOTLE_CANONICAL_URL).hostname
+
+    @property
+    def canonical_url(self):
+        if not self.uses_sites:
+            return settings.POOTLE_CANONICAL_URL
+        protocol = (
+            "http"
+            if self.use_insecure_http
+            else "https")
+        port = (
+            ":%s" % self.use_http_port
+            if self.use_http_port != 80
+            else "")
+        return (
+            "%s://%s%s"
+            % (protocol,
+               self.domain,
+               port))
+
+    def build_absolute_uri(self, url):
+        return "%s%s" % (self.canonical_url, url)

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -28,6 +28,7 @@ data_tool = Getter()
 data_updater = Getter()
 
 language_team = Getter()
+site = Getter()
 
 serializers = Provider(providing_args=["instance"])
 deserializers = Provider(providing_args=["instance"])

--- a/pootle/settings/30-site.conf
+++ b/pootle/settings/30-site.conf
@@ -15,6 +15,8 @@ MANAGERS = ADMINS
 
 DEBUG = False
 
+POOTLE_CANONICAL_URL = "http://localhost"
+
 # A list of strings representing the host/domain names that this Pootle server
 # can serve. This is a Django's security measure. More details at
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -36,6 +36,10 @@ ALLOWED_HOSTS = [
     #'${your_server}',
 ]
 
+# Set this to a canonical url for your site *without trailing slash*
+# This will be used when deriving urls to send out emails
+# If you use the `django.contrib.sites` framework set this to blank
+POOTLE_CANONICAL_URL = "http://localhost"
 
 #
 # Backends

--- a/tests/core/site.py
+++ b/tests/core/site.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.contrib.sites.models import Site
+
+from pootle.core.delegate import site
+
+
+@pytest.mark.django_db
+def test_site(settings):
+    # default using Sites framework
+    settings.POOTLE_CANONICAL_URL = ""
+    pootle_site = site.get()
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'https://example.com/foo')
+    assert not pootle_site.use_insecure_http
+    settings.USE_INSECURE_HTTP = True
+    assert pootle_site.use_insecure_http
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'http://example.com/foo')
+    contrib_site = Site.objects.get_current()
+    contrib_site.domain = "foo.com"
+    contrib_site.save()
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'http://foo.com/foo')
+    assert pootle_site.use_http_port == 80
+    settings.USE_HTTP_PORT = 8008
+    assert pootle_site.use_http_port == 8008
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'http://foo.com:8008/foo')
+
+
+@pytest.mark.django_db
+def test_site_canonical(settings):
+    # default using POOTLE_CANONICAL_URL
+    pootle_site = site.get()
+    settings.POOTLE_CANONICAL_URL = "http://foo.com"
+    assert not pootle_site.uses_sites
+    assert not pootle_site.contrib_site
+    assert pootle_site.use_insecure_http
+    assert pootle_site.use_http_port == 80
+    assert pootle_site.domain == "foo.com"
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'http://foo.com/foo')
+
+    settings.POOTLE_CANONICAL_URL = "http://foo.com/bar"
+    pootle_site = site.get()
+    assert not pootle_site.uses_sites
+    assert not pootle_site.contrib_site
+    assert pootle_site.use_insecure_http
+    assert pootle_site.use_http_port == 80
+    assert pootle_site.domain == "foo.com"
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'http://foo.com/bar/foo')
+
+    settings.POOTLE_CANONICAL_URL = "https://foo.com/bar"
+    pootle_site = site.get()
+    assert not pootle_site.uses_sites
+    assert not pootle_site.contrib_site
+    assert not pootle_site.use_insecure_http
+    assert pootle_site.use_http_port == 80
+    assert pootle_site.domain == "foo.com"
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'https://foo.com/bar/foo')
+
+    settings.POOTLE_CANONICAL_URL = "https://foo.com:8008/bar"
+    pootle_site = site.get()
+    assert not pootle_site.uses_sites
+    assert not pootle_site.contrib_site
+    assert not pootle_site.use_insecure_http
+    assert pootle_site.use_http_port == 8008
+    assert pootle_site.domain == "foo.com"
+    assert (
+        pootle_site.build_absolute_uri("/foo")
+        == u'https://foo.com:8008/bar/foo')


### PR DESCRIPTION
Enforce setting of a CANONICAL_URL

This means that async operations -  eg notifications can authoritatively obtain the correct URL

This will look for a CANONICAL_URL, and if that is set use it - otherwise it will use the django.contrib.sites framework for obtaining the url