### PR TITLE
Make more dates timezone aware

### DIFF
--- a/pootle/apps/pootle_comment/forms.py
+++ b/pootle/apps/pootle_comment/forms.py
@@ -14,6 +14,8 @@ from django.utils.functional import cached_property
 
 from django_comments.forms import CommentForm as DjCommentForm
 
+from pootle.core.utils.timezone import make_aware
+
 from .delegate import comment_should_not_be_saved
 from .exceptions import CommentNotSaved
 from .signals import comment_was_saved
@@ -55,7 +57,7 @@ class CommentForm(DjCommentForm):
     def save(self):
         comment = self.comment
         comment.user = self.cleaned_data["user"]
-        comment.submit_date = datetime.now()
+        comment.submit_date = make_aware(datetime.now())
         comment.save()
         comment_was_saved.send(
             sender=comment.__class__,

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -901,7 +901,7 @@ class Unit(models.Model, base.TranslationUnit):
         else:
             sub_type = SubmissionTypes.UNMUTE_CHECK
 
-        sub = Submission(creation_time=timezone.now(),
+        sub = Submission(creation_time=make_aware(timezone.now()),
                          translation_project=self.store.translation_project,
                          submitter=user, field=SubmissionFields.NONE,
                          unit=self, store=self.store, type=sub_type,

--- a/tests/models/scorelog.py
+++ b/tests/models/scorelog.py
@@ -8,8 +8,6 @@
 
 import pytest
 
-from datetime import datetime
-
 from pytest_pootle.factories import ScoreLogFactory, SubmissionFactory
 
 from pootle_statistics.models import (ScoreLog, SubmissionTypes, SubmissionFields,
@@ -38,7 +36,6 @@ def test_record_submission(member, submission_type):
         'mt_similarity': 0,
         'submitter': member,
         'translation_project': store.translation_project,
-        'creation_time': datetime.now(),
     }
 
     sub = SubmissionFactory(**submission_params)


### PR DESCRIPTION
This fixes areas of Submission and Comment that where not timezone aware.

I used `pytest-warning` to expose these RuntimeError warnings to be fixed, but that is not part of this PR.

This fixes #5441 