### PR TITLE
Fix droppy avatar

### DIFF
--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -884,6 +884,11 @@ html[dir="rtl"] .last-action img
     display: inline-block;
 }
 
+#top-stats .last-action a
+{
+    display: inline;
+}
+
 
 .last-action .user-info
 {


### PR DESCRIPTION
This works both for RTL and LTR. As a side effect we can drop
a CSS class.

This was tested locally using Chromium and Firefox.