### PR TITLE
i18n: Escape XML tags after rendering the translation

### DIFF
--- a/pootle/templates/admin/project_fs.html
+++ b/pootle/templates/admin/project_fs.html
@@ -56,10 +56,10 @@ $(function() {
 	    </blockquote>
 	  </p>
 	  <p>
-	    {% blocktrans trimmed %}
-	    Only `&lt;language_code&gt;` is required, although it must end with
-	    `.&lt;ext&gt;`
+	    {% blocktrans asvar translation trimmed %}
+	    Only `<language_code>` is required, although it must end with `.<ext>`
 	    {% endblocktrans %}
+	    {{ translation|escape }}
 	  </p>
 	  <p>
 	    {% blocktrans trimmed %}


### PR DESCRIPTION
Translators find easier to translate XML tags than entities.