### PR TITLE
Fix: aggregate headline stats correctly for admins

### DIFF
--- a/pootle/apps/pootle_data/directory_data.py
+++ b/pootle/apps/pootle_data/directory_data.py
@@ -31,9 +31,11 @@ class DirectoryDataTool(RelatedStoresDataTool):
             return self.all_stat_data.aggregate(rev=Max("max_unit_revision"))["rev"]
 
     def filter_data(self, qs):
-        return qs.filter(
-            store__translation_project=self.context.translation_project,
-            store__parent__tp_path__startswith=self.context.tp_path)
+        return (
+            qs.filter(
+                store__translation_project=self.context.translation_project,
+                store__parent__tp_path__startswith=self.context.tp_path)
+              .exclude(store__parent=self.context))
 
     def get_children_stats(self, qs):
         children = {}
@@ -50,12 +52,6 @@ class DirectoryDataTool(RelatedStoresDataTool):
         self.add_submission_info(self.stat_data, children)
         self.add_last_created_info(child_stores, children)
         return children
-
-    @property
-    def child_stats_qs(self):
-        return super(
-            DirectoryDataTool,
-            self).child_stats_qs.exclude(store__parent=self.context)
 
     def get_root_child_path(self, child):
         return (

--- a/tests/pootle_data/data_tool.py
+++ b/tests/pootle_data/data_tool.py
@@ -296,10 +296,12 @@ def test_data_language_stats(language0, request_users):
 
 @pytest.mark.django_db
 def test_data_directory_stats(subdir0):
+    filtered_units = Unit.objects.live().filter(
+        store__pootle_path__startswith=subdir0.pootle_path)
+    filtered_units = filtered_units.exclude(store__parent=subdir0)
     _test_object_stats(
         subdir0.data_tool.get_stats(include_children=False),
-        Unit.objects.live().filter(
-            store__pootle_path__startswith=subdir0.pootle_path))
+        filtered_units)
     # get the child stores
     _test_children_stats(
         subdir0.data_tool.get_stats(),
@@ -362,11 +364,12 @@ def test_data_tool_project_get_checks(project0):
 
 @pytest.mark.django_db
 def test_data_tool_directory_get_checks(subdir0):
+    expected = StoreChecksData.objects.filter(
+        store__pootle_path__startswith=subdir0.pootle_path)
+    expected = expected.exclude(store__parent=subdir0)
     assert (
         subdir0.data_tool.get_checks()
-        == _calculate_check_data(
-            StoreChecksData.objects.filter(
-                store__pootle_path__startswith=subdir0.pootle_path)))
+        == _calculate_check_data(expected))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
this resolves a bug where admins where seeing double for headline stats in tp directories