### PR TITLE
Remove other manage.py references

### DIFF
--- a/docs/developers/frontend.rst
+++ b/docs/developers/frontend.rst
@@ -38,7 +38,7 @@ Simply run:
 
 .. code-block:: console
 
-    (env) $ ./manage.py webpack --dev
+    (env) $ pootle webpack --dev
 
 
 This will make sure to build all the necessary scripts and create the
@@ -49,7 +49,7 @@ For creating a production-ready build, use:
 
 .. code-block:: console
 
-    (env) $ ./manage.py webpack
+    (env) $ pootle webpack
 
 
 This will also run the output through

--- a/docs/developers/hacking.rst
+++ b/docs/developers/hacking.rst
@@ -93,7 +93,7 @@ available, we can create our virtual environment.
 Replace ``<env-name>`` with a meaningful name that describes the environment
 you are creating. :ref:`mkvirtualenv <virtualenvwrapper:command-mkvirtualenv>`
 accepts any options that :command:`virtualenv` accepts. We could for example
-specify to use the Python 2.6 interpreter by passing the `-p python2.6
+specify to use the Python 3.3 interpreter by passing the `-p python3.3
 <https://virtualenv.pypa.io/en/latest/reference/#cmdoption--python>`_ option.
 
 .. note:: After running :ref:`mkvirtualenv

--- a/docs/developers/hacking.rst
+++ b/docs/developers/hacking.rst
@@ -193,7 +193,7 @@ Finally, run the development server.
 
 Once all is done, you can start the development server anytime by enabling the
 virtual environment (using the :ref:`workon <virtualenvwrapper:command-workon>`
-command) and running the :djadmin:`manage.py runserver <runserver>` command.
+command) and running the :djadmin:`pootle runserver <runserver>` command.
 
 
 Happy hacking!!

--- a/docs/developers/styleguide.rst
+++ b/docs/developers/styleguide.rst
@@ -241,7 +241,7 @@ For documenting several things, Pootle defines custom Sphinx roles.
   E.g. ``|icon:icon-google-translate|`` will insert this
   |icon:icon-google-translate| icon.
 
-- Pootle manage.py commands::
+- Pootle and Django commands::
 
     .. django-admin:: sync_stores
 

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -17,7 +17,8 @@ will run:
 .. note::
 
   If you run Pootle from a repository checkout you can use the *manage.py* file
-  found in the root of the repository.
+  found in the root of the repository.  Note that this approach is deprecated
+  and may not be supported in future.
 
 
 .. _commands#managing_pootle_projects:

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -96,8 +96,8 @@ Backend and caching settings.
 
   .. versionadded:: 2.7
 
-  The directory where Pootle writes event logs to. These are high-level
-  logs of events on store/unit changes and manage.py commands executed
+  The directory where Pootle writes event logs to. These are high-level logs of
+  events on store/unit changes and :command:`pootle` commands executed.
 
 
 30-site.conf

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -145,7 +145,7 @@ def check_redis(app_configs=None, **kwargs):
             if len(sys.argv) > 1 and sys.argv[1] in RQWORKER_WHITELIST:
                 errors.append(checks.Warning(
                     _("No RQ Worker running."),
-                    hint=_("Run new workers with manage.py rqworker"),
+                    hint=_("Run new workers with 'pootle rqworker'"),
                     id="pootle.W001",
                 ))
 

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -37,12 +37,10 @@ LXML_MINIMUM_REQUIRED_VERSION = (3, 5, 0, 0)
 REDIS_MINIMUM_REQUIRED_VERSION = (2, 8, 4)
 
 
-# XXX List of manage.py commands not to run the rqworker check on.
-# Maybe tagging can improve this?
+# List of pootle commands that need a running rqworker.
+# FIXME Maybe tagging can improve this?
 RQWORKER_WHITELIST = [
-    "start", "initdb", "revision", "sync_stores", "refresh_stats",
-    "update_stores", "calculate_checks", "retry_failed_jobs", "check",
-    "runserver",
+    "revision", "retry_failed_jobs", "check", "runserver",
 ]
 
 
@@ -140,7 +138,8 @@ def check_redis(app_configs=None, **kwargs):
             ))
 
         if len(queue.connection.smembers(Worker.redis_workers_keys)) == 0:
-            # We need to check we're not running manage.py rqworker right now..
+            # If we're not running 'pootle rqworker' report for whitelisted
+            # commands
             import sys
             if len(sys.argv) > 1 and sys.argv[1] in RQWORKER_WHITELIST:
                 errors.append(checks.Warning(

--- a/pootle/settings/91-travis.conf
+++ b/pootle/settings/91-travis.conf
@@ -44,4 +44,5 @@ if os.environ.get("TRAVIS"):
         'pootle.W005',  # DEBUG = True
         'pootle.W010',  # DEFAULT_FROM_EMAIL has default setting
         'pootle.W011',  # POOTLE_CONTACT_EMAIL has default setting
+        'pootle.W020',  # POOTLE_CANONICAL_URL has default setting
     ]


### PR DESCRIPTION
This remove almost all uses of manage.py

Except:

* tox.ini - if we use 'pootle' there then we don't seem to get the benefit of `91-travis.conf`
* Makefile - we should probably warn and exit if someone has not installed Pootle, but didn't want to block this for that.