### PR TITLE
Cleanup: pytest warnings

### DIFF
--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -41,6 +41,12 @@ def pytest_addoption(parser):
         help="Debug tests to a given file")
 
 
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line(
+        "markers", "pootle_vfolders: requires special virtual folder projects")
+
+
 @pytest.fixture(autouse=True)
 def test_timing(request, settings, log_timings):
     from django.db import reset_queries

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files=*.py
-addopts=--tb=short tests
+addopts=--tb=short --strict tests
 norecursedirs=.git _build tmp* requirements commands/*
 markers=
     cmd: Django admin commands.

--- a/tests/core/decorators.py
+++ b/tests/core/decorators.py
@@ -120,7 +120,6 @@ def test_get_path_obj_disabled(rf, default, admin,
              project_code=project_code_obsolete)
 
 
-@pytest.mark.django
 def test_deco_persistent_property_no_cache_key():
 
     # no cache key set - uses instance caching
@@ -154,7 +153,6 @@ def test_deco_persistent_property_no_cache_key():
     assert foo.__dict__ == dict(special_bar="Baz")
 
 
-@pytest.mark.django
 def test_deco_persistent_property():
 
     # cache_key set - cached with it

--- a/tests/core/formtable.py
+++ b/tests/core/formtable.py
@@ -6,8 +6,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import pytest
-
 from django.template import Context, Template
 
 from pootle.core.views.formtable import Formtable
@@ -15,7 +13,6 @@ from pootle.core.views.formtable import Formtable
 from .forms import DummyFormtableForm
 
 
-@pytest.mark.django
 def test_formtable():
 
     form = DummyFormtableForm()
@@ -50,7 +47,6 @@ def _render_template(string, context=None):
     return Template(string).render(context=context)
 
 
-@pytest.mark.django
 def test_formtable_inclusion_tag():
 
     form = DummyFormtableForm()

--- a/tests/local/dates.py
+++ b/tests/local/dates.py
@@ -9,14 +9,11 @@
 import time
 from datetime import datetime
 
-import pytest
-
 from babel.dates import format_timedelta
 
 from pootle.local.dates import localdate, timesince
 
 
-@pytest.mark.django
 def test_local_date_timesince(settings):
     timestamp = time.time() - 1000000
     assert (

--- a/tests/models/virtualfolder.py
+++ b/tests/models/virtualfolder.py
@@ -197,7 +197,7 @@ def test_vfolder_calc_priority(settings, store0):
     settings.INSTALLED_APPS.append("virtualfolder")
 
 
-@pytest.mark.pootle_vfolder
+@pytest.mark.pootle_vfolders
 @pytest.mark.django_db
 def test_vfolder_membership_new_store(tp0):
     vf0 = VirtualFolder.objects.create(

--- a/tests/pootle_misc/templatetags.py
+++ b/tests/pootle_misc/templatetags.py
@@ -6,8 +6,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import pytest
-
 from django.template import Context, Template
 
 
@@ -17,7 +15,6 @@ def _render_str(string, context=None):
     return Template(string).render(context)
 
 
-@pytest.mark.django
 def test_templatetag_progress_bar():
     rendered = _render_str("{% load common_tags %}{% progress_bar 0 0 0 %}")
     assert "<span class=\'value translated\'>0</span>" in rendered

--- a/tests/pootle_revision/revision_updater.py
+++ b/tests/pootle_revision/revision_updater.py
@@ -53,7 +53,6 @@ def test_revision_unit_updater(store0):
                     updater.all_pootle_paths))))
 
 
-@pytest.mark.django
 def test_revision_unit_updater_parent_paths():
     updater_class = revision_updater.get(Unit)
     updater = updater_class([])


### PR DESCRIPTION
* Adds `--strict` to turing pytest warnings into errors
* Register the pootle_vfolders pytest marker
* Drops and corrects other markers
