### PR TITLE
Cleanups: picked up from py3 porting

### DIFF
--- a/docs/developers/plugins.rst
+++ b/docs/developers/plugins.rst
@@ -173,6 +173,6 @@ Add a file called :file:`receivers.py` with the following code:
 
    @receiver(cache_cleared, sender=Store)
    def handle_cache_cleared(**kwargs):
-       logging.warn(
+       logging.warning(
            "Store cache cleared: %s"
 	   % kwargs["instance"].pootle_path)

--- a/pootle/apps/pootle_fs/resources.py
+++ b/pootle/apps/pootle_fs/resources.py
@@ -6,8 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from fnmatch import fnmatch
 import os
+from fnmatch import fnmatch
 
 from django.db.models import F, Max
 from django.utils.functional import cached_property

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -1076,10 +1076,10 @@ def run_given_filters(checker, unit, check_names=None):
 
         try:
             filterresult = checker.run_test(filterfunction, unit)
-        except checks.FilterFailure, e:
+        except checks.FilterFailure as e:
             filterresult = False
             filtermessage = unicode(e)
-        except Exception, e:
+        except Exception as e:
             if checker.errorhandler is None:
                 raise ValueError("error in filter %s: %r, %r, %s" %
                                  (functionname, unit.source, unit.target, e))

--- a/pootle/apps/pootle_misc/util.py
+++ b/pootle/apps/pootle_misc/util.py
@@ -21,7 +21,7 @@ def import_func(path):
     module, attr = path[:i], path[i+1:]
     try:
         mod = import_module(module)
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured('Error importing module %s: "%s"'
                                    % (module, e))
     try:

--- a/pootle/apps/pootle_score/utils.py
+++ b/pootle/apps/pootle_score/utils.py
@@ -13,12 +13,13 @@ from django.db.models import Sum
 from django.utils import timezone
 
 from pootle.core.decorators import persistent_property
-from pootle.core.delegate import display, scores, revision
+from pootle.core.delegate import display, revision, scores
 from pootle_app.models import Directory
 from pootle_language.models import Language
 
 from .apps import PootleScoreConfig
 from .models import UserTPScore
+
 
 User = get_user_model()
 

--- a/pootle/apps/pootle_terminology/utils.py
+++ b/pootle/apps/pootle_terminology/utils.py
@@ -8,13 +8,12 @@
 
 from django.utils.functional import cached_property
 
-from pootle.core.delegate import revision, text_comparison
 from pootle.core.decorators import persistent_property
+from pootle.core.delegate import revision, text_comparison
 from pootle_store.constants import TRANSLATED
 from pootle_store.models import Unit
 from pootle_translationproject.models import TranslationProject
 from pootle_word.utils import TextStemmer
-
 
 from .apps import PootleTerminologyConfig
 

--- a/pootle/core/views/browse.py
+++ b/pootle/core/views/browse.py
@@ -157,7 +157,7 @@ class PootleBrowseView(PootleDetailView):
             if panel in _panels:
                 yield _panels[panel](self).content
             else:
-                logger.warn("Unrecognized panel '%s'", panel)
+                logger.warning("Unrecognized panel '%s'", panel)
 
     def get_context_data(self, *args, **kwargs):
         filters = {}

--- a/pootle/settings.py
+++ b/pootle/settings.py
@@ -21,8 +21,7 @@ def working_path(filename):
 
 
 conf_files_path = os.path.join(WORKING_DIR, 'settings', '*.conf')
-conf_files = glob.glob(conf_files_path)
-conf_files.sort()
+conf_files = sorted(glob.glob(conf_files_path))
 
 for f in conf_files:
     execfile(os.path.abspath(f))

--- a/pootle/settings/95-outro.conf
+++ b/pootle/settings/95-outro.conf
@@ -25,7 +25,7 @@ if pootle_settings_filepath is not None:
         logger.info(u"Loading custom settings from %r...",
                     pootle_settings_filepath)
         execfile(os.path.abspath(pootle_settings_filepath))
-    except (IOError, OSError), e:
+    except (IOError, OSError) as e:
         logger.error(u"Cannot access configuration file at %r as defined by "
                      u"the %r environment variable:\n%s",
                      pootle_settings_filepath, pootle_settings_envvar, e)

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -124,7 +124,7 @@ def _setup_store_test(store, member, member2, test):
 
     for units in setup:
         store_revision = store.get_max_unit_revision()
-        print "setup store: %s %s" % (store_revision, units)
+        print("setup store: %s %s" % (store_revision, units))
         update_store(store, store_revision=store_revision, units=units,
                      user=member)
         for unit in store.units:


### PR DESCRIPTION
The following are simple cleanups taken from experimental Python 3 support.