### PR TITLE
Add --tmx option to export cli command which creates zipped TMX for a TP

### DIFF
--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -738,6 +738,16 @@ A file or a .zip of files is provided as output.  The file headers include a
 revision counter to assist Pootle to detetmine how to handle subsequent uploads
 of the file.
 
+Available options:
+
+.. django-admin-option:: --tmx
+
+  .. versionadded:: 2.8.0
+
+  Export every translation project as one zipped TMX file into :setting:`MEDIA_ROOT`
+  directory.
+
+
 .. django-admin:: import
 
 import

--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -60,15 +60,7 @@ class Command(PootleCommand):
                 self.handle_language(language)
             return
 
-        for project in project_query.iterator():
-            tp_query = project.translationproject_set \
-                              .order_by("language__code")
-
-            if self.languages:
-                tp_query = tp_query.filter(language__code__in=self.languages)
-
-            for tp in tp_query.iterator():
-                self.do_translation_project(tp, **options)
+        return super(Command, self).handle_all(**options)
 
     def handle_translation_project(self, translation_project, **options_):
         stores = translation_project.stores.live()

--- a/pootle/apps/pootle_revision/utils.py
+++ b/pootle/apps/pootle_revision/utils.py
@@ -91,10 +91,7 @@ class ProjectSetRevision(RevisionContext):
 
 
 class TPRevision(RevisionContext):
-
-    @property
-    def revision_context(self):
-        return self.context.directory.revisions
+    pass
 
 
 class RevisionUpdater(object):

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -9,6 +9,7 @@
 import logging
 
 from django.conf import settings
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -25,6 +26,7 @@ from pootle_format.models import Format
 from pootle_language.models import Language
 from pootle_misc.checks import excluded_filters
 from pootle_project.models import Project
+from pootle_revision.models import Revision
 from pootle_store.constants import PARSED
 from pootle_store.util import absolute_real_path, relative_real_path
 from staticpages.models import StaticPage
@@ -156,6 +158,7 @@ class TranslationProject(models.Model, CachedTreeItem):
                                    db_index=True, editable=False)
     creation_time = models.DateTimeField(auto_now_add=True, db_index=True,
                                          editable=False, null=True)
+    revisions = GenericRelation(Revision)
 
     objects = TranslationProjectManager()
 


### PR DESCRIPTION
This PR adds `--tmx` option into `export` command 
It will create zipped TMX file for every TP into MEDIA_ROOT directory.
