### PR TITLE
Settings: Use MySQL's STRICT_TRANS_TABLES

### DIFF
--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -62,6 +62,9 @@ DATABASES = {
         # See https://docs.djangoproject.com/en/1.10/topics/db/transactions/
         # required for Django + sqlite
         'ATOMIC_REQUESTS': True,
+        #'OPTIONS' : {
+        #    'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        #},
         'TEST': {
             'NAME': 'test_pootle',
         }


### PR DESCRIPTION
Option is commented by default since we can't rely on MySQL being
the database being used.