### PR TITLE
Use placeholders for times in children table panel

### DIFF
--- a/pootle/apps/pootle_app/panels.py
+++ b/pootle/apps/pootle_app/panels.py
@@ -6,8 +6,15 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import re
+
+from django.utils.safestring import mark_safe
+
 from pootle.core.browser import get_table_headings
+from pootle.core.decorators import persistent_property
 from pootle.core.views.panels import TablePanel
+
+from pootle.local.dates import timesince
 
 
 class ChildrenPanel(TablePanel):
@@ -15,6 +22,10 @@ class ChildrenPanel(TablePanel):
     table_fields = [
         'name', 'progress', 'total', 'need-translation',
         'suggestions', 'critical', 'last-updated', 'activity']
+
+    @property
+    def children(self):
+        return self.view.object_children
 
     @property
     def table(self):
@@ -25,7 +36,50 @@ class ChildrenPanel(TablePanel):
                 'headings': get_table_headings(self.table_fields),
                 'rows': self.view.object_children}
 
+    @persistent_property
+    def _content(self):
+        return self.render()
+
+    @property
+    def child_update_times(self):
+        _times = {}
+        for child in self.children:
+            last_created_unit = (
+                timesince(child["stats"]["last_created_unit"]["creation_time"])
+                if child["stats"].get("last_created_unit")
+                else None)
+            last_submission = (
+                timesince(child["stats"]["last_submission"]["mtime"])
+                if child["stats"].get("last_submission")
+                else None)
+            _times[child["code"]] = (last_submission, last_created_unit)
+        return _times
+
+    @property
+    def content(self):
+        return self.update_times(self._content)
+
     def get_context_data(self):
         return dict(
             table=self.table,
             can_translate=self.view.can_translate)
+
+    def update_times(self, content):
+        times = {}
+        update_times = self.child_update_times.items()
+        for name, (last_submission, last_created_unit) in update_times:
+            if last_submission:
+                times[
+                    "_XXX_LAST_SUBMISSION_%s_LAST_SUBMISSION_XXX_"
+                    % name] = last_submission
+            if last_created_unit:
+                times[
+                    "_XXX_LAST_CREATED_%s_LAST_CREATED_XXX_"
+                    % name] = last_created_unit
+        if times:
+            regex = re.compile("(%s)" % "|".join(map(re.escape, times.keys())))
+            return mark_safe(
+                regex.sub(
+                    lambda match: times[match.string[match.start():match.end()]],
+                    content))
+        return content

--- a/pootle/apps/virtualfolder/panels.py
+++ b/pootle/apps/virtualfolder/panels.py
@@ -16,10 +16,18 @@ class VFolderPanel(ChildrenPanel):
         'suggestions', 'critical', 'last-updated', 'activity']
 
     @property
-    def table(self):
+    def children(self):
         if not self.view.vfolders_data_view:
-            return ""
-        vfdata = self.view.vfolders_data_view.table_data
-        if not vfdata:
-            return ""
-        return vfdata["children"]
+            return {}
+        return self.view.vfolders_data_view.table_items
+
+    @property
+    def vfdata(self):
+        return self.view.vfolders_data_view
+
+    @property
+    def table(self):
+        return (
+            self.vfdata.table_data["children"]
+            if self.vfdata and self.vfdata.table_data
+            else "")

--- a/tests/pootle_language/panels.py
+++ b/tests/pootle_language/panels.py
@@ -47,7 +47,8 @@ def test_panel_language_table(language0, rf, member):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))

--- a/tests/pootle_project/panels.py
+++ b/tests/pootle_project/panels.py
@@ -47,10 +47,11 @@ def test_panel_project_table(project0, rf, member):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))
 
 
 @pytest.mark.django_db
@@ -82,10 +83,11 @@ def test_panel_projects_table(rf, member, project0):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))
 
 
 @pytest.mark.django_db
@@ -118,7 +120,8 @@ def test_panel_project_store_table(project0, store0, rf, member):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))

--- a/tests/pootle_translationproject/panels.py
+++ b/tests/pootle_translationproject/panels.py
@@ -48,10 +48,11 @@ def test_panel_tp_table(tp0, rf, member):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))
 
 
 @pytest.mark.pootle_vfolders
@@ -81,10 +82,11 @@ def test_panel_tp_vfolder_table(tp0, rf, member):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))
 
 
 @pytest.mark.django_db
@@ -118,13 +120,13 @@ def test_panel_tp_subdir_table(subdir0, rf, member):
     assert panel.table == table
     assert panel.get_context_data() == dict(
         table=table, can_translate=view.can_translate)
+    content = loader.render_to_string(
+        panel.template_name, context=panel.get_context_data())
     assert (
         panel.content
-        == loader.render_to_string(
-            panel.template_name, context=panel.get_context_data()))
+        == panel.update_times(content))
 
 
-@pytest.mark.pootle_vfolders
 @pytest.mark.django_db
 def test_panel_tp_no_vfolders_table(tp0, rf, member, no_vfolders):
     request = rf.get('/language0/project0/')


### PR DESCRIPTION
updates templates to use a placeholder that can be cached, and is then interpolated