### PR TITLE
Add cache_keys to pootle_fs.resources

### DIFF
--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -15,6 +15,7 @@ from translate.filters import checks
 from translate.lang.data import langcode_re
 
 from django.conf import settings
+from django.contrib.contenttypes.fields import GenericRelation
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
@@ -39,6 +40,7 @@ from pootle_app.models.permissions import PermissionSet
 from pootle_config.utils import ObjectConfig
 from pootle_format.models import Format
 from pootle_format.utils import ProjectFiletypes
+from pootle_revision.models import Revision
 from pootle_store.models import Store
 from pootle_store.util import absolute_real_path
 from staticpages.models import StaticPage
@@ -246,6 +248,7 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
                                          editable=False, null=True)
 
     disabled = models.BooleanField(verbose_name=_('Disabled'), default=False)
+    revisions = GenericRelation(Revision)
 
     objects = ProjectManager()
 

--- a/pootle/apps/pootle_revision/utils.py
+++ b/pootle/apps/pootle_revision/utils.py
@@ -65,10 +65,7 @@ class LanguageRevision(RevisionContext):
 
 
 class ProjectRevision(RevisionContext):
-
-    @property
-    def revision_context(self):
-        return self.context.directory.revisions
+    pass
 
 
 class ProjectResourceRevision(RevisionContext):

--- a/pytest_pootle/fixtures/pootle_fs/plugin.py
+++ b/pytest_pootle/fixtures/pootle_fs/plugin.py
@@ -117,7 +117,7 @@ def localfs_staged_envs(request):
 
 
 @pytest.fixture
-def localfs_env(project_fs, no_complex_po_):
+def localfs_env(project_fs, no_complex_po_, revision):
     return project_fs
 
 

--- a/tests/pootle_fs/commands/fs.py
+++ b/tests/pootle_fs/commands/fs.py
@@ -83,6 +83,9 @@ def test_fs_cmd_bad_project(project_fs, capsys, english):
 
 
 @pytest.mark.django_db
+@pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="path mangling broken on windows")
 def test_fs_cmd_unstage_response(capsys, localfs_envs):
     state_type, plugin = localfs_envs
     action = "unstage"

--- a/tests/pootle_fs/commands/init_fs_project.py
+++ b/tests/pootle_fs/commands/init_fs_project.py
@@ -30,7 +30,7 @@ def test_init_fs_project_cmd_bad_lang(capsys):
 @pytest.mark.cmd
 @pytest.mark.xfail(sys.platform == 'win32',
                    reason="broken on windows")
-def test_init_fs_project_cmd_nosync(settings, test_fs, tmpdir):
+def test_init_fs_project_cmd_nosync(settings, test_fs, tmpdir, revision):
     settings.POOTLE_FS_WORKING_PATH = str(tmpdir)
     fs_path = test_fs.path("data/fs/example_fs/non_gnu_style_minimal/")
     tr_path = "<language_code>/<filename>.<ext>"
@@ -69,7 +69,7 @@ def test_init_fs_project_cmd_nosync(settings, test_fs, tmpdir):
 @pytest.mark.cmd
 @pytest.mark.xfail(sys.platform == 'win32',
                    reason="broken on windows")
-def test_init_fs_project_cmd(capsys, settings, test_fs, tmpdir):
+def test_init_fs_project_cmd(capsys, settings, test_fs, tmpdir, revision):
     settings.POOTLE_FS_WORKING_PATH = str(tmpdir)
     fs_path = test_fs.path("data/fs/example_fs/non_gnu_style_minimal/")
     tr_path = "<language_code>/<filename>.<ext>"

--- a/tests/pootle_fs/display.py
+++ b/tests/pootle_fs/display.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import sys
+
 import pytest
 
 
@@ -93,6 +95,9 @@ def test_fs_response_display_item_instance(localfs_pootle_untracked):
 
 
 @pytest.mark.django_db
+@pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="path mangling broken on windows")
 def test_fs_response_display_item_fs_untracked(localfs_fs_untracked):
     plugin = localfs_fs_untracked
     response = plugin.add()
@@ -207,6 +212,9 @@ def test_fs_display_state_item_instance_file(localfs_pootle_untracked):
 
 
 @pytest.mark.django_db
+@pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="path mangling broken on windows")
 def test_fs_display_state_item_instance_fs_untracked(localfs_fs_untracked):
     plugin = localfs_fs_untracked
     state_item = plugin.state()["fs_untracked"][0]

--- a/tests/pootle_fs/plugin.py
+++ b/tests/pootle_fs/plugin.py
@@ -7,6 +7,7 @@
 # AUTHORS file for copyright and authorship information.
 
 import os
+import sys
 
 import pytest
 
@@ -97,6 +98,9 @@ def _test_dummy_response(action, responses, **kwargs):
 
 
 @pytest.mark.django_db
+@pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="path mangling broken on windows")
 def test_fs_plugin_unstage_response(capsys, no_complex_po_, localfs_envs):
     state_type, plugin = localfs_envs
     action = "unstage"
@@ -150,6 +154,9 @@ def test_fs_plugin_paths(project_fs_empty, possible_actions):
 
 
 @pytest.mark.django_db
+@pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="path mangling broken on windows")
 def test_fs_plugin_response(localfs_envs, possible_actions, fs_response_map):
     state_type, plugin = localfs_envs
     action_name, action, command_args, plugin_kwargs = possible_actions
@@ -316,6 +323,9 @@ def test_fs_plugin_matcher(localfs):
 
 
 @pytest.mark.django_db
+@pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="path mangling broken on windows")
 def test_fs_plugin_localfs_push(localfs_pootle_staged_real):
     plugin = localfs_pootle_staged_real
     response = plugin.sync()

--- a/tests/pootle_fs/resources.py
+++ b/tests/pootle_fs/resources.py
@@ -14,6 +14,7 @@ import pytest
 
 from django.utils.functional import cached_property
 
+from pootle_fs.apps import PootleFSConfig
 from pootle_fs.models import StoreFS
 from pootle_fs.resources import (
     FSProjectResources, FSProjectStateResources)
@@ -388,3 +389,17 @@ def test_fs_state_found_file_matches(fs_path_qs, dummyfs):
     assert (
         resources.found_file_paths
         == [x[1] for x in resources.found_file_matches])
+
+
+@pytest.mark.django_db
+def test_fs_resources_cache_key(project_fs):
+    plugin = project_fs
+    resources = plugin.state().resources
+    assert resources.ns == "pootle.fs.resources"
+    assert resources.sw_version == PootleFSConfig.version
+    assert (
+        resources.cache_key
+        == ("%s.%s.%s"
+            % (resources.project_revision,
+               resources.sync_revision,
+               plugin.latest_hash)))


### PR DESCRIPTION
Adds a `pootle.fs.sync` revision hash to fs projects, which is expired when tracking info is changed.

This is used in combination with the filesystem hash for cache_keys in fs.resources