### PR TITLE
Allow adding new format loaders in default editor app

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -111,6 +111,8 @@ PTL.editor = {
       assign(this.settings, options);
     }
 
+    this.formats = {};
+
     /* Cached elements */
     this.backToBrowserEl = q('.js-back-to-browser');
     this.$editorActivity = $('#js-editor-act');
@@ -2469,5 +2471,9 @@ PTL.editor = {
       this.suggestionFeedbackForm = undefined;
       this.isSuggestionFeedbackFormDirty = false;
     }
+  },
+
+  addFormats(formats) {
+    this.formats = assign(this.formats, formats);
   },
 };

--- a/pootle/static/js/editor/formats/FormatLoader.js
+++ b/pootle/static/js/editor/formats/FormatLoader.js
@@ -16,9 +16,10 @@ export function loadFormatAdaptor(options, onLoad) {
   const props = assign({}, options);
   delete props.fileType;
 
-  switch (options.fileType) {
-    default: {
-      onLoad(props, FormatAdaptor);
-    }
+  const loadFormat = PTL.editor.formats[options.fileType];
+  if (loadFormat !== undefined) {
+    loadFormat(props, onLoad);
+  } else {
+    onLoad(props, FormatAdaptor);
   }
 }


### PR DESCRIPTION
There are some questions:
- ~~is it possible to move webpack dev requirements to plugin?~~ #5453 is created.
- ~~is is possible to add new format loader functions to PTL.editor.formats dictionary via webpack plugins without changing html templates?~~ overwriting of templates with using `PTL.editor.addFormats()` should work fine here.
