### PR TITLE
Cleanup: Remove pootle_fs.plugin.fetch command

### DIFF
--- a/pootle/apps/pootle_fs/display.py
+++ b/pootle/apps/pootle_fs/display.py
@@ -15,7 +15,7 @@ BOTH_EXISTS_ACTIONS = [
     "merged_from_fs", "merged_from_pootle",
     "pulled_to_pootle", "pushed_to_fs",
     "staged_for_merge_fs", "staged_for_merge_pootle"]
-FS_EXISTS_ACTIONS = BOTH_EXISTS_ACTIONS + ["fetched_from_fs"]
+FS_EXISTS_ACTIONS = BOTH_EXISTS_ACTIONS + ["added_from_fs"]
 STORE_EXISTS_ACTIONS = BOTH_EXISTS_ACTIONS + ["added_from_pootle"]
 BOTH_EXISTS_STATES = [
     "fs_ahead", "pootle_ahead",
@@ -68,7 +68,7 @@ class ResponseItemDisplay(FSItemDisplay):
     @property
     def fs_added(self):
         return (
-            self.action_type == "fetched_from_fs"
+            self.action_type == "added_from_fs"
             and self.state_type not in ["conflict", "conflict_untracked"])
 
     @property

--- a/pootle/apps/pootle_fs/management/commands/init_fs_project.py
+++ b/pootle/apps/pootle_fs/management/commands/init_fs_project.py
@@ -114,5 +114,5 @@ class Command(BaseCommand):
 
         if options['sync']:
             plugin = FSPlugin(project)
-            plugin.fetch()
+            plugin.add()
             plugin.sync()

--- a/pootle/apps/pootle_fs/plugin.py
+++ b/pootle/apps/pootle_fs/plugin.py
@@ -226,36 +226,6 @@ class Plugin(object):
         return response
 
     @responds_to_state
-    def fetch(self, state, response,
-              fs_path=None, pootle_path=None, force=False):
-        """
-        Stage translations from FS into Pootle
-
-        If ``force``=``True`` is present it will also:
-        - stage untracked conflicting files from FS
-        - stage tracked conflicting files to update from FS
-
-        :param force: Fetch conflicting translations.
-        :param fs_path: FS path glob to filter translations
-        :param pootle_path: Pootle path glob to filter translations
-        :returns response: Where ``response`` is an instance of self.respose_class
-        """
-        to_create = state["fs_untracked"]
-        to_update = []
-        if force:
-            to_create += state["conflict_untracked"]
-            to_update += (
-                state["pootle_removed"]
-                + state["conflict"])
-        self.update_store_fs(
-            to_update,
-            resolve_conflict=SOURCE_WINS)
-        self.create_store_fs(to_create, resolve_conflict=SOURCE_WINS)
-        for fs_state in to_create + to_update:
-            response.add("fetched_from_fs", fs_state=fs_state)
-        return response
-
-    @responds_to_state
     def resolve(self, state, response, fs_path=None, pootle_path=None,
                 merge=True, pootle_wins=False):
         """

--- a/pootle/apps/pootle_fs/response.py
+++ b/pootle/apps/pootle_fs/response.py
@@ -26,8 +26,8 @@ FS_RESPONSE["added_from_pootle"] = {
     "title": "Added from Pootle",
     "description":
         "Files staged from Pootle that were new or newer than their files"}
-FS_RESPONSE["fetched_from_fs"] = {
-    "title": "Fetched from filesystem",
+FS_RESPONSE["added_from_fs"] = {
+    "title": "Added from filesystem",
     "description":
         ("Files staged from the filesystem that were new or newer than their "
          "Pootle Stores")}

--- a/pytest_pootle/fixtures/pootle_fs/commands.py
+++ b/pytest_pootle/fixtures/pootle_fs/commands.py
@@ -14,7 +14,6 @@ from django.utils.lru_cache import lru_cache
 
 DUMMY_RESPONSE_MAP = dict(
     add="added_from_pootle",
-    fetch="fetched_from_fs",
     resolve="staged_for_merge_fs",
     rm="remove",
     sync="merged_from_pootle")
@@ -45,7 +44,7 @@ def _get_dummy_api_plugin():
 
         response_types = [
             "remove", "remove_args",
-            "fetched_from_fs", "fetched_from_fs_args",
+            "added_from_fs", "added_from_fs_args",
             "added_from_pootle", "added_from_pootle_args", "staged_for_merge_fs",
             "staged_for_merge_pootle", "staged_for_merge_pootle_args",
             "merged_from_pootle", "merged_from_pootle_args"]

--- a/tests/pootle_fs/display.py
+++ b/tests/pootle_fs/display.py
@@ -96,9 +96,9 @@ def test_fs_response_display_item_instance(localfs_pootle_untracked):
 def test_fs_response_display_item_fs_untracked(localfs_fs_untracked):
     plugin = localfs_fs_untracked
     response = plugin.add()
-    response_item = response["fetched_from_fs"][0]
+    response_item = response["added_from_fs"][0]
     item_display = ResponseItemDisplay(None, response_item)
-    assert item_display.action_type == "fetched_from_fs"
+    assert item_display.action_type == "added_from_fs"
     assert item_display.state_item == response_item.fs_state
     assert item_display.file_exists is True
     assert item_display.store_exists is False
@@ -140,7 +140,7 @@ def test_fs_response_display_item_existence(fs_responses, fs_states):
             and (fs_states
                  in ["pootle_untracked", "fs_removed"])))
     fs_added = (
-        fs_responses == "fetched_from_fs"
+        fs_responses == "added_from_fs"
         and fs_states not in ["conflict", "conflict_untracked"])
     pootle_added = (
         fs_responses == "added_from_pootle"

--- a/tests/pootle_fs/display.py
+++ b/tests/pootle_fs/display.py
@@ -95,7 +95,7 @@ def test_fs_response_display_item_instance(localfs_pootle_untracked):
 @pytest.mark.django_db
 def test_fs_response_display_item_fs_untracked(localfs_fs_untracked):
     plugin = localfs_fs_untracked
-    response = plugin.fetch()
+    response = plugin.add()
     response_item = response["fetched_from_fs"][0]
     item_display = ResponseItemDisplay(None, response_item)
     assert item_display.action_type == "fetched_from_fs"

--- a/tests/pootle_fs/fs_response.py
+++ b/tests/pootle_fs/fs_response.py
@@ -146,7 +146,7 @@ def test_fs_response_path_items(settings, tmpdir):
              "/language0/%s/fs_untracked_%s.po" % (project.code, i)))
     _test_fs_response(
         fs_untracked=fs_untracked,
-        action_type="fetched_from_fs",
+        action_type="added_from_fs",
         state_type="fs_untracked")
 
 

--- a/tests/pootle_fs/signals.py
+++ b/tests/pootle_fs/signals.py
@@ -17,7 +17,7 @@ from pootle_fs.signals import (
 @pytest.mark.django_db
 def test_fs_pull_signal(project_fs):
 
-    project_fs.fetch(force=True)
+    project_fs.add(force=True)
     state = project_fs.state()
 
     class Success(object):


### PR DESCRIPTION
The functionality provided by this method is not provided by resolve
and add.

We may want to bring this command back as something like git fetch,
ie to pull the upstream repo, but best remove the old method first.