### PR TITLE
Improve unit syncing on store.update

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1250,6 +1250,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
                     translation_project_id=self.translation_project_id,
                     submitter=user,
                     unit=unit,
+                    revision=unit.revision,
                     store_id=self.id,
                     field=field,
                     type=submission_type,

--- a/pootle/apps/pootle_store/utils.py
+++ b/pootle/apps/pootle_store/utils.py
@@ -140,6 +140,7 @@ class SuggestionsReview(object):
                 'translation_project': translation_project,
                 'submitter': self.reviewer,
                 'unit': unit,
+                'revision': unit.revision,
                 'store': unit.store,
                 'field': field,
                 'type': SubmissionTypes.SUGG_ACCEPT,


### PR DESCRIPTION
When comparing upstream units, this PR takes account of whether
or not the unit has changed upstream, in as far as Pootle can tell.