### PR TITLE
Dont use _raw_delete

### DIFF
--- a/pootle/apps/pootle_revision/utils.py
+++ b/pootle/apps/pootle_revision/utils.py
@@ -169,7 +169,7 @@ class RevisionUpdater(object):
     def update(self, keys=None):
         parents = list(self.parents.values_list("id", flat=True))
         revisions = self.get_revisions(parents, keys=keys)
-        revisions._raw_delete(revisions.db)
+        revisions.delete()
         Revision.objects.bulk_create(
             self.create_revisions(parents, keys=keys))
 


### PR DESCRIPTION
_raw_delete was used because it reduces the number of sql calls
required to bulk delete.

It might be the cause of #5730 so this commit switches to using
a normal qs.delete()