### PR TITLE
Add l20n validation check name

### DIFF
--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -118,6 +118,9 @@ check_names = {
     'percent_brace_placeholders': _(u"Percent brace placeholders"),
     'plurr_format': _(u'Plurr format'),
     'plurr_placeholders': _(u'Plurr placeholders'),
+
+    # FIXME: make checks customisable
+    'ftl_format': _(u'ftl format'),
 }
 
 excluded_filters = ['hassuggestion', 'spellcheck', 'isfuzzy',


### PR DESCRIPTION
L20nChecker requires l20n_validation check but check titles are contained in Pootle module.
Let's add required check title before we make checks customisable.