### PR TITLE
Fix select_related for non-relational fields

### DIFF
--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -309,7 +309,7 @@ class ProjectsMixin(object):
     def get_object(self):
         user_projects = (
             Project.objects.for_user(self.request.user)
-                           .select_related("directory__pootle_path"))
+                           .select_related("directory"))
         return ProjectSet(user_projects)
 
     @property


### PR DESCRIPTION
Issue identified in Django 1.10 porting

This looks like the last one that can be backported from the Django 1.10 migration.