### PR TITLE
Fix handling of wrong langs in TPOfflineTMView

### DIFF
--- a/pootle/apps/pootle_translationproject/views.py
+++ b/pootle/apps/pootle_translationproject/views.py
@@ -73,7 +73,7 @@ def redirect_to_tp_on_404(f):
                     permanent=True,
                     **kwargs)
 
-            elif kwargs["dir_path"] or kwargs.get("filename", None):
+            elif kwargs.get("dir_path", None) or kwargs.get("filename", None):
                 try:
                     TranslationProject.objects.get(
                         project__code=kwargs["project_code"],

--- a/tests/import_export/export.py
+++ b/tests/import_export/export.py
@@ -50,3 +50,10 @@ def test_exported_tmx_url(client, tp0):
     response = client.get(reverse('pootle-offline-tm-tp', args=args))
     assert response.status_code == 302
     assert response.url == exported_url
+
+
+@pytest.mark.django_db
+def test_wrong_language_exported_tmx_url(client):
+    args = ('language_foo', 'project0')
+    response = client.get(reverse('pootle-offline-tm-tp', args=args))
+    assert response.status_code == 404


### PR DESCRIPTION
- Use `None`as default value for `dir_path` url kwarg;
- Add test for wrong lang for TPOfflineTMView;
