### PR TITLE
Fix mysql timezone test

### DIFF
--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -538,8 +538,8 @@ def check_mysql_timezones(app_configs=None, **kwargs):
     errors = []
     with connection.cursor() as cursor:
         if hasattr(cursor.db, "mysql_version"):
-            cursor.execute("SELECT COUNT(*) FROM mysql.time_zone_name;")
-            timezone_count = cursor.fetchone()[0]
-            if timezone_count == 0:
+            cursor.execute("SELECT CONVERT_TZ(NOW(), 'UTC', 'UTC');")
+            converted_now = cursor.fetchone()[0]
+            if converted_now is None:
                 errors.append(missing_mysql_timezone_tables)
     return errors


### PR DESCRIPTION
Timezone aware test required access to mysql DB which was not right.
This commit solves the issue via "CONVERT_TZ(NOW(), 'UTC', 'UTC')" SQL function
which returns NULL if time zone tables are not loaded.