### PR TITLE
Add Schema tool API

### DIFF
--- a/pootle/core/schema/base.py
+++ b/pootle/core/schema/base.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.apps import apps
+from django.conf import settings
+from django.db import connection
+
+from .mysql import MySQLSchemaDumper
+
+
+class SchemaTool(object):
+    def __init__(self, *app_labels):
+        self.schema_dumper = None
+        if not app_labels:
+            app_labels = [app_label.split('.')[-1]
+                          for app_label in settings.INSTALLED_APPS]
+
+        self.app_configs = [apps.get_app_config(app_label)
+                            for app_label in app_labels]
+
+        with connection.cursor() as cursor:
+            if hasattr(cursor.db, "mysql_version"):
+                self.schema_dumper = MySQLSchemaDumper()
+
+    def get_app_tables(self, app_config):
+        return [model._meta.db_table
+                for model in app_config.get_models(include_auto_created=True)]
+
+    def get_defaults(self):
+        if self.schema_dumper is not None:
+            return self.schema_dumper.get_defaults()
+
+    def get_table_fields(self, table_name):
+        if self.schema_dumper is not None:
+            return self.schema_dumper.get_table_fields(table_name)
+
+    def get_table_indices(self, table_name):
+        if self.schema_dumper is not None:
+            return self.schema_dumper.get_table_indices(table_name)
+
+    def get_table_constraints(self, table_name):
+        if self.schema_dumper is not None:
+            return self.schema_dumper.get_table_constraints(table_name)

--- a/pootle/core/schema/mysql.py
+++ b/pootle/core/schema/mysql.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.db import connection
+
+
+def fetchall_asdicts(cursor, fields):
+    """Return all rows from a cursor as a dict filtered by fields."""
+
+    columns = [col[0] for col in cursor.description]
+    return [
+        dict(filter(lambda x: x[0].lower() in fields, zip(columns, row)))
+        for row in cursor.fetchall()
+    ]
+
+
+class MySQLSchemaDumper(object):
+    def get_defaults(self):
+        sql = ("SELECT default_character_set_name, default_collation_name "
+               "FROM information_schema.SCHEMATA WHERE schema_name = '%s'")
+        with connection.cursor() as cursor:
+            cursor.execute(sql % cursor.db.settings_dict['NAME'])
+            character_set, collation = cursor.fetchone()
+
+        return dict(character_set=character_set, collation=collation)
+
+    def get_table_fields(self, table_name):
+        fields = ('field', 'type', 'collation', 'key', 'extra')
+        with connection.cursor() as cursor:
+            cursor.execute("SHOW FULL COLUMNS FROM %s" % table_name)
+            result = fetchall_asdicts(cursor, fields)
+
+        return result
+
+    def get_table_indices(self, table_name):
+        fields = ('non_unique', 'key_name', 'column_name')
+        with connection.cursor() as cursor:
+            cursor.execute("SHOW INDEX FROM %s" % table_name)
+            result = fetchall_asdicts(cursor, fields)
+
+        return result
+
+    def get_table_constraints(self, table_name):
+        fields = ('table_name', 'column_name', 'constraint_name',
+                  'referenced_table_name', 'referenced_column_name')
+
+        sql = (
+            "SELECT %s from INFORMATION_SCHEMA.KEY_COLUMN_USAGE "
+            "WHERE TABLE_NAME = '%s' AND CONSTRAINT_SCHEMA = '%s'" % (
+                ', '.join(fields),
+                table_name,
+                connection.settings_dict['NAME'])
+        )
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            result = fetchall_asdicts(cursor, fields)
+
+        return result

--- a/tests/core/schema.py
+++ b/tests/core/schema.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle.core.schema.base import SchemaTool
+from pootle.core.schema.mysql import MySQLSchemaDumper
+
+
+TEST_MYSQL_SCHEMA_PARAM_NAMES = {
+    'defaults': set(['collation', 'character_set']),
+    'tables': {
+        'fields': set(['collation', 'field', 'type', 'key', 'extra']),
+        'indices': set(['key_name', 'non_unique', 'column_name']),
+        'constraints': set([
+            'referenced_table_name',
+            'table_name',
+            'referenced_column_name',
+            'constraint_name',
+            'column_name',
+        ]),
+    }
+}
+
+
+@pytest.mark.django_db
+def test_schema_tool():
+    schema_tool = SchemaTool()
+    if isinstance(schema_tool.schema_dumper, MySQLSchemaDumper):
+        defaults = schema_tool.get_defaults()
+        assert set(defaults.keys()) == TEST_MYSQL_SCHEMA_PARAM_NAMES['defaults']
+        for app_config in schema_tool.app_configs:
+            for table in schema_tool.get_app_tables(app_config):
+                row = schema_tool.get_table_fields(table)[0]
+                assert (
+                    set([x.lower() for x in row.keys()]) ==
+                    TEST_MYSQL_SCHEMA_PARAM_NAMES['tables']['fields']
+                )
+                row = schema_tool.get_table_indices(table)[0]
+                assert (
+                    set([x.lower() for x in row.keys()]) ==
+                    TEST_MYSQL_SCHEMA_PARAM_NAMES['tables']['indices']
+                )
+                row = schema_tool.get_table_constraints(table)[0]
+                assert (
+                    set([x.lower() for x in row.keys()]) ==
+                    TEST_MYSQL_SCHEMA_PARAM_NAMES['tables']['constraints']
+                )


### PR DESCRIPTION
This PR adds SchemaTool MySQL dumper class which allows to
- dump default schema character_set, collation
- all table names
- fields 
- indices
- constraints