### PR TITLE
Match @ in fs.finder language_codes

### DIFF
--- a/pootle/apps/pootle_fs/finder.py
+++ b/pootle/apps/pootle_fs/finder.py
@@ -22,7 +22,7 @@ from .apps import PootleFSConfig
 
 PATH_MAPPING = (
     (".", "\."),
-    ("<language_code>", "(?P<language_code>[\w\-\.]*)"),
+    ("<language_code>", "(?P<language_code>[\w\@\-\.]*)"),
     ("<filename>", "(?P<filename>[\w\-\.]*)"),
     ("/<dir_path>/", "/<dir_path>"),
     ("<dir_path>", "(?P<dir_path>[\w\/\-]*?)"))

--- a/tests/pootle_fs/finder.py
+++ b/tests/pootle_fs/finder.py
@@ -256,3 +256,13 @@ def test_finder_cache_key():
             % (finder.fs_hash,
                "::".join(finder.exclude_languages),
                hash(finder.regex.pattern))))
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(sys.platform == 'win32',
+                   reason="path mangling broken on windows")
+def test_finder_lang_codes():
+    finder = TranslationFileFinder(
+        "/path/to/<dir_path>/<language_code>.<ext>")
+    match = finder.match("/path/to/foo/bar@baz.po")
+    assert match[1]["language_code"] == "bar@baz"


### PR DESCRIPTION
allow language codes with `@` symbol