### PR TITLE
Adjust versions of npm packages

### DIFF
--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -11,6 +11,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 import subprocess
 
 from django.conf import settings
+from django.contrib.staticfiles.finders import AppDirectoriesFinder
 from django.core.management.base import BaseCommand, CommandError
 
 from pootle_misc.baseurl import l
@@ -52,6 +53,15 @@ class Command(BaseCommand):
         default_static_dir = os.path.join(settings.WORKING_DIR, 'static')
         custom_static_dirs = filter(lambda x: x != default_static_dir,
                                     settings.STATICFILES_DIRS)
+
+        finder = AppDirectoriesFinder()
+        for app_name in finder.storages:
+            location = finder.storages[app_name].location
+            add_new_custom_dir = (location != default_static_dir
+                                  and location not in custom_static_dirs)
+            if add_new_custom_dir:
+                custom_static_dirs.append(location)
+
         default_js_dir = os.path.join(default_static_dir, 'js')
 
         webpack_config_file = os.path.join(default_js_dir, 'webpack.config.js')

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -24,7 +24,7 @@
     "eslint-config-airbnb": "~6.2.0",
     "eslint-plugin-react": "^4.2.0",
     "expect": "^1.14.0",
-    "lodash": "^2.4.1",
+    "lodash": "^4.2.1",
     "lolex": "^1.5.1",
     "mocha": "^3.0.2",
     "style-loader": "^0.8.0",

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
-    "babel-loader": "<=6.2.5",
+    "babel-loader": "^6.0.0",
     "babel-plugin-rewire": "^1.0.0-rc-7",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-react": "^6.0.0",


### PR DESCRIPTION
- `babel-loader@6.2.6` was broken and we don't need to pin anything after `babel-loader@6.2.7` is released.
- bump up lodash to avoid 
```
npm ERR! missing: lodash@^4.2.1, required by redux@3.6.0
```
- re-add static app dirs to custom_static_dirs list which was reverted by mistake in 120cdc8.
