### PR TITLE
Pin babel-loader version

### DIFF
--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
-    "babel-loader": "^6.0.0",
+    "babel-loader": "<=6.2.5",
     "babel-plugin-rewire": "^1.0.0-rc-7",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-react": "^6.0.0",


### PR DESCRIPTION
webpack fails with the error on `babel-loader@6.2.6`

```
ERROR in ./common.js
Module build failed: TypeError: Path must be a string. Received null
    at assertPath (path.js:7:11)
    at Object.join (path.js:1211:7)
    at module.exports (/home/travis/build/translate/pootle/pootle/static/js/node_modules/babel-loader/lib/fs-cache.js:131:19)
```