### PR TITLE
Fix: dont get stats for children that have none

### DIFF
--- a/pootle/apps/pootle_app/panels.py
+++ b/pootle/apps/pootle_app/panels.py
@@ -44,6 +44,8 @@ class ChildrenPanel(TablePanel):
     def child_update_times(self):
         _times = {}
         for child in self.children:
+            if not child.get("stats"):
+                continue
             last_created_unit = (
                 timesince(child["stats"]["last_created_unit"]["creation_time"])
                 if child["stats"].get("last_created_unit")


### PR DESCRIPTION
if a child - ie project/directory/language has no stores it will
genuinely have no stats.

This PR prevents failure in that case