### PR TITLE
Software cache keys

### DIFF
--- a/pootle/apps/pootle_data/apps.py
+++ b/pootle/apps/pootle_data/apps.py
@@ -15,6 +15,7 @@ class PootleDataConfig(AppConfig):
 
     name = "pootle_data"
     verbose_name = "Pootle Data"
+    version = "0.0.1"
 
     def ready(self):
         importlib.import_module("pootle_data.models")

--- a/pootle/apps/pootle_data/utils.py
+++ b/pootle/apps/pootle_data/utils.py
@@ -17,6 +17,7 @@ from pootle_statistics.models import Submission
 from pootle_statistics.proxy import SubmissionProxy
 from pootle_store.models import Unit
 
+from .apps import PootleDataConfig
 from .models import StoreChecksData, StoreData, TPChecksData, TPData
 
 
@@ -265,6 +266,7 @@ class DataUpdater(object):
 
 
 class RelatedStoresDataTool(DataTool):
+    ns = "pootle.data"
     group_by = (
         "store__pootle_path", )
     max_fields = (
@@ -318,10 +320,15 @@ class RelatedStoresDataTool(DataTool):
             self.context.__class__)(self.context).get(key="stats")
 
     @property
+    def sw_version(self):
+        return PootleDataConfig.version
+
+    @property
     def cache_key(self):
         return (
-            'pootle_data.%s.%s.%s'
-            % (self.cache_key_name,
+            '%s.%s.%s.%s'
+            % (self.sw_version,
+               self.cache_key_name,
                self.context_name,
                self.rev_cache_key))
 

--- a/pootle/apps/pootle_language/apps.py
+++ b/pootle/apps/pootle_language/apps.py
@@ -15,6 +15,7 @@ class PootleLanguageConfig(AppConfig):
 
     name = "pootle_language"
     verbose_name = "Pootle Language"
+    version = "0.0.1"
 
     def ready(self):
         importlib.import_module("pootle_language.getters")

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -25,6 +25,7 @@ from pootle.core.views.mixins import PootleJSONMixin
 from pootle.i18n.gettext import tr_lang, ugettext_lazy as _
 from pootle_store.constants import STATES_MAP
 
+from .apps import PootleLanguageConfig
 from .forms import (
     LanguageSpecialCharsForm, LanguageSuggestionAdminForm, LanguageTeamAdminForm,
     LanguageTeamNewMemberSearchForm)
@@ -32,6 +33,8 @@ from .models import Language
 
 
 class LanguageMixin(object):
+    ns = "pootle.language"
+    sw_version = PootleLanguageConfig.version
     model = Language
     browse_url_path = "pootle-language-browse"
     translate_url_path = "pootle-language-translate"

--- a/pootle/apps/pootle_project/apps.py
+++ b/pootle/apps/pootle_project/apps.py
@@ -15,6 +15,7 @@ class PootleProjectConfig(AppConfig):
 
     name = "pootle_project"
     verbose_name = "Pootle Project"
+    version = "0.0.1"
 
     def ready(self):
         importlib.import_module("pootle_project.getters")

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -34,11 +34,14 @@ from pootle_project.forms import TranslationProjectForm
 from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
 
+from .apps import PootleProjectConfig
 from .forms import TranslationProjectFormSet
 from .models import Project, ProjectResource, ProjectSet
 
 
 class ProjectMixin(object):
+    ns = "pootle.project"
+    sw_version = PootleProjectConfig.version
     model = Project
     browse_url_path = "pootle-project-browse"
     translate_url_path = "pootle-project-translate"

--- a/pootle/apps/pootle_translationproject/apps.py
+++ b/pootle/apps/pootle_translationproject/apps.py
@@ -19,6 +19,7 @@ from django.apps import AppConfig
 class PootleTPConfig(AppConfig):
     name = "pootle_translationproject"
     verbose_name = "PootleTranslationProject"
+    version = "0.0.1"
 
     def ready(self):
         importlib.import_module("pootle_translationproject.receivers")

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -28,6 +28,7 @@ from pootle_app.views.admin.permissions import admin_permissions as admin_perms
 from pootle_language.models import Language
 from pootle_store.models import Store
 
+from .apps import PootleTPConfig
 from .models import TranslationProject
 
 
@@ -119,6 +120,9 @@ class TPMixin(object):
 
     The context object may be a resource with the TP, ie a Directory or Store.
     """
+
+    ns = "pootle.tp"
+    sw_version = PootleTPConfig.version
 
     @redirect_to_tp_on_404
     def dispatch(self, request, *args, **kwargs):

--- a/pootle/apps/virtualfolder/utils.py
+++ b/pootle/apps/virtualfolder/utils.py
@@ -192,6 +192,7 @@ class VirtualFolderPathMatcher(object):
 
 class DirectoryVFDataTool(RelatedStoresDataTool):
     group_by = ("store__vfolders__name", )
+    ns = "virtualfolder"
     cache_key_name = "vfolder"
 
     @property

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -174,17 +174,20 @@ class persistent_property(object):
     `always_cache` to False in the decorator.
     """
 
-    def __init__(self, func, name=None, key_attr=None, always_cache=True):
+    def __init__(self, func, name=None, key_attr=None, always_cache=True,
+                 ns_attr=None):
         self.func = func
         self.__doc__ = getattr(func, '__doc__')
         self.name = name or func.__name__
+        self.ns_attr = ns_attr or "ns"
         self.key_attr = key_attr or "cache_key"
         self.always_cache = always_cache
 
     def _get_cache_key(self, instance):
+        ns = getattr(instance, self.ns_attr, "pootle.core")
         cache_key = getattr(instance, self.key_attr, None)
         if cache_key:
-            return "%s/%s" % (cache_key, self.name)
+            return "%s.%s.%s" % (ns, cache_key, self.name)
 
     def __get__(self, instance, cls=None):
         if instance is None:

--- a/pootle/core/views/base.py
+++ b/pootle/core/views/base.py
@@ -26,6 +26,8 @@ class PootleDetailView(GatherContextMixin, DetailView):
     browse_url_path = ""
     resource_path = ""
     view_name = ""
+    sw_version = 0
+    ns = "pootle.core"
 
     @property
     def browse_url(self):
@@ -36,8 +38,9 @@ class PootleDetailView(GatherContextMixin, DetailView):
     @property
     def cache_key(self):
         return (
-            "%s.%s.%s.%s"
-            % (self.page_name,
+            "%s.%s.%s.%s.%s"
+            % (self.sw_version,
+               self.page_name,
                self.view_name,
                self.object.data_tool.cache_key,
                self.request_lang))

--- a/pootle/core/views/browse.py
+++ b/pootle/core/views/browse.py
@@ -63,8 +63,9 @@ class PootleBrowseView(PootleDetailView):
     @property
     def cache_key(self):
         return (
-            "%s.%s.%s.%s.%s"
-            % (self.page_name,
+            "%s.%s.%s.%s.%s.%s"
+            % (self.sw_version,
+               self.page_name,
                self.view_name,
                self.object.data_tool.cache_key,
                self.show_all,

--- a/tests/core/decorators.py
+++ b/tests/core/decorators.py
@@ -167,7 +167,7 @@ def test_deco_persistent_property():
     assert Foo.bar.__doc__ == "Get a bar man"
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('foo-cache/bar') == "Baz"
+    assert get_cache().get('pootle.core.foo-cache.bar') == "Baz"
     # cached version this time
     assert foo.bar == "Baz"
 
@@ -180,7 +180,7 @@ def test_deco_persistent_property():
         bar = persistent_property(_bar, key_attr="special_key")
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('special-foo-cache/_bar') == "Baz"
+    assert get_cache().get('pootle.core.special-foo-cache._bar') == "Baz"
 
     # cache_key set with custom key attr and name - cached with it
     class Foo(object):
@@ -192,4 +192,20 @@ def test_deco_persistent_property():
             _bar, name="bar", key_attr="special_key")
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('special-foo-cache/bar') == "Baz"
+    assert get_cache().get('pootle.core.special-foo-cache.bar') == "Baz"
+
+    # cache_key set with custom namespace
+    class Foo(object):
+        ns = "pootle.foo"
+        cache_key = "foo-cache"
+
+        @persistent_property
+        def bar(self):
+            """Get a bar man"""
+            return "Baz"
+
+    foo = Foo()
+    assert foo.bar == "Baz"
+    assert get_cache().get('pootle.foo.foo-cache.bar') == "Baz"
+    # cached version this time
+    assert foo.bar == "Baz"

--- a/tests/pootle_data/data_tool.py
+++ b/tests/pootle_data/data_tool.py
@@ -12,6 +12,7 @@ from django.db.models import Sum
 
 from pootle.core.delegate import data_tool, revision
 from pootle_app.models import Directory
+from pootle_data.apps import PootleDataConfig
 from pootle_data.models import StoreChecksData, StoreData, TPChecksData
 from pootle_data.store_data import StoreDataTool
 from pootle_data.utils import DataTool
@@ -221,48 +222,60 @@ def test_data_project_stats(project0):
 @pytest.mark.django_db
 def test_data_cache_keys(language0, project0, subdir0, vfolder0):
     # language
+    assert language0.data_tool.ns == "pootle.data"
     assert (
-        'pootle_data.%s.%s.%s'
-        % (language0.data_tool.cache_key_name,
+        '%s.%s.%s.%s'
+        % (PootleDataConfig.version,
+           language0.data_tool.cache_key_name,
            language0.code,
            revision.get(Language)(language0).get(key="stats"))
         == language0.data_tool.cache_key)
     # project
+    assert project0.data_tool.ns == "pootle.data"
     assert (
-        'pootle_data.%s.%s.%s'
-        % (project0.data_tool.cache_key_name,
+        '%s.%s.%s.%s'
+        % (PootleDataConfig.version,
+           project0.data_tool.cache_key_name,
            project0.code,
            revision.get(Project)(project0).get(key="stats"))
         == project0.data_tool.cache_key)
     # directory
+    assert subdir0.data_tool.ns == "pootle.data"
     assert (
-        'pootle_data.%s.%s.%s'
-        % (subdir0.data_tool.cache_key_name,
+        '%s.%s.%s.%s'
+        % (PootleDataConfig.version,
+           subdir0.data_tool.cache_key_name,
            subdir0.pootle_path,
            revision.get(Directory)(subdir0).get(key="stats"))
         == subdir0.data_tool.cache_key)
     # projectresource
     resource_path = "%s%s" % (project0.pootle_path, subdir0.path)
     projectresource = ProjectResource(Directory.objects.none(), resource_path)
+    assert projectresource.data_tool.ns == "pootle.data"
     assert (
-        'pootle_data.%s.%s.%s'
-        % (projectresource.data_tool.cache_key_name,
+        '%s.%s.%s.%s'
+        % (PootleDataConfig.version,
+           projectresource.data_tool.cache_key_name,
            resource_path,
            revision.get(ProjectResource)(projectresource).get(key="stats"))
         == projectresource.data_tool.cache_key)
     # projectset
     projectset = ProjectSet(Project.objects.all())
+    assert projectset.data_tool.ns == "pootle.data"
     assert (
-        'pootle_data.%s.%s.%s'
-        % (projectset.data_tool.cache_key_name,
+        '%s.%s.%s.%s'
+        % (PootleDataConfig.version,
+           projectset.data_tool.cache_key_name,
            "ALL",
            revision.get(ProjectSet)(projectset).get(key="stats"))
         == projectset.data_tool.cache_key)
     # vfolders
     vfdata = vfolders_data_tool.get(Directory)(subdir0)
+    assert vfdata.ns == "virtualfolder"
     assert (
-        'pootle_data.%s.%s.%s'
-        % (vfdata.cache_key_name,
+        '%s.%s.%s.%s'
+        % (PootleDataConfig.version,
+           vfdata.cache_key_name,
            subdir0.pootle_path,
            revision.get(subdir0.__class__)(subdir0).get(key="stats"))
         == vfdata.cache_key)


### PR DESCRIPTION
add software cache_keys and namespacing

this allows certain modules to expire related caches when software changes without the need to flush the (entire) cache manually