### PR TITLE
i18n: formatter tests and followon 84c44f3bf41f

### DIFF
--- a/pootle/i18n/formatter.py
+++ b/pootle/i18n/formatter.py
@@ -16,10 +16,12 @@ from django.utils.translation import get_language, to_locale
 
 
 def _get_locale_formats():
-    try:
-        locale = babel_core.Locale.parse(to_locale(get_language()))
-    except UnknownLocaleError:
-        locale = settings.LANGUAGE_CODE
+    for language in [get_language(), settings.LANGUAGE_CODE, 'en-us']:
+        try:
+            locale = babel_core.Locale.parse(to_locale(language))
+            break
+        except UnknownLocaleError:
+            continue
     return babel_support.Format(locale)
 
 

--- a/tests/i18n/formatter.py
+++ b/tests/i18n/formatter.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+from babel.support import Format
+
+from django.utils.translation import override
+
+from pootle.i18n.formatter import (_clean_zero, _get_locale_formats, number,
+                                   percent)
+
+
+@pytest.mark.parametrize('language', [
+    'af', 'en-za', 'en-us',  # Normal
+    'son',  # Missing in babel
+])
+def test__get_locale_formats(language):
+    with override(language):
+        assert isinstance(_get_locale_formats(), Format)
+
+
+def test__clean_zero():
+    assert _clean_zero(None) == 0
+    assert _clean_zero('') == 0
+    assert _clean_zero(0) == 0
+    assert _clean_zero(3.1415) == 3.1415
+
+
+@pytest.mark.parametrize('language, expected', [
+    ('en-gb', '1,000.5'),  # Normal
+    ('gl', '1.000,5'),  # Galician (inverted wrt en-us)
+    ('af-za', u'1\u00a0000,5'),  # Major difference
+    ('son', '1,000.5'),  # Missing
+])
+def test_number(language, expected):
+    with override(language):
+        assert number('1000.5') == expected
+
+
+@pytest.mark.parametrize('language, expected', [
+    ('en-gb', '1,000%'),  # Normal
+    ('gl', '1.000%'),  # Galician (inverted wrt en-us)
+    ('af-za', u'1\u00a0000%'),  # Major difference
+    ('son', '1,000%'),  # Missing
+])
+def test_percent(language, expected):
+    with override(language):
+        assert percent(10.005) == expected
+
+
+@pytest.mark.parametrize('language, expected', [
+    ('en-gb', '1,000.5%'),  # Normal
+    ('gl', '1.000,5%'),  # Galician (inverted wrt en-us)
+    ('af-za', u'1\u00a0000,5%'),  # Major difference
+    ('son', '1,000.5%'),  # Missing
+])
+def test_percent_format(language, expected):
+    with override(language):
+        assert percent(10.005, '#,##0.0%') == expected


### PR DESCRIPTION
Fixes an issues with locale fallback and adds tests to validate that
the formatters work.

Note to self.  This is why you write tests....