### PR TITLE
Fix: filter data in tp data tool correctly

### DIFF
--- a/pootle/apps/pootle_data/utils.py
+++ b/pootle/apps/pootle_data/utils.py
@@ -535,6 +535,9 @@ class RelatedStoresDataTool(DataTool):
                 children[root][mapped_k] = child[child_k]
         return root
 
+    def filter_data(self, qs):
+        return qs.filter(store__translation_project=self.context)
+
     def get_lastaction(self, **kwargs):
         return kwargs.get("lastaction")
 


### PR DESCRIPTION
since switching to tp_path, the tp data tool was not filtering correctly