### PR TITLE
Python 3 cleanups: print() and Octal

### DIFF
--- a/.pylint-travisrc
+++ b/.pylint-travisrc
@@ -10,7 +10,7 @@
 # 4. We don't include anything that the devs can't agree on in terms of linting
 
 [MASTER]
-ignore=migrations,.eggs
+ignore=migrations,.eggs,.git,.tox
 
 [MESSAGES CONTROL]
 disable=all

--- a/.pylint-travisrc
+++ b/.pylint-travisrc
@@ -16,7 +16,8 @@ ignore=migrations,.eggs,.git,.tox
 disable=all
 # For checkers and individual checks see
 # https://pylint.readthedocs.io/en/latest/features.html
-enable=reimported,logging,stdlib,string,unneeded-not,undefined-loop-variable
+enable=reimported, logging, stdlib, string, unneeded-not, undefined-loop-variable, old-octal-literal
+
 dummy-variables-rgx=__|^.*[^_]_$
 
 [REPORTS]

--- a/.pylint-travisrc
+++ b/.pylint-travisrc
@@ -16,7 +16,7 @@ ignore=migrations,.eggs,.git,.tox
 disable=all
 # For checkers and individual checks see
 # https://pylint.readthedocs.io/en/latest/features.html
-enable=reimported, logging, stdlib, string, unneeded-not, undefined-loop-variable, old-octal-literal
+enable=reimported, logging, stdlib, string, unneeded-not, undefined-loop-variable, old-octal-literal, print-statement
 
 dummy-variables-rgx=__|^.*[^_]_$
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ lint-py: lint-python
 lint-python:
 	flake8 --config=setup.cfg && \
 	isort --check-only --diff && \
-	pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle
+	pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle docs
 
 lint-js:
 	cd ${JS_DIR} \

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ lint-py: lint-python
 lint-python:
 	flake8 --config=setup.cfg && \
 	isort --check-only --diff && \
-	pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle docs
+	pylint --rcfile=.pylint-travisrc pootle tests pytest_pootle docs pootle/settings/*.conf*
 
 lint-js:
 	cd ${JS_DIR} \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import print_function
+
 import os
 import re
 import sys

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,12 +144,12 @@ if build_icons_inc:
     with open(icons_inc_file_name, "w") as icons_txt_file:
         for icon_image in os.listdir(icons_dir):
             icon_name = icon_image[:icon_image.rfind(".")]
-            print >>icons_txt_file, ".. |icon:" + icon_name + "| " + \
-                                    "image:: /" + icons_dir + "/" + icon_image
-            print >>icons_txt_file, "                      :alt: " + \
-                                    icon_name.replace("-", " ").replace("_", " ") + \
-                                    " icon"
-            print >>icons_txt_file
+            print(".. |icon:" + icon_name + "| " + \
+                  "image:: /" + icons_dir + "/" + icon_image, file=icons_txt_file)
+            print("                      :alt: " + \
+                  icon_name.replace("-", " ").replace("_", " ") + \
+                  " icon", file=icons_txt_file)
+            print(file=icons_txt_file)
 
 # Files to include at the end of every .rst file
 rst_epilog = """

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -339,13 +339,13 @@ Translation environment configuration settings.
 .. setting:: POOTLE_SYNC_FILE_MODE
 
 ``POOTLE_SYNC_FILE_MODE``
-  Default: ``0644``
+  Default: ``0o644``
 
   .. versionchanged:: 2.7
 
-  On POSIX systems, files synchronized to disk will be assigned this permission.
-  Use ``0644`` for publically-readable files or ``0600`` if you want only the
-  Pootle user to be able to read them.
+  On POSIX systems, files synchronized to disk will be assigned this
+  permission.  Use ``0o644`` for publically-readable files or ``0o600`` if you
+  want only the Pootle user to be able to read them.
 
 
 .. setting:: POOTLE_TM_SERVER

--- a/pootle/core/utils/version.py
+++ b/pootle/core/utils/version.py
@@ -11,6 +11,8 @@
 # Copyright (c) Django Software Foundation and individual contributors.  All
 # rights reserved.
 
+from __future__ import print_function
+
 import datetime
 import os
 import subprocess

--- a/pootle/middleware/errorpages.py
+++ b/pootle/middleware/errorpages.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from __future__ import print_function
+
 import sys
 import traceback
 

--- a/pootle/middleware/errorpages.py
+++ b/pootle/middleware/errorpages.py
@@ -59,7 +59,7 @@ def log_exception(request, exception, tb):
 def handle_exception(request, exception, template_name):
     # XXX: remove this? exceptions are already displayed in debug mode
     tb = traceback.format_exc()
-    print >> sys.stderr, tb
+    print(tb, file=sys.stderr)
 
     if settings.DEBUG:
         return None

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -7,6 +7,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from __future__ import print_function
+
 import os
 import sys
 from argparse import SUPPRESS, ArgumentParser

--- a/pootle/settings/60-translation.conf
+++ b/pootle/settings/60-translation.conf
@@ -7,9 +7,9 @@
 POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 
 # On POSIX systems, files synchronized to disk will be assigned these
-# permissions. Use 0644/0755 for publically-readable files, or 0600/0700 if you
-# want only the Pootle user to be able to read them.
-POOTLE_SYNC_FILE_MODE = 0644
+# permissions. Use 0o644/0o755 for publically-readable files, or 0o600/0o700 if
+# you want only the Pootle user to be able to read them.
+POOTLE_SYNC_FILE_MODE = 0o644
 
 # File parse pool settings
 #

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from __future__ import print_function
+
 import os
 from collections import OrderedDict
 

--- a/tests/models/legalpage.py
+++ b/tests/models/legalpage.py
@@ -23,7 +23,7 @@ def test_pending_agreements():
 
     privacy_policy = LegalPageFactory.create(
         active=True,
-        modified_on=aware_datetime(2014, 01, 01),
+        modified_on=aware_datetime(2014, 1, 1),
     )
 
     # `foo_user` hasn't agreed the privacy policy yet
@@ -35,7 +35,7 @@ def test_pending_agreements():
     AgreementFactory.create(
         user=foo_user,
         document=privacy_policy,
-        agreed_on=aware_datetime(2014, 02, 02),
+        agreed_on=aware_datetime(2014, 2, 2),
     )
 
     pending = list(LegalPage.objects.pending_user_agreement(foo_user))
@@ -44,7 +44,7 @@ def test_pending_agreements():
     # Let's add a new ToS
     tos = LegalPageFactory.create(
         active=True,
-        modified_on=aware_datetime(2015, 01, 01),
+        modified_on=aware_datetime(2015, 1, 1),
     )
 
     pending = list(LegalPage.objects.pending_user_agreement(foo_user))
@@ -55,14 +55,14 @@ def test_pending_agreements():
     AgreementFactory.create(
         user=foo_user,
         document=tos,
-        agreed_on=aware_datetime(2015, 02, 02),
+        agreed_on=aware_datetime(2015, 2, 2),
     )
 
     pending = list(LegalPage.objects.pending_user_agreement(foo_user))
     assert len(pending) == 0
 
     # The ToS were modified, `foo_user` must agree it
-    tos.modified_on = aware_datetime(2015, 03, 03)
+    tos.modified_on = aware_datetime(2015, 3, 3)
     tos.save()
 
     pending = list(LegalPage.objects.pending_user_agreement(foo_user))
@@ -70,7 +70,7 @@ def test_pending_agreements():
     assert tos in pending
 
     # Same with the privacy policy
-    privacy_policy.modified_on = aware_datetime(2015, 04, 04)
+    privacy_policy.modified_on = aware_datetime(2015, 4, 4)
     privacy_policy.save()
 
     pending = list(LegalPage.objects.pending_user_agreement(foo_user))


### PR DESCRIPTION
Octal: use new syntax and prevent regression
print(): prevent regression, use `__future__` as needed and fix remaining print[sp] occurances