### PR TITLE
Cleanup: dont use cached_property for store.syncer

### DIFF
--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -121,7 +121,7 @@ class StoreSyncer(object):
     def __init__(self, store):
         self.store = store
 
-    @cached_property
+    @property
     def disk_store(self):
         return self.store.file.store
 


### PR DESCRIPTION
In testing this causes a potential gotcha where the cached version
of the disk store is written to disk