### PR TITLE
Do not store announcement mtimes in cookie

### DIFF
--- a/pootle/static/js/common.js
+++ b/pootle/static/js/common.js
@@ -239,7 +239,7 @@ PTL.common = {
     $(document).on('click', '.js-sidebar-toggle', () => {
       const $sidebar = $('.js-sidebar');
       const openClass = 'sidebar-open';
-      const cookieName = 'pootle-browser-sidebar';
+      const cookieName = 'pootle-browser-open-sidebar';
       const cookieData = JSON.parse(cookie(cookieName)) || {};
 
       $sidebar.toggleClass(openClass);

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -34,10 +34,11 @@ from pootle_misc.forms import make_search_form
 def _test_browse_view(language, request, response, kwargs):
     assert (
         response.cookies["pootle-language"].value == language.code)
-    cookie_data = json.loads(
-        unquote(response.cookies[SIDEBAR_COOKIE_NAME].value))
-    assert cookie_data["foo"] == "bar"
-    assert "announcements_%s" % language.code in cookie_data
+    if SIDEBAR_COOKIE_NAME in response.cookies:
+        cookie_data = json.loads(
+            unquote(response.cookies[SIDEBAR_COOKIE_NAME].value))
+        assert cookie_data["foo"] == "bar"
+    assert "announcements/%s" % language.code in request.session
     ctx = response.context
     user_tps = language.get_children_for_user(request.user)
     stats = language.data_tool.get_stats(user=request.user)

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -93,10 +93,11 @@ def _test_translate_view(project, request, response, kwargs, settings):
 
 
 def _test_browse_view(project, request, response, kwargs):
-    cookie_data = json.loads(
-        unquote(response.cookies[SIDEBAR_COOKIE_NAME].value))
-    assert cookie_data["foo"] == "bar"
-    assert "announcements_projects_%s" % project.code in cookie_data
+    if SIDEBAR_COOKIE_NAME in response.cookies:
+        cookie_data = json.loads(
+            unquote(response.cookies[SIDEBAR_COOKIE_NAME].value))
+        assert cookie_data["foo"] == "bar"
+    assert "announcements/projects/%s" % project.code in request.session
     ctx = response.context
     kwargs["project_code"] = project.code
     resource_path = (

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -35,16 +35,16 @@ from virtualfolder.delegate import vfolders_data_view
 
 
 def _test_browse_view(tp, request, response, kwargs):
-
-    cookie_data = json.loads(
-        unquote(response.cookies[SIDEBAR_COOKIE_NAME].value))
-    assert cookie_data["foo"] == "bar"
-    assert "announcements_projects_%s" % tp.project.code in cookie_data
-    assert "announcements_%s" % tp.language.code in cookie_data
+    if SIDEBAR_COOKIE_NAME in response.cookies:
+        cookie_data = json.loads(
+            unquote(response.cookies[SIDEBAR_COOKIE_NAME].value))
+        assert cookie_data["foo"] == "bar"
+    assert "announcements/projects/%s" % tp.project.code in request.session
+    assert "announcements/%s" % tp.language.code in request.session
     assert (
-        "announcements_%s_%s"
+        "announcements/%s/%s"
         % (tp.language.code, tp.project.code)
-        in cookie_data)
+        in request.session)
     ctx = response.context
     kwargs["project_code"] = tp.project.code
     kwargs["language_code"] = tp.language.code


### PR DESCRIPTION
Use the user session instead.

Fixes #5637.

Replaces #5671 which misteriously closed itself last night.