### PR TITLE
[WIP] Update README for branches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,23 @@ class PootleBuildMo(DistutilsBuild):
         self.build_mo()
 
 
+class PootleUpdateReadme(Command):
+    user_options = []
+    # --check - to see that README is what is expected
+    # --write - to write to README.rst
+    # --release - create a release ready README.rst
+    # --branch - make a branch ready README.rst
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        print(parse_long_description('README.rst'))
+
+
 class BuildChecksTemplatesCommand(Command):
     user_options = []
 
@@ -415,6 +432,7 @@ setup(
     cmdclass={
         'build_checks_templates': BuildChecksTemplatesCommand,
         'build_mo': PootleBuildMo,
+        'update_readme': PootleUpdateReadme,
         'test': PyTest,
     },
 )

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Adjust the README.rst for stable/M.N.x branches and release M.N.O tags
+
+# update-readme.sh - will do alterations on the current branch
+# update-readme.sh branch some/branch - will do branch some/branch no matter what your current branch is
+#
+# Doc links are change from latest -> stable-M.N.x only if this is a stable/* branch or a release
+
+change_type="branch"
+if [[ $# -eq 0 ]]; then
+    change_type="branch"
+elif [[ $# -eq 1 ]]; then
+    change_type=$1
+    if [[ $change_type != "branch" && $change_type != "release" ]]; then
+        echo "Valid options are 'release' or 'branch'"
+        exit 1
+    fi
+fi
+
+README=README.rst
+
+VERSION=$(python -m pootle.core.utils.version main)
+FULL_VERSION=$(python -m pootle.core.utils.version)
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ $change_type == "branch" ]]; then
+    if [[ $# -eq 2 ]]; then
+        branch=$2
+    fi
+fi
+branch_escape=$(echo $branch | sed "s#/#%2F#")
+
+docs=latest
+if [[ $branch =~ "stable/" ]]; then
+    docs="stable-"$(python -m pootle.core.utils.version docs)".x"
+fi
+
+# Release Notes
+sed -E -i "" "s#releases/[0-9]\.[0-9]\.[0-9]\.html#releases/$VERSION.html#" $README
+
+# Adjust docs away from /latest/
+sed -E -i "" "s#/pootle/en/latest/#/pootle/en/$docs/#" $README
+
+### Badge rewrites
+
+# Codecov
+if [[ $change_type == "branch" ]]; then
+    codecov_badge=$branch
+    codecov_link=$branch_escape
+else
+    codecov_badge=$FULL_VERSION
+    codecov_link=$FULL_VERSION
+fi
+sed -E -i "" "s#codecov.io/gh/translate/pootle/branch/master#codecov.io/gh/translate/pootle/branch/$codecov_link#" $README
+sed -E -i "" "s#codecov.io/github/translate/pootle\?branch=master#codecov.io/github/translate/pootle?branch=$codecov_link#" $README
+ed -E -i "" "s#shields.io/codecov/c/github/translate/pootle/master#shields.io/codecov/c/github/translate/pootle/$codecov_link#" $README
+
+# Travis - we change only the badge as we can't link directly to anything
+if [[ $change_type == "branch" ]]; then
+    travis_badge=$branch
+else
+    travis_badge=$FULL_VERSION
+fi
+sed -E -i "" "s#travis/translate/pootle/master#travis/translate/pootle/$travis_badge#" $README
+
+# Landscape
+sed -E -i "" "s#landscape.io/github/translate/pootle/master#landscape.io/github/translate/pootle/$branch#" $README
+
+# Requires.io
+if [[ $change_type == "branch" ]]; then
+    sed -E -i "" "s#requires/github/translate/pootle/master#requires/github/translate/pootle/$branch#" $README
+    sed -E -i "" "s#requirements/\?branch=master#requirements/?branch=$branch_escape#" $README
+else
+    sed -E -i "" "s#https://img.shields.io/requires/.*#https://requires.io/github/translate/pootle/requirements.svg?tag=$FULL_VERSION#" $README
+    sed -E -i "" "s#requirements/\?branch=master#requirements/?tag=$FULL_VERSION#" $README
+fi
+
+echo "Commit and push README.rst, don't forget to check that all the links actually work correctly especially for a release"


### PR DESCRIPTION
This is a bash script that updates the README.rst for branches.  Its horrible and nasty but at least it documents what we likely should do in a README update for a final release and to the README on a branch.

My idea was this:

* It should be converted to Python
* It should run as part of `setup.py` (a lot does already)
* That it should change to stable branch links when run by setup.py on a `stable/N.M.O` branch
* It should be run on stable branches to create a stable branch README, but also as part of Travis to check that it remains correct.

Putting this up so that whoever works on #5679 can do it without the linking, checking and testing that I had to do.