### PR TITLE
Add --rotate exported files option to export tmx cli command

### DIFF
--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -744,9 +744,15 @@ Available options:
 
   .. versionadded:: 2.8.0
 
-  Export every translation project as one zipped TMX file into :setting:`MEDIA_ROOT`
-  directory.
+  Export every translation project as one zipped TMX file
+  into :setting:`MEDIA_ROOT` directory.
 
+.. django-admin-option:: --rotate
+
+  .. versionadded:: 2.8.0
+
+  Remove old exported zipped TMX files (except previous one)
+  from :setting:`MEDIA_ROOT` directory after current exported file is saved.
 
 .. django-admin:: import
 

--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -89,8 +89,10 @@ class Command(PootleCommand):
                     translation_project)
                 return False
 
-            filename = exporter.export(rotate=options['rotate'])
+            filename, removed = exporter.export(rotate=options['rotate'])
             self.stdout.write('File "%s" has been saved.' % filename)
+            for filename in removed:
+                self.stdout.write('File "%s" has been removed.' % filename)
         else:
             stores = translation_project.stores.live()
             prefix = "%s-%s" % (translation_project.project.code,

--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -46,6 +46,13 @@ class Command(PootleCommand):
             default=False,
             help="Overwrite already exported TMX files",
         )
+        parser.add_argument(
+            "--rotate",
+            action="store_true",
+            dest="rotate",
+            default=False,
+            help="Remove old exported TMX files",
+        )
 
     def _create_zip(self, stores, prefix):
         with open("%s.zip" % (prefix), "wb") as f:
@@ -82,7 +89,7 @@ class Command(PootleCommand):
                     translation_project)
                 return False
 
-            filename = exporter.export()
+            filename = exporter.export(rotate=options['rotate'])
             self.stdout.write('File "%s" has been saved.' % filename)
         else:
             stores = translation_project.stores.live()

--- a/pootle/apps/import_export/utils.py
+++ b/pootle/apps/import_export/utils.py
@@ -167,10 +167,12 @@ class TPTMXExporter(object):
         last_exported_filepath = self.last_exported_file_path
         self.update_exported_revision()
 
+        removed = []
         if rotate:
             for fn in os.listdir(self.directory):
                 filepath = os.path.join(self.directory, fn)
                 if filepath not in [self.abs_filepath, last_exported_filepath]:
+                    removed.append(filepath)
                     os.remove(filepath)
 
-        return self.abs_filepath
+        return self.abs_filepath, removed

--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -206,3 +206,16 @@ def test_fs():
             return open(self.path(paths), *args, **kwargs)
 
     return TestFs()
+
+
+@pytest.fixture
+def media_test_dir(request, settings, tmpdir):
+    media_dir = str(tmpdir.mkdir("media"))
+    settings.MEDIA_ROOT = media_dir
+
+    def rm_media_dir():
+        if os.path.exists(media_dir):
+            shutil.rmtree(media_dir)
+
+    request.addfinalizer(rm_media_dir)
+    return media_dir

--- a/tests/commands/export.py
+++ b/tests/commands/export.py
@@ -88,7 +88,7 @@ def test_export_path_unknown():
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_export_tmx_tp(capfd, tp0):
+def test_export_tmx_tp(capfd, tp0, media_test_dir):
     """Export a tp"""
     lang_code = tp0.language.code
     prj_code = tp0.project.code
@@ -113,3 +113,53 @@ def test_export_tmx_with_wrong_options(capfd):
     with pytest.raises(CommandError) as e:
         call_command('export', '--tmx', '--path=/language0/project0/store0.po')
     assert "--path: not allowed with argument --tmx" in str(e)
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_export_tmx_tp_rotate(capfd, tp0, media_test_dir):
+    """Export a tp"""
+    lang_code = tp0.language.code
+    prj_code = tp0.project.code
+    export_dir = os.path.join(media_test_dir, 'offline_tm')
+    call_command('export', '--tmx', '--project=%s' % prj_code,
+                 '--language=%s' % lang_code)
+    out, err = capfd.readouterr()
+
+    def get_filename():
+        rev = revision.get(tp0.__class__)(tp0.directory).get(key="stats")
+        filename = '%s.%s.%s.tmx.zip' % (
+            tp0.project.code,
+            tp0.language.code, rev[:10])
+        return os.path.join(lang_code, filename)
+
+    filename_1 = get_filename()
+    assert '%s" has been saved' % filename_1 in out
+    assert os.path.exists(os.path.join(export_dir, filename_1))
+
+    unit = tp0.stores.first().units.first()
+    unit.target_f = unit.target_f + ' CHANGED'
+    unit.save()
+    call_command('export', '--tmx', '--project=%s' % prj_code,
+                 '--language=%s' % lang_code)
+    out, err = capfd.readouterr()
+
+    filename_2 = get_filename()
+    assert '%s" has been saved' % filename_2 in out
+    assert os.path.exists(os.path.join(export_dir, filename_2))
+
+    unit = tp0.stores.first().units.first()
+    unit.target_f = unit.target_f + ' CHANGED'
+    unit.save()
+    call_command('export', '--tmx', '--rotate', '--project=%s' % prj_code,
+                 '--language=%s' % lang_code)
+    out, err = capfd.readouterr()
+
+    filename_3 = get_filename()
+    assert '%s" has been saved' % filename_3 in out
+    assert '%s" has been removed' % filename_1 in out
+    assert '%s" has been removed' % filename_2 not in out
+
+    assert not os.path.exists(os.path.join(export_dir, filename_1))
+    assert os.path.exists(os.path.join(export_dir, filename_2))
+    assert os.path.exists(os.path.join(export_dir, filename_3))


### PR DESCRIPTION
export TMX with `--rotate` option will remove all exported zipped TMX files besides two last exported files.