### PR TITLE
Grabbag: README and auto update of pip install options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@
 |chat| |build| |health| |coverage| |requirements|
 
 
+.. Resources
+
 `Docs <http://docs.translatehouse.org/projects/pootle/en/latest/>`_ |
 `Changes <http://docs.translatehouse.org/projects/pootle/en/latest/releases/2.8.0.html>`_ |
 `Issues <https://github.com/translate/pootle/issues>`_ |

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Installation
 
 ::
 
-  pip install --pre Pootle
+  pip install --process-dependency-links --pre Pootle
 
 Don't forget to read the `installation guide
 <http://docs.translatehouse.org/projects/pootle/en/latest/server/installation.html>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -417,6 +417,7 @@ intersphinx_mapping = {
                'https://docs.djangoproject.com/en/%s/_objects/' % django_ver),
     'toolkit': ('http://docs.translatehouse.org/projects/translate-toolkit/en/latest/', None),
     'virtualenvwrapper': ('https://virtualenvwrapper.readthedocs.io/en/latest/', None),
+    'pip': ('https://pip.pypa.io/en/stable/', None),
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,11 @@
 # serve to show the default.
 
 import os
+import re
 import sys
 
 from django import __version__ as dj_version_actual
+from pootle.core.utils import version as pootle_version
 from translate.__version__ import sver as ttk_version_actual
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -66,8 +68,7 @@ author = u'Pootle contributors'
 # built documents.
 #
 # The short X.Y version.
-from pootle.core.utils.version import get_docs_version
-version = get_docs_version()
+version = pootle_version.get_docs_version()
 # The full version, including alpha/beta/rc tags.
 from pootle import __version__
 release = __version__
@@ -434,7 +435,23 @@ extlinks = {
 
 # -- Dependency versions ----
 
+install_options = []
+requirements_dir = '../requirements'
+for requirement in os.listdir(requirements_dir):
+    with open(os.path.join(requirements_dir, requirement)) as req:
+        for line in req.readlines():
+            if re.match(r'^\s*-e\s+', line):
+                install_options += ["--process-dependency-links"]
+                break
+if pootle_version.is_prerelease():
+    install_options += ["--pre"]
+if install_options:
+    install_options_string = " ".join(install_options)
+else:
+    install_options_string = "\\"
+
 rst_prolog = """
 .. |django_ver| replace:: %s
 .. |ttk_ver| replace:: %s
-""" % (dj_version_actual, ttk_version_actual)
+.. |--process-dependency-links --pre| replace:: %s
+""" % (dj_version_actual, ttk_version_actual, install_options_string)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 from django import __version__ as dj_version_actual
 from translate.__version__ import sver as ttk_version_actual

--- a/docs/features/pootle_fs_install_plugins.rst
+++ b/docs/features/pootle_fs_install_plugins.rst
@@ -16,9 +16,10 @@ examples for Git:
 
 - Install the plugin:
 
-  .. code-block:: console
+  .. highlight:: console
+  .. parsed-literal::
 
-    (env) $ pip install --process-dependency-links --pre Pootle[git]
+    (env) $ pip install |--process-dependency-links --pre| Pootle[git]
 
 
 - Add the plugin to :setting:`INSTALLED_APPS`:

--- a/docs/server/installation.rst
+++ b/docs/server/installation.rst
@@ -122,9 +122,10 @@ Installing Pootle
 
 Use :command:`pip` to install Pootle into the virtual environment:
 
-.. code-block:: console
+.. highlight:: console
+.. parsed-literal::
 
-  (env) $ pip install --process-dependency-links --pre Pootle
+  (env) $ pip install |--process-dependency-links --pre| Pootle
 
 
 This will also fetch and install Pootle's dependencies.

--- a/docs/server/installation.rst
+++ b/docs/server/installation.rst
@@ -129,6 +129,11 @@ Use :command:`pip` to install Pootle into the virtual environment:
 
 This will also fetch and install Pootle's dependencies.
 
+.. note:: pip requires :ref:`--pre <pip:install_--pre>` to install pre-release
+   versions of Pootle, i.e. alpha, beta and rc versions. You may require
+   :ref:`--process-dependency-links <pip:--process-dependency-links>` if Pootle
+   depends on unreleased versions of third-party software software.
+
 To verify that everything installed correctly, you should be able to access the
 :command:`pootle` command line tool within your environment.
 

--- a/docs/server/mysql_installation.rst
+++ b/docs/server/mysql_installation.rst
@@ -57,9 +57,10 @@ you will need to install the MySQL driver.
 
 You can do so as follows:
 
-.. code-block:: console
+.. highlight:: console
+.. parsed-literal::
 
-  (env) $ pip install Pootle[mysql]
+  (env) $ pip install |--process-dependency-links --pre| Pootle[mysql]
 
 
 .. _mysql_installation#init-config:

--- a/docs/server/postgresql_installation.rst
+++ b/docs/server/postgresql_installation.rst
@@ -54,9 +54,10 @@ you will need to install the PostgreSQL bindings.
 
 You can do so as follows:
 
-.. code-block:: console
+.. highlight:: console
+.. parsed-literal::
 
-  (env) $ pip install Pootle[postgresql]
+  (env) $ pip install |--process-dependency-links --pre| Pootle[postgresql]
 
 
 .. _postgresql_installation#init-config:

--- a/docs/server/upgrading.rst
+++ b/docs/server/upgrading.rst
@@ -128,9 +128,10 @@ Upgrading from version 2.6.x or later
 
 Upgrade to the latest Pootle version:
 
-.. code-block:: console
+.. highlight:: console
+.. parsed-literal::
 
-   (env) $ pip install --process-dependency-links --pre --upgrade Pootle
+   (env) $ pip install |--process-dependency-links --pre| --upgrade Pootle
 
 
 .. _upgrading#check-settings:

--- a/docs/server/upgrading.rst
+++ b/docs/server/upgrading.rst
@@ -185,12 +185,19 @@ Migrate your database schema
 ----------------------------
 
 Once you have updated your settings you can perform the database schema and
-data upgrade by running. This needs to be done in a few steps:
+data upgrade by running. This is done as follows:
+
+.. note:: The following fake migrations are required when migrating from
+   Pootle 2.6 or older.  Subsequent versions do not require these steps:
+
+   .. code-block:: console
+
+      (env) $ pootle migrate accounts 0002 --fake
+      (env) $ pootle migrate pootle_translationproject 0002 --fake
+
 
 .. code-block:: console
 
-   (env) $ pootle migrate accounts 0002 --fake
-   (env) $ pootle migrate pootle_translationproject 0002 --fake
    (env) $ pootle migrate
 
 

--- a/pootle/core/utils/version.py
+++ b/pootle/core/utils/version.py
@@ -252,3 +252,9 @@ if __name__ == "__main__":
             print(get_docs_version())
     else:
         print(get_version())
+
+
+def is_prerelease(version=None):
+    """Is this a final release or not"""
+
+    return _get_candidate(get_complete_version(version)) != 'final'

--- a/requirements/_docs.txt
+++ b/requirements/_docs.txt
@@ -1,3 +1,4 @@
 # Documentation
 
+readme_renderer==16.0
 sphinx==1.5.1

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def parse_requirements(file_name, recurse=False):
                     re.sub(r'-r\s*(.*[.]txt)$', r'\1', line), recurse))
             continue
 
-        if re.match(r'\s*-e\s+', line):
+        if re.match(r'^\s*-e\s+', line):
             requirements.append(re.sub(
                 r'''\s*-e\s+          # -e marker
                  .*                   # URL
@@ -77,7 +77,7 @@ def parse_requirements(file_name, recurse=False):
 def parse_dependency_links(file_name, recurse=False):
     dependency_links = []
     for line in open(file_name, 'r').read().split('\n'):
-        if re.match(r'\s*-e\s+', line):
+        if re.match(r'^\s*-e\s+', line):
             dependency_links.append(re.sub(r'\s*-e\s+', '', line))
 
         if re.match(r'-r .*$', line):

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ commands=
     make travis-assets
     python setup.py sdist
     make docs
+    python setup.py check --restructuredtext --strict
     python setup.py build_mo
     make lint-js
     make lint-css


### PR DESCRIPTION
* Adds README check to CI
* Address docs issues with extra parms, fake installs in upgrades
* Dynamically create extra options in Docs and in long_description