### PR TITLE
Cleanup: render_to_string & render

### DIFF
--- a/pootle/apps/contact/views.py
+++ b/pootle/apps/contact/views.py
@@ -87,14 +87,14 @@ class ReportFormView(ContactFormView):
                     initial.update({
                         'subject': render_to_string(
                             'contact_form/report_form_subject.txt',
-                            {
+                            context={
                                 'unit': unit,
                                 'language':
                                     unit.store.translation_project.language.code,
                             }),
                         'body': render_to_string(
                             'contact_form/report_form_body.txt',
-                            {
+                            context={
                                 'unit': unit,
                                 'unit_absolute_url': unit_absolute_url,
                             }),

--- a/pootle/apps/pootle_store/utils.py
+++ b/pootle/apps/pootle_store/utils.py
@@ -197,8 +197,8 @@ class SuggestionsReview(object):
                     suggestion.unit.get_translate_url()))
         return loader.render_to_string(
             template,
-            dict(suggestions=suggestions,
-                 comment=comment))
+            context=dict(suggestions=suggestions,
+                         comment=comment))
 
     def notify_suggesters(self, rejected=True, comment=""):
         for suggester, suggestions in self.users_and_suggestions.items():

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -147,7 +147,7 @@ def _get_critical_checks_snippet(request, unit):
         'unit': unit,
     }
     template = loader.get_template('editor/units/xhr_checks.html')
-    return template.render(ctx, request)
+    return template.render(context=ctx, request=request)
 
 
 @ajax_required
@@ -259,7 +259,8 @@ def save_comment(request, unit):
         }
         t = loader.get_template('editor/units/xhr_comment.html')
 
-        return JsonResponse({'comment': t.render(ctx, request)})
+        return JsonResponse({'comment': t.render(context=ctx,
+                                                 request=request)})
 
     return JsonResponseBadRequest({'msg': _("Comment submission failed.")})
 
@@ -340,7 +341,7 @@ class UnitTimelineJSON(PootleUnitJSON):
             'timeline': self.render_timeline(context)}
 
     def render_timeline(self, context):
-        return loader.get_template(self.template_name).render(context)
+        return loader.get_template(self.template_name).render(context=context)
 
     def get_entries_group_data(self, context):
         result = []
@@ -367,7 +368,8 @@ class UnitEditJSON(PootleUnitJSON):
         return loader.get_template('editor/units/edit.html')
 
     def render_edit_template(self, context):
-        return self.get_edit_template().render(context, self.request)
+        return self.get_edit_template().render(context=context,
+                                               request=self.request)
 
     def get_source_nplurals(self):
         if self.object.hasplural():

--- a/pootle/apps/pootle_translationproject/receivers.py
+++ b/pootle/apps/pootle_translationproject/receivers.py
@@ -34,7 +34,7 @@ def tp_inited_async_handler(**kwargs):
     ctx = {"tp": instance,
            "url": urljoin(response_url, instance.get_absolute_url())}
     message = render_to_string(
-        'projects/admin/email/translation_project_created.txt', ctx)
+        'projects/admin/email/translation_project_created.txt', context=ctx)
     subject = _(u"Translation project (%s) created" % instance)
     recipients = get_recipients(instance.project)
     send_mail(subject, message, from_email=None,
@@ -47,7 +47,8 @@ def tp_init_failed_async_handler(**kwargs):
 
     ctx = {"tp": instance}
     message = render_to_string(
-        'projects/admin/email/translation_project_creation_failed.txt', ctx)
+        'projects/admin/email/translation_project_creation_failed.txt',
+        context=ctx)
     subject = _(u"Translation project (%s) creation failed" % instance)
     recipients = get_recipients(instance.project)
     send_mail(subject, message, from_email=None,

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -199,7 +199,7 @@ def display_page(request, virtual_path):
 
 def _get_rendered_agreement(request, form):
     template = get_template('staticpages/agreement.html')
-    return template.render({'form': form}, request)
+    return template.render(context={'form': form}, request=request)
 
 
 @ajax_required

--- a/pootle/core/views/formtable.py
+++ b/pootle/core/views/formtable.py
@@ -77,7 +77,7 @@ class Formtable(object):
         return (
             render_to_string(
                 self.filters_template,
-                dict(formtable=self))
+                context=dict(formtable=self))
             if self.filters_template
             else "")
 

--- a/pootle/core/views/panels.py
+++ b/pootle/core/views/panels.py
@@ -25,7 +25,7 @@ class Panel(object):
         if not self.template_name:
             return ""
         return loader.render_to_string(
-            self.template_name, self.get_context_data())
+            self.template_name, context=self.get_context_data())
 
     @property
     def cache_key(self):

--- a/pootle/middleware/errorpages.py
+++ b/pootle/middleware/errorpages.py
@@ -14,7 +14,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.mail import mail_admins
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseForbidden, HttpResponseServerError
-from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.encoding import force_unicode
 
@@ -83,8 +82,7 @@ def handle_exception(request, exception, template_name):
             ctx['fserror'] = msg
 
         return HttpResponseServerError(
-            render_to_string(template_name, ctx,
-                             RequestContext(request))
+            render_to_string(template_name, context=ctx, request=request)
         )
     except:
         # Let's not confuse things by throwing an exception here
@@ -122,8 +120,8 @@ class ErrorPagesMiddleware(object):
                 ctx["login_message"] = login_msg
 
             return HttpResponseForbidden(
-                render_to_string('errors/403.html', ctx,
-                                 RequestContext(request)))
+                render_to_string('errors/403.html', context=ctx,
+                                 request=request))
         elif (exception.__class__.__name__ in
                 ('OperationalError', 'ProgrammingError', 'DatabaseError')):
             # HACKISH: Since exceptions thrown by different databases do not

--- a/tests/core/formtable.py
+++ b/tests/core/formtable.py
@@ -47,7 +47,7 @@ def test_formtable():
 def _render_template(string, context=None):
     context = context or {}
     context = Context(context)
-    return Template(string).render(context)
+    return Template(string).render(context=context)
 
 
 @pytest.mark.django

--- a/tests/pootle_language/panels.py
+++ b/tests/pootle_language/panels.py
@@ -51,4 +51,4 @@ def test_panel_language_table(language0, rf, member):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))

--- a/tests/pootle_project/panels.py
+++ b/tests/pootle_project/panels.py
@@ -51,7 +51,7 @@ def test_panel_project_table(project0, rf, member):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))
 
 
 @pytest.mark.django_db
@@ -87,7 +87,7 @@ def test_panel_projects_table(rf, member, project0):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))
 
 
 @pytest.mark.django_db
@@ -124,4 +124,4 @@ def test_panel_project_store_table(project0, store0, rf, member):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))

--- a/tests/pootle_translationproject/panels.py
+++ b/tests/pootle_translationproject/panels.py
@@ -52,7 +52,7 @@ def test_panel_tp_table(tp0, rf, member):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))
 
 
 @pytest.mark.pootle_vfolders
@@ -85,7 +85,7 @@ def test_panel_tp_vfolder_table(tp0, rf, member):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))
 
 
 @pytest.mark.django_db
@@ -123,7 +123,7 @@ def test_panel_tp_subdir_table(subdir0, rf, member):
     assert (
         panel.content
         == loader.render_to_string(
-            panel.template_name, panel.get_context_data()))
+            panel.template_name, context=panel.get_context_data()))
 
 
 @pytest.mark.pootle_vfolders

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -208,7 +208,7 @@ def _calculate_timeline(request, unit):
     entries_group.reverse()
     context['entries_group'] = entries_group
     t = loader.get_template('editor/units/xhr_timeline.html')
-    return t.render(context, request)
+    return t.render(context=context, request=request)
 
 
 def _timeline_test(client, request_user, unit):


### PR DESCRIPTION
This deals with deprecated Django 1.8 items that disappear in Django 1.10. So sort of a forward port from the Django 1.10 migration.