### PR TITLE
Allow specialchars field in language form to be blank

### DIFF
--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -25,7 +25,7 @@ LANGCODE_RE = re.compile("^[a-z]{2,}([_-]([a-z]{2,}|[0-9]{3}))*(@[a-z0-9]+)?$",
 
 class LanguageForm(forms.ModelForm):
 
-    specialchars = forms.CharField(strip=False)
+    specialchars = forms.CharField(strip=False, required=False)
 
     class Meta(object):
         model = Language

--- a/tests/forms/language.py
+++ b/tests/forms/language.py
@@ -12,6 +12,7 @@ from pootle_app.forms import LanguageForm
 
 
 @pytest.mark.parametrize('specialchars', [
+    ' ',
     ' abcde ',
     ' ab cd',
     ' abcde',
@@ -52,3 +53,18 @@ def test_clean_specialchars_unique(specialchars, count_char):
     form = LanguageForm(form_data)
     assert form.is_valid()
     assert form.cleaned_data['specialchars'].count(count_char) == 1
+
+
+@pytest.mark.django_db
+def test_specialchars_can_be_blank():
+    """Test that a blank special character field is valid."""
+    form_data = {
+        'code': 'foo',
+        'fullname': 'Foo',
+        'checkstyle': 'foo',
+        'nplurals': '2',
+        'specialchars': '',
+    }
+    form = LanguageForm(form_data)
+    assert form.is_valid()
+    assert form.cleaned_data['specialchars'] == ''


### PR DESCRIPTION
Fixes #5817 