### PR TITLE
Sw versions 2

### DIFF
--- a/pootle/apps/pootle_data/utils.py
+++ b/pootle/apps/pootle_data/utils.py
@@ -326,9 +326,8 @@ class RelatedStoresDataTool(DataTool):
     @property
     def cache_key(self):
         return (
-            '%s.%s.%s.%s'
-            % (self.sw_version,
-               self.cache_key_name,
+            '%s.%s.%s'
+            % (self.cache_key_name,
                self.context_name,
                self.rev_cache_key))
 

--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -175,19 +175,23 @@ class persistent_property(object):
     """
 
     def __init__(self, func, name=None, key_attr=None, always_cache=True,
-                 ns_attr=None):
+                 ns_attr=None, version_attr=None):
         self.func = func
         self.__doc__ = getattr(func, '__doc__')
         self.name = name or func.__name__
         self.ns_attr = ns_attr or "ns"
         self.key_attr = key_attr or "cache_key"
+        self.version_attr = version_attr or "sw_version"
         self.always_cache = always_cache
 
     def _get_cache_key(self, instance):
         ns = getattr(instance, self.ns_attr, "pootle.core")
+        sw_version = getattr(instance, self.version_attr, "")
         cache_key = getattr(instance, self.key_attr, None)
         if cache_key:
-            return "%s.%s.%s" % (ns, cache_key, self.name)
+            return (
+                "%s.%s.%s.%s"
+                % (ns, sw_version, cache_key, self.name))
 
     def __get__(self, instance, cls=None):
         if instance is None:

--- a/pootle/core/views/base.py
+++ b/pootle/core/views/base.py
@@ -38,9 +38,8 @@ class PootleDetailView(GatherContextMixin, DetailView):
     @property
     def cache_key(self):
         return (
-            "%s.%s.%s.%s.%s"
-            % (self.sw_version,
-               self.page_name,
+            "%s.%s.%s.%s"
+            % (self.page_name,
                self.view_name,
                self.object.data_tool.cache_key,
                self.request_lang))

--- a/pootle/core/views/browse.py
+++ b/pootle/core/views/browse.py
@@ -63,9 +63,8 @@ class PootleBrowseView(PootleDetailView):
     @property
     def cache_key(self):
         return (
-            "%s.%s.%s.%s.%s.%s"
-            % (self.sw_version,
-               self.page_name,
+            "%s.%s.%s.%s.%s"
+            % (self.page_name,
                self.view_name,
                self.object.data_tool.cache_key,
                self.show_all,

--- a/tests/core/decorators.py
+++ b/tests/core/decorators.py
@@ -167,7 +167,7 @@ def test_deco_persistent_property():
     assert Foo.bar.__doc__ == "Get a bar man"
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.core.foo-cache.bar') == "Baz"
+    assert get_cache().get('pootle.core..foo-cache.bar') == "Baz"
     # cached version this time
     assert foo.bar == "Baz"
 
@@ -180,7 +180,7 @@ def test_deco_persistent_property():
         bar = persistent_property(_bar, key_attr="special_key")
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.core.special-foo-cache._bar') == "Baz"
+    assert get_cache().get('pootle.core..special-foo-cache._bar') == "Baz"
 
     # cache_key set with custom key attr and name - cached with it
     class Foo(object):
@@ -192,7 +192,7 @@ def test_deco_persistent_property():
             _bar, name="bar", key_attr="special_key")
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.core.special-foo-cache.bar') == "Baz"
+    assert get_cache().get('pootle.core..special-foo-cache.bar') == "Baz"
 
     # cache_key set with custom namespace
     class Foo(object):
@@ -206,6 +206,23 @@ def test_deco_persistent_property():
 
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.foo.foo-cache.bar') == "Baz"
+    assert get_cache().get('pootle.foo..foo-cache.bar') == "Baz"
+    # cached version this time
+    assert foo.bar == "Baz"
+
+    # cache_key set with custom namespace and sw_version
+    class Foo(object):
+        ns = "pootle.foo"
+        cache_key = "foo-cache"
+        sw_version = "0.2.3"
+
+        @persistent_property
+        def bar(self):
+            """Get a bar man"""
+            return "Baz"
+
+    foo = Foo()
+    assert foo.bar == "Baz"
+    assert get_cache().get('pootle.foo.0.2.3.foo-cache.bar') == "Baz"
     # cached version this time
     assert foo.bar == "Baz"

--- a/tests/pootle_data/data_tool.py
+++ b/tests/pootle_data/data_tool.py
@@ -223,28 +223,28 @@ def test_data_project_stats(project0):
 def test_data_cache_keys(language0, project0, subdir0, vfolder0):
     # language
     assert language0.data_tool.ns == "pootle.data"
+    assert language0.data_tool.sw_version == PootleDataConfig.version
     assert (
-        '%s.%s.%s.%s'
-        % (PootleDataConfig.version,
-           language0.data_tool.cache_key_name,
+        '%s.%s.%s'
+        % (language0.data_tool.cache_key_name,
            language0.code,
            revision.get(Language)(language0).get(key="stats"))
         == language0.data_tool.cache_key)
     # project
     assert project0.data_tool.ns == "pootle.data"
+    assert project0.data_tool.sw_version == PootleDataConfig.version
     assert (
-        '%s.%s.%s.%s'
-        % (PootleDataConfig.version,
-           project0.data_tool.cache_key_name,
+        '%s.%s.%s'
+        % (project0.data_tool.cache_key_name,
            project0.code,
            revision.get(Project)(project0).get(key="stats"))
         == project0.data_tool.cache_key)
     # directory
     assert subdir0.data_tool.ns == "pootle.data"
+    assert subdir0.data_tool.sw_version == PootleDataConfig.version
     assert (
-        '%s.%s.%s.%s'
-        % (PootleDataConfig.version,
-           subdir0.data_tool.cache_key_name,
+        '%s.%s.%s'
+        % (subdir0.data_tool.cache_key_name,
            subdir0.pootle_path,
            revision.get(Directory)(subdir0).get(key="stats"))
         == subdir0.data_tool.cache_key)
@@ -252,30 +252,30 @@ def test_data_cache_keys(language0, project0, subdir0, vfolder0):
     resource_path = "%s%s" % (project0.pootle_path, subdir0.path)
     projectresource = ProjectResource(Directory.objects.none(), resource_path)
     assert projectresource.data_tool.ns == "pootle.data"
+    assert projectresource.data_tool.sw_version == PootleDataConfig.version
     assert (
-        '%s.%s.%s.%s'
-        % (PootleDataConfig.version,
-           projectresource.data_tool.cache_key_name,
+        '%s.%s.%s'
+        % (projectresource.data_tool.cache_key_name,
            resource_path,
            revision.get(ProjectResource)(projectresource).get(key="stats"))
         == projectresource.data_tool.cache_key)
     # projectset
     projectset = ProjectSet(Project.objects.all())
     assert projectset.data_tool.ns == "pootle.data"
+    assert projectset.data_tool.sw_version == PootleDataConfig.version
     assert (
-        '%s.%s.%s.%s'
-        % (PootleDataConfig.version,
-           projectset.data_tool.cache_key_name,
+        '%s.%s.%s'
+        % (projectset.data_tool.cache_key_name,
            "ALL",
            revision.get(ProjectSet)(projectset).get(key="stats"))
         == projectset.data_tool.cache_key)
     # vfolders
     vfdata = vfolders_data_tool.get(Directory)(subdir0)
     assert vfdata.ns == "virtualfolder"
+    assert vfdata.sw_version == PootleDataConfig.version
     assert (
-        '%s.%s.%s.%s'
-        % (PootleDataConfig.version,
-           vfdata.cache_key_name,
+        '%s.%s.%s'
+        % (vfdata.cache_key_name,
            subdir0.pootle_path,
            revision.get(subdir0.__class__)(subdir0).get(key="stats"))
         == vfdata.cache_key)


### PR DESCRIPTION
This PR moves the `sw_version` part of cache_key from indiv classes into the `persistent_property` decorator