### PR TITLE
Remove caching of editor snippet template 

### DIFF
--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -1,7 +1,6 @@
-{% load core i18n common_tags store_tags cleanhtml cache locale %}
+{% load core i18n common_tags store_tags cleanhtml locale %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.get_terminology %}
 <td colspan="2" rowspan="1" class="translate-full translate-focus{% if unit.isfuzzy %} fuzzy-unit{% endif %}" dir="{% locale_dir %}">
   <div class="translate-lightbox js-translate-lightbox"></div>
   <div class="translate-container{% if unit.get_active_critical_qualitychecks.exists %} error{% endif %}">
@@ -351,4 +350,3 @@
     </div>
   </div>
 </td>
-{% endcache %}


### PR DESCRIPTION
So this PR removes editor snippet caching which fixes #5558.