### PR TITLE
Term matcher stemmer

### DIFF
--- a/pootle/apps/pootle_word/apps.py
+++ b/pootle/apps/pootle_word/apps.py
@@ -19,3 +19,4 @@ class PootleWordConfig(AppConfig):
 
     def ready(self):
         importlib.import_module("pootle_word.models")
+        importlib.import_module("pootle_word.getters")

--- a/pootle/apps/pootle_word/getters.py
+++ b/pootle/apps/pootle_word/getters.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.delegate import stemmer
+from pootle.core.plugin import getter
+
+from stemming.porter2 import stem
+
+
+@getter(stemmer)
+def get_stemmer(**kwargs_):
+    return stem

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,6 +29,7 @@ python-levenshtein==0.12.0
 pytz==2016.10
 rq==0.7.1
 scandir==1.4
+stemming==1.0.1
 
 # Translate Toolkit
 # Note: also adjust pootle/checks::TTK_MINIMUM_REQUIRED_VERSION

--- a/tests/pootle_word/utils.py
+++ b/tests/pootle_word/utils.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from stemming.porter2 import stem
+
+from pootle.core.delegate import stemmer
+
+
+def test_stemmer():
+    assert stemmer.get() is stem


### PR DESCRIPTION
Adds a pluggable stemmer, by default uses `stemming.porter2`