### PR TITLE
A grab bag of static pages fixes

### DIFF
--- a/pootle/core/markup/fields.py
+++ b/pootle/core/markup/fields.py
@@ -120,7 +120,7 @@ class MarkupField(models.TextField):
         return value
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
     def formfield(self, **kwargs):

--- a/pootle/core/markup/fields.py
+++ b/pootle/core/markup/fields.py
@@ -119,6 +119,9 @@ class MarkupField(models.TextField):
 
         return value
 
+    def to_python(self, value):
+        return self.get_prep_value(value)
+
     def value_to_string(self, obj):
         value = self.value_from_object(obj)
         return self.get_prep_value(value)

--- a/pootle/static/js/admin/general/components/LiveEditor.js
+++ b/pootle/static/js/admin/general/components/LiveEditor.js
@@ -96,6 +96,7 @@ export const LiveEditor = React.createClass({
   loadRemotePreview() {
     fetch({
       url: '/xhr/preview/',
+      method: 'POST',
       body: {
         text: this.state.value,
       },

--- a/pootle/templates/admin/staticpages/base_edit.html
+++ b/pootle/templates/admin/staticpages/base_edit.html
@@ -19,7 +19,7 @@
       page: 'staticpages',
       opts: {
         htmlName: '{{ form.body.html_name }}',
-        initialValue: '{{ form.initial.body.raw|escapejs }}',
+        initialValue: '{{ object.body.raw|escapejs }}',
         markup: PTL.settings.MARKUP_FILTER,
       }
     });


### PR DESCRIPTION
This PR includes a few fixes related to static pages:

* Adjusts a deprecated method call.
* Uses an `StaticPage` object directly to pass initial static page values instead of relying on form's internal attributes.
* Addresses the backwards-incompatible change by mplementing `to_python` in `MarkupField`.

Please check each commit message for further details.

Fixes #5467.