### PR TITLE
Req: bump django-rq pin to v0.9.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-contact-form==1.3
 django-contrib-comments==1.7.3
 django-overextends==0.4.2
 django-redis==4.6.0
-django-rq>=0.9.0,<=0.9.3
+django-rq==0.9.4
 django-sortedm2m==1.3.2
 django-statici18n==1.2.1
 


### PR DESCRIPTION
Fixes and issue with rqworker for Django <1.10.  Note though that we
don't seem to use any of that functionality.

Seemed time to drop the range based versions which we've kept around
through the Django 1.9 upgrade.  Lets move to a pure pin.