### PR TITLE
Adjust README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,27 @@
 |logo| Pootle
 =============
 
-|chat| |build| |health| |coverage| |requirements|
+.. image:: https://img.shields.io/gitter/room/translate/pootle.svg?style=flat-square
+    :alt: Join the chat at https://gitter.im/translate/pootle
+    :target: https://gitter.im/translate/pootle
 
-.. Resources: 
+.. image:: https://img.shields.io/travis/translate/pootle/master.svg?style=flat-square
+    :alt: Build Status
+    :target: https://travis-ci.org/translate/pootle
+
+.. image:: https://landscape.io/github/translate/pootle/master/landscape.svg?style=flat-square
+    :target: https://landscape.io/github/translate/pootle/master
+    :alt: Code Health
+
+.. image:: https://img.shields.io/coveralls/translate/pootle/master.svg?style=flat-square
+   :target: https://coveralls.io/github/translate/pootle?branch=master
+   :alt: Test Coverage
+
+.. image:: https://img.shields.io/requires/github/translate/pootle.svg?style=flat-square
+   :target: https://requires.io/github/translate/pootle/requirements/?branch=master
+   :alt: Requirements
+
+
 `Docs <http://docs.translatehouse.org/projects/pootle/en/latest/>`_ |
 `Changes <http://docs.translatehouse.org/projects/pootle/en/latest/releases/2.8.0.html>`_ |
 `Issues <https://github.com/translate/pootle/issues>`_ |
@@ -27,6 +45,7 @@ A number of translation projects for a number of languages can be hosted on
 Pootle.  Teams can manage their files, permissions, projects, and translate
 on-line.  Files can be downloaded for offline translation.
 
+
 Installation
 ------------
 
@@ -43,29 +62,10 @@ Copying
 -------
 
 Pootle is released under the General Public License, version 3 or later. See
-the `LICENSE`_ file for details.
+the the `LICENSE <https://github.com/translate/pootle/blob/master/LICENSE>`_
+file for details.
 
-.. _LICENSE: https://github.com/translate/pootle/blob/master/LICENSE
+
 .. |logo| image:: https://cdn.rawgit.com/dwaynebailey/pootle/master/pootle/static/images/logo-color.svg
           :target: https://github.com/translate/pootle
           :align: bottom
-
-.. |chat| image:: https://img.shields.io/gitter/room/translate/pootle.svg?style=flat-square
-   :alt: Join the chat at https://gitter.im/translate/pootle
-   :target: https://gitter.im/translate/pootle
-
-.. |build| image:: https://img.shields.io/travis/translate/pootle/master.svg?style=flat-square
-    :alt: Build Status
-    :target: https://travis-ci.org/translate/pootle/branches
-
-.. |health| image:: https://landscape.io/github/translate/pootle/master/landscape.svg?style=flat-square
-    :target: https://landscape.io/github/translate/pootle/master
-    :alt: Code Health
-
-.. |coverage| image:: https://img.shields.io/coveralls/translate/pootle/master.svg?style=flat-square
-   :target: https://coveralls.io/github/translate/pootle?branch=master
-   :alt: Test Coverage
-
-.. |requirements| image:: https://img.shields.io/requires/github/translate/pootle/master.svg?style=flat-square
-   :target: https://requires.io/github/translate/pootle/requirements/?branch=master
-   :alt: Requirements

--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,19 @@ class BuildChecksTemplatesCommand(Command):
         print("Checks templates written to %r" % (filename))
 
 
+def parse_long_description(filename):
+    filename = os.path.join(os.path.dirname(__file__), filename)
+    readme_lines = []
+    with open(filename) as f:
+        readme_lines = f.readlines()
+    pootle = "Pootle"
+    initial_title = [  # PyPI doesn't like |logo|
+        pootle,
+        "="*len(pootle)
+    ]
+    return "\n".join(initial_title + readme_lines[2:-4])
+
+
 check_pep440_versions()
 
 
@@ -308,9 +321,7 @@ setup(
     version=__version__,
 
     description="An online collaborative localization tool.",
-    long_description=open(
-        os.path.join(os.path.dirname(__file__), 'README.rst')
-    ).read(),
+    long_description=parse_long_description('README.rst'),
 
     author="Translate",
     author_email="dev@translate.org.za",


### PR DESCRIPTION
This file is used as the PyPI package description, but most of this
trickery is not pleasant for PyPI.

The usage of |logo| still will present problems for PyPI, but that
will be handled on a followup commit.