### PR TITLE
Make pootle.core.log debug only

### DIFF
--- a/pootle/core/log.py
+++ b/pootle/core/log.py
@@ -33,7 +33,7 @@ PAID_TASK_DELETED = 'PTD'
 
 def log(message):
     logger = logging.getLogger('action')
-    logger.info(message)
+    logger.debug(message)
 
 
 def action_log(*args, **kwargs):
@@ -50,7 +50,7 @@ def action_log(*args, **kwargs):
     msg = (u"%(user)s\t%(action)s\t%(lang)s\t"
            "%(unit)s\t%(path)s\t%(translation)s" % d)
 
-    logger.info(msg)
+    logger.debug(msg)
 
 
 def cmd_log(*args, **kwargs):
@@ -87,4 +87,4 @@ def store_log(*args, **kwargs):
 
     message = "%(user)s\t%(action)s\t%(path)s\t%(store)s" % d
 
-    logger.info(message)
+    logger.debug(message)

--- a/pootle/settings/25-logging.conf
+++ b/pootle/settings/25-logging.conf
@@ -53,6 +53,7 @@ LOGGING = {
             'formatter': 'rq_console',
         },
         'log_action': {
+            'level': 'DEBUG',
             'class': 'logging.handlers.WatchedFileHandler',
             'filename': os.path.join('%POOTLE_LOG_DIRECTORY%',
                                      'pootle-activity.log'),
@@ -67,7 +68,6 @@ LOGGING = {
     'loggers': {
         'action': {
             'handlers': ['log_action', 'console'],
-            'level': 'INFO',
             'propagate': True,
         },
         'django.db.backends': {

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -18,9 +18,8 @@ def test_update_stores_noargs(capfd, project0_nongnu, project1, language1):
     # speed up test by deleting objects
     project1.delete()
     language1.delete()
-    call_command('update_stores')
+    call_command('update_stores', '-v3')
     out, err = capfd.readouterr()
-
     # Store and Unit are deleted as there are no files on disk
     # SO - Store Obsolete
     assert 'system\tSO\t/language0/project0/store0.po' in err
@@ -28,7 +27,7 @@ def test_update_stores_noargs(capfd, project0_nongnu, project1, language1):
     assert 'system\tUO\tlanguage0' in err
 
     # Repeat and we should have zero output
-    call_command('update_stores')
+    call_command('update_stores', "-v3")
     out, err = capfd.readouterr()
     assert 'system\tSO' not in err
     assert 'system\tUO' not in err


### PR DESCRIPTION
this will prevent pootle from flooding stderr
