### PR TITLE
Invalidate superusers language cache

### DIFF
--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -230,3 +230,6 @@ def invalidate_language_list_cache(**kwargs):
 
     key = make_method_key('LiveLanguageManager', 'cached_dict', '*')
     cache.delete_pattern(key)
+
+    key = make_method_key('LiveLanguageManager', 'all_cached_dict', '*')
+    cache.delete_pattern(key)


### PR DESCRIPTION
Otherwise when adding or deleting a language or TP the languages
in the dropdown are not updated until cache expires naturally.