### PR TITLE
setup: ensure full PEP440 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,20 @@ from distutils.command.build import build as DistutilsBuild
 from distutils.core import Command
 from distutils.errors import DistutilsOptionError
 
+from pkg_resources import parse_version, require
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 from pootle import __version__
+
+
+def check_pep440_versions():
+    if require('setuptools')[0].parsed_version < parse_version('8.0'):
+        exit("Incompatible version of 'setuptools'. Please run\n"
+             "'pip install --upgrade setuptools'")
+    if require('pip')[0].parsed_version < parse_version('6.0'):
+        exit("Incompatible version of 'pip'. Please run\n"
+             "'pip install --upgrade pip'")
 
 
 def parse_requirements(file_name):
@@ -221,6 +231,7 @@ class BuildChecksTemplatesCommand(Command):
         print("Checks templates written to %r" % (filename))
 
 
+check_pep440_versions()
 setup(
     name="Pootle",
     version=__version__,


### PR DESCRIPTION
pip and setuptools only fully support PEP440 following certain versions
and on some platforms they use older versions.  So we need to test that
we have the correct versions.

We are making use of the PEP440 ~= syntax because its clearer and less
cluttered, but that means that these deps should be upgraded if they are
too old.

We also need to catch these requirements before 'install_requires' and
we can't specify them in 'requirements/base.txt' because older tools
cannot parse those.