### PR TITLE
Recover suggestion created time 

### DIFF
--- a/pootle/apps/pootle_misc/templatetags/locale.py
+++ b/pootle/apps/pootle_misc/templatetags/locale.py
@@ -6,11 +6,14 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import calendar
+
 from django import template
 from django.utils.formats import get_format
 from django.utils.translation import trans_real
 
 from pootle.core.utils import dateformat
+from pootle.local.dates import timesince
 
 
 register = template.Library()
@@ -38,6 +41,11 @@ def do_dateformat(value, use_format='c'):
         pass
 
     return dateformat.format(value, use_format)
+
+
+@register.filter(name='relative_datetime_format')
+def do_relative_datetime_format(value):
+    return timesince(calendar.timegm(value.timetuple()))
 
 
 @register.simple_tag

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -207,9 +207,9 @@
             </div>
             {% if unit.submitted_by and unit.submitted_on %}
             <div class="unit-meta">
-              <time class="js-relative-date"
+              <time
                 title="{{ unit.submitted_on|dateformat }}"
-                datetime="{{ unit.submitted_on.isoformat }}">&nbsp;</time>
+                datetime="{{ unit.submitted_on.isoformat }}">{{ unit.submitted_on|relative_datetime_format }}</time>
               {% with reviewer=unit.reviewed_by %}
               {% if reviewer %}
               <br>

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -304,9 +304,9 @@
             <div class="suggestion-feedback js-mnt-suggestion-feedback-{{ sugg.id }}"></div>
             {% block suggestion_comment %}{% endblock %}
             {% if sugg.creation_time %}
-            <time class="extra-item-meta js-relative-date"
+            <time class="extra-item-meta"
               title="{{ sugg.creation_time|dateformat }}"
-              datetime="{{ sugg.creation_time.isoformat }}">&nbsp;</time>
+              datetime="{{ sugg.creation_time.isoformat }}">{{ sugg.creation_time|relative_datetime_format }}</time>
             {% else %}
             <time class="extra-item-meta">{% trans 'A long time ago' %}</time>
             {% endif%}


### PR DESCRIPTION
Relative time logic was deleted in https://github.com/translate/pootle/commit/05444789d79b42f97624fccb52aa01578b0f6956#diff-8a04c7270a9f99803167ff22d34d6414
It dropped relative time auto-update at all which probably should be brought back somehow.
So we can easily use template tag to show relative suggestion creation time atm.