### PR TITLE
Fix: use user.pk in UserScores.cache_key, prevent unicode fail

### DIFF
--- a/pootle/apps/pootle_score/utils.py
+++ b/pootle/apps/pootle_score/utils.py
@@ -148,7 +148,7 @@ class UserScores(Scores):
     def cache_key(self):
         return (
             "%s.%s.%s"
-            % (self.context.username,
+            % (self.context.id,
                timezone.now().date(),
                self.revision))
 

--- a/tests/pootle_score/utils.py
+++ b/tests/pootle_score/utils.py
@@ -179,7 +179,7 @@ def test_scores_user(member, system):
     assert (
         score_data.cache_key
         == ("%s.%s.%s"
-            % (member.username,
+            % (member.id,
                timezone.now().date(),
                score_data.revision)))
     # system gets no rank


### PR DESCRIPTION
as in title