### PR TITLE
Cleanup: remove duplicated view definition

### DIFF
--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -161,9 +161,6 @@ GET_UNITS_TESTS = OrderedDict(
        "checks": ["endpunc"]}),
      ("checks_category_critical",
       {"filter": "checks",
-       "category": "critical"}),
-     ("checks_category_critical",
-      {"filter": "checks",
        "category": "critical"})))
 
 GET_VFOLDER_UNITS_TESTS = OrderedDict(


### PR DESCRIPTION
The `checks_category_critical` view is repeated.