### PR TITLE
Use changed suggestion as extra parameter in handleSubmit() method

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -556,6 +556,7 @@ def submit(request, unit, **kwargs_):
             json['checks'] = _get_critical_checks_snippet(request, unit)
 
         json['user_score'] = request.user.public_score
+        json['newtargets'] = [target for target in form.instance.target.strings]
 
         return JsonResponse(json)
 

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1622,7 +1622,7 @@ PTL.editor = {
     }
 
     const unit = this.units.getCurrent();
-    unit.setTranslation(ReactEditor.stateValues);
+    unit.setTranslation(data.newtargets);
     unit.set('isfuzzy', this.isFuzzy());
 
     const hasCriticalChecks = !!data.checks;

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1546,9 +1546,15 @@ PTL.editor = {
   },
 
   /* Pushes translation submissions and moves to the next unit */
-  handleSubmit(comment = '') {
+  handleSubmit({ translation = null, comment = '' } = {}) {
     const el = q('input.submit');
-    const newTranslation = ReactEditor.stateValues[0];
+    let valueStateData = {};
+    if (translation !== null) {
+      valueStateData[getAreaId(0)] = translation;
+    } else {
+      valueStateData = this.getValueStateData();
+    }
+    const newTranslation = valueStateData[0];
     const suggestions = $('.js-user-suggestion').map(function getSuggestions() {
       return {
         text: this.dataset.translationAid,
@@ -1587,7 +1593,7 @@ PTL.editor = {
       this.checkSimilarTranslations();
     }
 
-    const body = assign({}, this.getCheckedStateData(), this.getValueStateData(),
+    const body = assign({}, this.getCheckedStateData(), valueStateData,
                         this.getReqData(), this.getSimilarityData(),
                         captchaCallbacks);
 
@@ -2306,13 +2312,8 @@ PTL.editor = {
     suggId, { requestData = {}, isSuggestionChanged = false } = {}
   ) {
     if (isSuggestionChanged) {
-      // hack: this is a revert due to broken suggestion ui
-      // most likely the ReactEditor state shoud be set elsewhere
-      const area = $('.js-translation-area');
-      area.val(decodeEntities(requestData.translation));
-      ReactEditor.setValueFor(area[0], area.val());
       this.undoFuzzyBox();
-      this.handleSubmit(requestData.comment);
+      this.handleSubmit(requestData);
     } else {
       this.acceptSuggestion(suggId, { requestData });
     }

--- a/tests/views/unit.py
+++ b/tests/views/unit.py
@@ -92,6 +92,7 @@ def test_submit_with_suggestion_and_comment(client, request_users, settings):
 
         content = json.loads(response.content)
 
+        assert content['newtargets'] == [edited_target]
         assert content['user_score'] == response.wsgi_request.user.public_score
         assert content['checks'] is None
 


### PR DESCRIPTION
handleSubmit() is used when we submit translation from the main ReactEditor
and when we accept suggestion with changes. So we need to support two types of
providing changes unit translation to put it into ediotor view rows.

Test is required here.

Fixes #5444
