### PR TITLE
Fix: dont parse sub info in user profile if none

### DIFF
--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -449,6 +449,6 @@ class User(AbstractBaseUser):
         """Returns the latest submission linked with this user. If there's
         no activity, `None` is returned instead.
         """
-        return ActionDisplay(
-            Submission.objects.filter(
-                submitter=self).last().get_submission_info())
+        last_event = Submission.objects.filter(submitter=self).last()
+        if last_event:
+            return ActionDisplay(last_event.get_submission_info())

--- a/tests/accounts/models.py
+++ b/tests/accounts/models.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pytest_pootle.factories import UserFactory
+
+from pootle.core.views.display import ActionDisplay
+from pootle_statistics.models import Submission
+
+
+@pytest.mark.django_db
+def test_model_user_last_event(member):
+    last_submission = Submission.objects.filter(submitter=member).last()
+    last_event = member.last_event()
+    assert isinstance(last_event, ActionDisplay)
+    assert last_event.action == last_submission.get_submission_info()
+    user = UserFactory()
+    assert not user.last_event()


### PR DESCRIPTION
found this while testing