### PR TITLE
Add pytest-warnings

### DIFF
--- a/pootle/apps/accounts/management/commands/verify_user.py
+++ b/pootle/apps/accounts/management/commands/verify_user.py
@@ -42,7 +42,7 @@ class Command(UserCommand):
                     utils.verify_user(user)
                     self.stdout.write("Verified user '%s'" % user.username)
                 except (ValueError, ValidationError) as e:
-                    self.stderr.write(e.message)
+                    self.stderr.write(e[0])
 
         if options['user']:
             for user in options['user']:
@@ -50,4 +50,4 @@ class Command(UserCommand):
                     utils.verify_user(self.get_user(user))
                     self.stdout.write("User '%s' has been verified" % user)
                 except (ValueError, ValidationError) as e:
-                    self.stderr.write(e.message)
+                    self.stderr.write(e[0])

--- a/pootle/apps/pootle_app/management/commands/list_serializers.py
+++ b/pootle/apps/pootle_app/management/commands/list_serializers.py
@@ -65,4 +65,4 @@ class Command(BaseCommand):
         self.stdout.write("-" * len(heading))
         for name, serializer in serials.items():
             self.stdout.write(
-                "{: <30} {: <50} ".format(name, serializer))
+                "{!s: <30} {!s: <50} ".format(name, serializer))

--- a/pootle/apps/pootle_fs/forms.py
+++ b/pootle/apps/pootle_fs/forms.py
@@ -99,7 +99,7 @@ class ProjectFSAdminForm(forms.Form):
                 self.fs_path_validator(
                     self.cleaned_data["translation_mapping"]).validate()
             except ValueError as e:
-                self.add_error("translation_mapping", e.message)
+                self.add_error("translation_mapping", e)
         if not self.fs_url_validator or not self.cleaned_data.get("fs_url"):
             return
         try:
@@ -111,7 +111,7 @@ class ProjectFSAdminForm(forms.Form):
                     "Incorrect URL or path ('%s') for plugin type '%s': %s"
                     % (self.cleaned_data.get("fs_url"),
                        self.cleaned_data.get("fs_type"),
-                       e.message)))
+                       e)))
 
     def save(self):
         self.project.config["pootle_fs.fs_type"] = self.cleaned_data["fs_type"]

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -985,7 +985,7 @@ class ENChecker(checks.UnitChecker):
                 'callback': lambda x: '',
             })
         except SyntaxError as e:
-            raise checks.FilterFailure(e.message)
+            raise checks.FilterFailure(e)
 
         return True
 

--- a/pootle/core/initdb.py
+++ b/pootle/core/initdb.py
@@ -73,7 +73,7 @@ class InitDB(object):
         permission_set, created = self._create_object(PermissionSet,
                                                       **criteria)
         if created:
-            permission_set.positive_permissions = permissions
+            permission_set.positive_permissions.set(permissions)
             permission_set.save()
         return permission_set
 

--- a/pootle/core/management/subcommands.py
+++ b/pootle/core/management/subcommands.py
@@ -158,7 +158,7 @@ class CommandWithSubcommands(BaseCommand):
         except SubcommandsError as e:
             # we have to raise SystemExit here if necessary
             parser.print_usage(sys.stderr)
-            return parser.exit(2, "%s\n" % e.message)
+            return parser.exit(2, "%s\n" % e)
         cmd_options = vars(options)
         args = cmd_options.pop('args', ())
         handle_default_options(options)

--- a/pytest_pootle/fixtures/models/permission_set.py
+++ b/pytest_pootle/fixtures/models/permission_set.py
@@ -18,9 +18,9 @@ def _require_permission_set(user, directory, positive_permissions=None,
     }
     permission_set = PermissionSet.objects.get_or_create(**criteria)[0]
     if positive_permissions is not None:
-        permission_set.positive_permissions = positive_permissions
+        permission_set.positive_permissions.set(positive_permissions)
     if negative_permissions is not None:
-        permission_set.negative_permissions = negative_permissions
+        permission_set.negative_permissions.set(negative_permissions)
 
     permission_set.save()
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,3 +5,4 @@ pytest==3.0.4
 pytest-catchlog==1.2.2
 pytest-cov==2.4.0
 pytest-django==3.1.2
+pytest-warnings==0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,36 @@ addopts=--tb=short --strict tests
 norecursedirs=.git _build tmp* requirements commands/*
 markers=
     cmd: Django admin commands.
+# https://docs.python.org/2/library/warnings.html#the-warnings-filter
+filterwarnings =
+    # Error by default
+    error
+    ## Deprecation related issues:
+    ## * Not clean:
+    ##   - default - in our own code till they are fixed (we can see what we
+    ##     need to fix, but builds don't break)
+    ##   - ignore - in other's code (no noise please, clean ours first)
+    ## * Clean:
+    ##   - error - in our own code (don't regress)
+    ##   - default - in other's code if they are not fixed.  Be specific about
+    ##     what module so we don't allow other brokenness in (able to watch
+    ##     others fixing their code, don't hide it)
+    ##   - error - if we have no occurances in our's or other's code (keep it
+    ##     clean - should essentially not be listed and falls to default error
+    ##     behaviour)
+    #
+    # Sadly can't use RemovedInDjango20Warning directly
+    # Not Clean
+    default:.*settings.MIDDLEWARE_CLASSES is deprecated.*
+    default:.*use_for_related_fields.*
+    # Clean
+    default:.*assignment_tag.*::.*socialaccount
+    ## Other
+    # allauth - these two are deprecated, unused in our code but trigger a
+    # false positive.  Likely because of Django template loader simply also
+    # loading the deprecated module.
+    ignore:.*account_tags.*
+    ignore:.*socialaccount_tags.*
 
 [pydocstyle]
 inherit=false

--- a/tests/commands/list_serializers.py
+++ b/tests/commands/list_serializers.py
@@ -69,7 +69,7 @@ def _test_serializer_list(out, err, model=None):
         expected.append("\n%s" % heading)
         expected.append("-" * len(heading))
         for name, klass in serials.items():
-            expected.append("{: <30} {: <50} ".format(name, klass))
+            expected.append("{!s: <30} {!s: <50} ".format(name, klass))
     assert out == "%s\n" % ("\n".join(expected))
 
 
@@ -88,7 +88,7 @@ def _test_deserializer_list(out, err, model=None):
         expected.append("\n%s" % heading)
         expected.append("-" * len(heading))
         for name, klass in deserials.items():
-            expected.append("{: <30} {: <50} ".format(name, klass))
+            expected.append("{!s: <30} {!s: <50} ".format(name, klass))
     assert out == "%s\n" % ("\n".join(expected))
 
 

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -458,7 +458,7 @@ def test_user_has_manager_permissions(no_perms_user, administrate, tp0):
         'directory': tp0.directory,
     }
     ps = PermissionSet.objects.get_or_create(**criteria)[0]
-    ps.positive_permissions = [administrate]
+    ps.positive_permissions.set([administrate])
     ps.save()
     assert no_perms_user.has_manager_permissions()
     ps.positive_permissions.clear()
@@ -467,7 +467,7 @@ def test_user_has_manager_permissions(no_perms_user, administrate, tp0):
     # Assign 'administrate' right for 'Language0' and check user is manager.
     criteria['directory'] = language0.directory
     ps = PermissionSet.objects.get_or_create(**criteria)[0]
-    ps.positive_permissions = [administrate]
+    ps.positive_permissions.set([administrate])
     ps.save()
     assert no_perms_user.has_manager_permissions()
     ps.positive_permissions.clear()
@@ -476,7 +476,7 @@ def test_user_has_manager_permissions(no_perms_user, administrate, tp0):
     # Assign 'administrate' right for 'Project0' and check user is manager.
     criteria['directory'] = project0.directory
     ps = PermissionSet.objects.get_or_create(**criteria)[0]
-    ps.positive_permissions = [administrate]
+    ps.positive_permissions.set([administrate])
     ps.save()
     assert no_perms_user.has_manager_permissions()
     ps.positive_permissions.clear()
@@ -502,7 +502,7 @@ def test_get_users_with_permission(default, member, translate):
     # remove "Can submit translation" permission for default user
     ps = PermissionSet.objects.filter(user=default,
                                       directory=Directory.objects.root)[0]
-    ps.positive_permissions = ps.positive_permissions.exclude(id=translate.id)
+    ps.positive_permissions.set(ps.positive_permissions.exclude(id=translate.id))
     ps.save()
     users = User.objects.get_users_with_permission('translate', project, language)
     for user in users:

--- a/tests/views/admin.py
+++ b/tests/views/admin.py
@@ -162,7 +162,7 @@ def test_admin_view_project_manager(client, member, administrate):
         'user': member,
         'directory': project.directory}
     ps = PermissionSet.objects.create(**criteria)
-    ps.positive_permissions = [administrate]
+    ps.positive_permissions.set([administrate])
     client.login(
         username=member.username,
         password=TEST_USERS[member.username]["password"])


### PR DESCRIPTION
This adds a pytest plugin to manage warnings.

There are a number of warning related fixes in this PR

Also a configuration which defaults to 'error' for warning.  Known deprecation warnings are suppressed for now.  There is also a guideline of how and when to suppress.