### PR TITLE
Separate can_create and can_obsolete permissions

### DIFF
--- a/pootle/apps/import_export/utils.py
+++ b/pootle/apps/import_export/utils.py
@@ -68,7 +68,8 @@ def import_file(f, user=None):
         store.update(store=ttk, user=user,
                      submission_type=SubmissionTypes.UPLOAD,
                      store_revision=rev,
-                     allow_add_and_obsolete=allow_add_and_obsolete)
+                     can_create=allow_add_and_obsolete,
+                     can_obsolete=allow_add_and_obsolete)
     except Exception as e:
         # This should not happen!
         logger.error("Error importing file: %s", str(e))

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1265,7 +1265,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
     def update(self, store, user=None, store_revision=None,
                submission_type=None, resolve_conflict=POOTLE_WINS,
-               allow_add_and_obsolete=True):
+               can_create=True, can_obsolete=True):
         """Update DB with units from a ttk Store.
 
         :param store: a source `Store` instance from TTK.
@@ -1273,13 +1273,14 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             synced.
         :param user: User to attribute updates to.
         :param submission_type: Submission type of saved updates.
-        :param allow_add_and_obsolete: allow to add new units
-            and make obsolete existing units
+        :param resolve_conflict: set how update conflicts should be resolved.
+        :param can_create: allow to add new units.
+        :param can_obsolete: allow to mark existing units as obsolete.
         """
         self.updater.update(
             store, user=user, store_revision=store_revision,
             submission_type=submission_type, resolve_conflict=resolve_conflict,
-            allow_add_and_obsolete=allow_add_and_obsolete)
+            can_create=can_create, can_obsolete=can_obsolete)
 
     def deserialize(self, data):
         return StoreDeserialization(self).deserialize(data)

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -236,7 +236,7 @@ class StoreUpdater(object):
 
     def update(self, store, user=None, store_revision=None,
                submission_type=None, resolve_conflict=POOTLE_WINS,
-               allow_add_and_obsolete=True):
+               can_create=True, can_obsolete=True):
         logging.debug(u"Updating %s", self.target_store.pootle_path)
         old_state = self.target_store.state
 
@@ -256,7 +256,7 @@ class StoreUpdater(object):
                     diff, update_revision,
                     user, submission_type,
                     resolve_conflict,
-                    allow_add_and_obsolete)
+                    can_create, can_obsolete)
         finally:
             if old_state < PARSED:
                 self.target_store.state = PARSED
@@ -274,10 +274,10 @@ class StoreUpdater(object):
     def update_from_diff(self, store, store_revision,
                          to_change, update_revision, user,
                          submission_type, resolve_conflict=POOTLE_WINS,
-                         allow_add_and_obsolete=True):
+                         can_create=True, can_obsolete=True):
         changes = {}
 
-        if allow_add_and_obsolete:
+        if can_create:
             # Update indexes
             for start, delta in to_change["index"]:
                 self.target_store.update_index(start=start, delta=delta)
@@ -289,7 +289,7 @@ class StoreUpdater(object):
                         unit, new_unit_index, user=user,
                         update_revision=update_revision)
             changes["added"] = len(to_change["add"])
-
+        if can_obsolete:
             # Obsolete units
             changes["obsoleted"] = self.target_store.mark_units_obsolete(
                 to_change["obsolete"],
@@ -302,7 +302,7 @@ class StoreUpdater(object):
             user=user,
             submission_type=submission_type,
             resolve_conflict=resolve_conflict,
-            change_indices=allow_add_and_obsolete,
+            change_indices=can_create,
             uids=update_dbids,
             indices=uid_index_map,
             store_revision=store_revision,

--- a/pootle/apps/pootle_translationproject/utils.py
+++ b/pootle/apps/pootle_translationproject/utils.py
@@ -216,7 +216,7 @@ class TPTool(object):
         self.update_children(
             source.directory, target.directory, update_cache=update_cache)
 
-    def update_store(self, source, target):
+    def update_store(self, source, target, can_create=True, can_obsolete=True):
         """Update a target Store from a given source Store"""
         source_revision = target.data.max_unit_revision + 1
         differ = StoreDiff(target, source, source_revision)
@@ -233,4 +233,6 @@ class TPTool(object):
             system,
             SubmissionTypes.SYSTEM,
             SOURCE_WINS,
-            True)
+            can_create=can_create,
+            can_obsolete=can_obsolete
+        )


### PR DESCRIPTION
Replace `allow_add_and_obsolete` with separate flags.