### PR TITLE
Use request locale when getting timesince

### DIFF
--- a/pootle/apps/pootle_app/panels.py
+++ b/pootle/apps/pootle_app/panels.py
@@ -58,11 +58,15 @@ class ChildrenPanel(TablePanel):
             if not child.get("stats"):
                 continue
             last_created_unit = (
-                timesince(child["stats"]["last_created_unit"]["creation_time"])
+                timesince(
+                    child["stats"]["last_created_unit"]["creation_time"],
+                    locale=self.view.request_lang)
                 if child["stats"].get("last_created_unit")
                 else None)
             last_submission = (
-                timesince(child["stats"]["last_submission"]["mtime"])
+                timesince(
+                    child["stats"]["last_submission"]["mtime"],
+                    locale=self.view.request_lang)
                 if child["stats"].get("last_submission")
                 else None)
             _times[child["code"]] = (last_submission, last_created_unit)

--- a/pootle/i18n/dates.py
+++ b/pootle/i18n/dates.py
@@ -49,4 +49,6 @@ localdate = LocalDate()
 
 
 def timesince(timestamp, locale=None):
+    if locale:
+        locale = translation.to_locale(locale)
     return localdate.format_timesince(timestamp, locale=locale)


### PR DESCRIPTION
currently the times in browse tables are being localised to server lang not request lang, this fixes that

fixes #5914 