### PR TITLE
Add dependency links for non-pypi, usually github dependencies

### DIFF
--- a/requirements/_pootle_fs_git.txt
+++ b/requirements/_pootle_fs_git.txt
@@ -1,3 +1,3 @@
 # Pootle FS Git plugin
 
--e git+https://github.com/translate/pootle_fs_git@updates#egg=pootle-fs-git
+-e git+https://github.com/translate/pootle_fs_git@updates#egg=pootle-fs-git-0.0.1

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,15 @@ def parse_requirements(file_name, recurse=False):
     return requirements
 
 
+def parse_dependency_links(file_name):
+    dependency_links = []
+    for line in open(file_name, 'r').read().split('\n'):
+        if re.match(r'\s*-e\s+', line):
+            dependency_links.append(re.sub(r'\s*-e\s+', '', line))
+
+    return dependency_links
+
+
 class PyTest(TestCommand):
 
     def finalize_options(self):
@@ -255,6 +264,7 @@ setup(
         __version__,
 
     install_requires=parse_requirements('requirements/base.txt'),
+    dependency_links=parse_dependency_links('requirements/base.txt'),
     tests_require=parse_requirements('requirements/tests.txt'),
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ def parse_requirements(file_name, recurse=False):
             continue
 
         if re.match(r'\s*-e\s+', line):
-            requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1', line))
+            requirements.append(re.sub(r'\s*-e\s+.*#egg=([^\d]*)-([\.\d]*)$',
+                                       r'\1==\2', line))
         elif re.match(r'\s*-f\s+', line):
             pass
         else:

--- a/setup.py
+++ b/setup.py
@@ -248,6 +248,32 @@ class BuildChecksTemplatesCommand(Command):
 
 
 check_pep440_versions()
+
+
+dependency_links = []
+
+install_requires = parse_requirements('requirements/base.txt'),
+dependency_links += parse_dependency_links('requirements/base.txt')
+
+tests_require = parse_requirements('requirements/tests.txt'),
+dependency_links += parse_dependency_links('requirements/tests.txt')
+
+extras_require = {}
+extras_require['dev'] = parse_requirements('requirements/dev.txt', recurse=True)
+dependency_links += parse_dependency_links('requirements/dev.txt')
+# Database dependencies
+extras_require['mysql'] = parse_requirements('requirements/_db_mysql.txt')
+dependency_links += parse_dependency_links('requirements/_db_mysql.txt')
+extras_require['postgresql'] = parse_requirements('requirements/_db_postgresql.txt')
+dependency_links += parse_dependency_links('requirements/_db_postgresql.txt')
+# Pootle FS plugins
+extras_require['git'] = parse_requirements('requirements/_pootle_fs_git.txt')
+dependency_links += parse_dependency_links('requirements/_pootle_fs_git.txt')
+# Markdown
+extras_require['markdown'] = parse_requirements('requirements/_markup_markdown.txt')
+dependency_links += parse_dependency_links('requirements/_markup_markdown.txt')
+
+
 setup(
     name="Pootle",
     version=__version__,
@@ -264,20 +290,11 @@ setup(
     download_url="https://github.com/translate/pootle/releases/tag/" +
         __version__,
 
-    install_requires=parse_requirements('requirements/base.txt'),
-    dependency_links=parse_dependency_links('requirements/base.txt'),
-    tests_require=parse_requirements('requirements/tests.txt'),
+    install_requires=install_requires,
+    dependency_links=dependency_links,
+    tests_require=tests_require,
 
-    extras_require={
-        'dev': parse_requirements('requirements/dev.txt', recurse=True),
-        # Database dependencies
-        'mysql': parse_requirements('requirements/_db_mysql.txt'),
-        'postgresql': parse_requirements('requirements/_db_postgresql.txt'),
-        # Pootle FS plugins
-        'git': parse_requirements('requirements/_pootle_fs_git.txt'),
-        # Markdown
-        'markdown': parse_requirements('requirements/_markup_markdown.txt'),
-    },
+    extras_require=extras_require,
 
     platforms=["any"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,18 @@ def parse_requirements(file_name, recurse=False):
     return requirements
 
 
-def parse_dependency_links(file_name):
+def parse_dependency_links(file_name, recurse=False):
     dependency_links = []
     for line in open(file_name, 'r').read().split('\n'):
         if re.match(r'\s*-e\s+', line):
             dependency_links.append(re.sub(r'\s*-e\s+', '', line))
+
+        if re.match(r'-r .*$', line):
+            if recurse:
+                dependency_links.extend(parse_dependency_links(
+                    'requirements/' +
+                    re.sub(r'-r\s*(.*[.]txt)$', r'\1', line), recurse))
+            continue
 
     return dependency_links
 
@@ -260,7 +267,7 @@ dependency_links += parse_dependency_links('requirements/tests.txt')
 
 extras_require = {}
 extras_require['dev'] = parse_requirements('requirements/dev.txt', recurse=True)
-dependency_links += parse_dependency_links('requirements/dev.txt')
+dependency_links += parse_dependency_links('requirements/dev.txt', recurse=True)
 # Database dependencies
 extras_require['mysql'] = parse_requirements('requirements/_db_mysql.txt')
 dependency_links += parse_dependency_links('requirements/_db_mysql.txt')


### PR DESCRIPTION
This replaces https://github.com/translate/pootle/pull/5482

It works but feels like I could clean things up and the dependency_links function should also recurse.