### PR TITLE
Add top scorers caching

### DIFF
--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -93,6 +93,10 @@ class LanguageBrowseView(LanguageMixin, PootleBrowseView):
         response.set_cookie('pootle-language', self.object.code)
         return response
 
+    @property
+    def top_scorers_context(self):
+        return self.object.directory
+
 
 class LanguageTranslateView(LanguageMixin, PootleTranslateView):
     url_pattern_name = "pootle-language-translate"

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -145,6 +145,10 @@ class ProjectBrowseView(ProjectMixin, PootleBrowseView):
         items.sort(cmp_by_last_activity)
         return items
 
+    @property
+    def top_scorers_context(self):
+        return self.project.directory
+
 
 class ProjectTranslateView(ProjectMixin, PootleTranslateView):
     required_permission = "administrate"
@@ -345,6 +349,10 @@ class ProjectsBrowseView(ProjectsMixin, PootleBrowseView):
         response = super(ProjectsBrowseView, self).get(*args, **kwargs)
         response.set_cookie('pootle-language', "projects")
         return response
+
+    @property
+    def top_scorers_context(self):
+        return self.object.directory
 
 
 class ProjectsTranslateView(ProjectsMixin, PootleTranslateView):

--- a/pootle/apps/pootle_statistics/apps.py
+++ b/pootle/apps/pootle_statistics/apps.py
@@ -15,6 +15,7 @@ class PootleStatisticsConfig(AppConfig):
 
     name = "pootle_statistics"
     verbose_name = "Pootle Statistics"
+    version = "0.0.1"
 
     def ready(self):
         importlib.import_module("pootle_statistics.getters")

--- a/pootle/apps/pootle_statistics/getters.py
+++ b/pootle/apps/pootle_statistics/getters.py
@@ -6,12 +6,17 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from pootle.core.delegate import contributors
+from pootle.core.delegate import contributors, top_scorers_data_tool
 from pootle.core.plugin import getter
 
-from .utils import Contributors
+from .utils import Contributors, TopScorersDataTool
 
 
 @getter(contributors)
 def get_contributors(**kwargs_):
     return Contributors
+
+
+@getter(top_scorers_data_tool)
+def get_top_scorers_data_tool(**kwargs_):
+    return TopScorersDataTool

--- a/pootle/apps/pootle_statistics/utils.py
+++ b/pootle/apps/pootle_statistics/utils.py
@@ -16,6 +16,7 @@ from pootle.core.decorators import persistent_property
 from pootle.core.url_helpers import split_pootle_path
 from pootle.core.utils.stats import TOP_CONTRIBUTORS_CHUNK_SIZE
 
+from .apps import PootleStatisticsConfig
 
 
 class Contributors(object):
@@ -92,6 +93,7 @@ class Contributors(object):
 
 class TopScorersDataTool(object):
     ns = 'pootle.top_scores'
+    sw_version = PootleStatisticsConfig.version
 
     def __init__(self, context, pootle_path):
         self.context = context

--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -272,6 +272,10 @@ class TPBrowseBaseView(PootleBrowseView):
     def post(self, *args, **kwargs):
         return self.get(*args, **kwargs)
 
+    @property
+    def top_scorers_context(self):
+        return self.tp.directory
+
 
 class TPBrowseStoreView(TPStoreMixin, TPBrowseBaseView):
 

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -26,6 +26,7 @@ filetype_tool = Getter()
 tp_tool = Getter()
 data_tool = Getter()
 data_updater = Getter()
+top_scorers_data_tool = Getter()
 
 language_team = Getter()
 review = Getter()

--- a/pootle/core/views/browse.py
+++ b/pootle/core/views/browse.py
@@ -8,18 +8,17 @@
 
 import logging
 
-from django.contrib.auth import get_user_model
 from django.utils.functional import cached_property
 
 from pootle.core.decorators import persistent_property
 from pootle.core.delegate import panels
 from pootle.core.helpers import (SIDEBAR_COOKIE_NAME,
                                  get_sidebar_announcements_context)
-from pootle.core.url_helpers import split_pootle_path
 from pootle.core.utils.stats import (TOP_CONTRIBUTORS_CHUNK_SIZE,
                                      get_top_scorers_data,
                                      get_translation_states)
 from pootle.i18n import formatter
+from pootle_statistics.utils import TopScorersDataTool
 
 from .base import PootleDetailView
 from .display import ChecksDisplay, StatsDisplay
@@ -131,12 +130,8 @@ class PootleBrowseView(PootleDetailView):
 
     @cached_property
     def top_scorers(self):
-        User = get_user_model()
-        lang_code, proj_code = split_pootle_path(self.pootle_path)[:2]
-        return User.top_scorers(
-            project=proj_code,
-            language=lang_code,
-            limit=TOP_CONTRIBUTORS_CHUNK_SIZE + 1)
+        return TopScorersDataTool(self.top_scorers_context,
+                                  self.pootle_path).data
 
     @property
     def top_scorer_data(self):

--- a/pootle/core/views/browse.py
+++ b/pootle/core/views/browse.py
@@ -11,14 +11,13 @@ import logging
 from django.utils.functional import cached_property
 
 from pootle.core.decorators import persistent_property
-from pootle.core.delegate import panels
+from pootle.core.delegate import panels, top_scorers_data_tool
 from pootle.core.helpers import (SIDEBAR_COOKIE_NAME,
                                  get_sidebar_announcements_context)
 from pootle.core.utils.stats import (TOP_CONTRIBUTORS_CHUNK_SIZE,
                                      get_top_scorers_data,
                                      get_translation_states)
 from pootle.i18n import formatter
-from pootle_statistics.utils import TopScorersDataTool
 
 from .base import PootleDetailView
 from .display import ChecksDisplay, StatsDisplay
@@ -130,8 +129,9 @@ class PootleBrowseView(PootleDetailView):
 
     @cached_property
     def top_scorers(self):
-        return TopScorersDataTool(self.top_scorers_context,
-                                  self.pootle_path).data
+        top_scorers_data_tool_class = top_scorers_data_tool.get()
+        return top_scorers_data_tool_class(self.top_scorers_context,
+                                           self.pootle_path).data
 
     @property
     def top_scorer_data(self):


### PR DESCRIPTION
Add TopScorersDataTool class which uses persistent_property for caching top scorers data.
Current date is included into cache_key. It allows to update top scorers cache data properly to support `last 30 days` time interval.