### PR TITLE
pluralize_sugg only returns 3 arguments

### DIFF
--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -333,7 +333,7 @@
                 </a>
               {% endif %}
             </div>
-            {% for i, target, diff, title in sugg|pluralize_sugg %}
+            {% for i, target, title in sugg|pluralize_sugg %}
             <div class="extra-item-content">
               <div class="extra-item">
                 <div


### PR DESCRIPTION
Picked from Django 1.10 migration.  Seems only in 1.10 does this fail, but it's been wrong for quite some time.  Not sure what or how this impact plural suggestions in the UI