### PR TITLE
Django 1.8: Template.render() expects  context=dict()

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import Http404, QueryDict
 from django.shortcuts import redirect
-from django.template import RequestContext, loader
+from django.template import loader
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.lru_cache import lru_cache
@@ -149,7 +149,7 @@ def _get_critical_checks_snippet(request, unit):
         'unit': unit,
     }
     template = loader.get_template('editor/units/xhr_checks.html')
-    return template.render(RequestContext(request, ctx))
+    return template.render(ctx, request)
 
 
 @ajax_required
@@ -260,9 +260,8 @@ def save_comment(request, unit):
             'cansuggest': check_user_permission(user, 'suggest', directory),
         }
         t = loader.get_template('editor/units/xhr_comment.html')
-        c = RequestContext(request, ctx)
 
-        return JsonResponse({'comment': t.render(c)})
+        return JsonResponse({'comment': t.render(ctx, request)})
 
     return JsonResponseBadRequest({'msg': _("Comment submission failed.")})
 
@@ -372,8 +371,7 @@ class UnitEditJSON(PootleUnitJSON):
         return loader.get_template('editor/units/edit.html')
 
     def render_edit_template(self, context):
-        return self.get_edit_template().render(
-            RequestContext(self.request, context))
+        return self.get_edit_template().render(context, self.request)
 
     def get_source_nplurals(self):
         if self.object.hasplural():

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -10,7 +10,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse_lazy
 from django.http import Http404
 from django.shortcuts import redirect, render
-from django.template import RequestContext
 from django.template.loader import get_template
 from django.views.generic import (CreateView, DeleteView, TemplateView,
                                   UpdateView)
@@ -200,7 +199,7 @@ def display_page(request, virtual_path):
 
 def _get_rendered_agreement(request, form):
     template = get_template('staticpages/agreement.html')
-    return template.render(RequestContext(request, {'form': form}))
+    return template.render({'form': form}, request)
 
 
 @ajax_required

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -15,7 +15,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from django.template import RequestContext, loader
+from django.template import loader
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
@@ -208,8 +208,7 @@ def _calculate_timeline(request, unit):
     entries_group.reverse()
     context['entries_group'] = entries_group
     t = loader.get_template('editor/units/xhr_timeline.html')
-    c = RequestContext(request, context)
-    return t.render(c)
+    return t.render(context, request)
 
 
 def _timeline_test(client, request_user, unit):


### PR DESCRIPTION
This address #5442 

".. provide a render() method, however, the former takes a
django.template.Context as an argument while the latter expects a dict."

That is we need to move to use a context dict and not a Context
instance.

See
https://docs.djangoproject.com/en/1.10/releases/1.8/#rendering-templates-loaded-by-get-template-with-a-context