### PR TITLE
Dont save unit in suggestion.add

### DIFF
--- a/pootle/apps/pootle_store/apps.py
+++ b/pootle/apps/pootle_store/apps.py
@@ -19,3 +19,4 @@ class PootleStoreConfig(AppConfig):
     def ready(self):
         importlib.import_module("pootle_store.getters")
         importlib.import_module("pootle_store.providers")
+        importlib.import_module("pootle_store.receivers")

--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from pootle.core.signals import update_data
+
+from pootle_store.models import Suggestion
+
+
+@receiver(post_save, sender=Suggestion)
+def handle_suggestion_added(**kwargs):
+    created = kwargs.get("created")
+    if not created:
+        return
+    store = kwargs["instance"].unit.store
+    update_data.send(store.__class__, instance=store)

--- a/pootle/apps/pootle_store/utils.py
+++ b/pootle/apps/pootle_store/utils.py
@@ -87,14 +87,12 @@ class SuggestionsReview(object):
                 dict(comment=comment,
                      user=self.reviewer)).save()
 
-    def add(self, unit, translation, user=None, touch=True):
+    def add(self, unit, translation, user=None):
         """Adds a new suggestion to the unit.
 
         :param translation: suggested translation text
         :param user: user who is making the suggestion. If it's ``None``,
             the ``system`` user will be used.
-        :param touch: whether to update the unit's timestamp after adding
-            the suggestion or not.
 
         :return: a tuple ``(suggestion, created)`` where ``created`` is a
             boolean indicating if the suggestion was successfully added.
@@ -123,8 +121,6 @@ class SuggestionsReview(object):
                 suggestion,
                 SubmissionTypes.SUGG_ADD,
                 user).save()
-            if touch:
-                unit.save()
         return (suggestion, True)
 
     def create_submission(self, suggestion, suggestion_type, user, **kwargs):

--- a/pytest_pootle/env.py
+++ b/pytest_pootle/env.py
@@ -477,8 +477,7 @@ class PootleTestEnv(object):
         suggestion, created_ = suggestion_review().add(
             unit,
             "Suggestion for %s" % (unit.target or unit.source),
-            user=member,
-            touch=False)
+            user=member)
         self._update_submission_times(unit, first_modified, created)
 
         # accept the suggestion 7 days later if not untranslated
@@ -498,8 +497,7 @@ class PootleTestEnv(object):
         suggestion2_, created_ = suggestion_review().add(
             unit,
             "Suggestion 2 for %s" % (unit.target or unit.source),
-            user=member2,
-            touch=False)
+            user=member2)
         self._update_submission_times(
             unit,
             first_modified + timedelta(days=14),


### PR DESCRIPTION
currently it has a `touch` param which is only used in tests, to suppress saving units on suggestion.add

im not sure if we need to save unit, atm its needed to expire stats, not sure what is needed, or best way
 
it does increment unit.revision/mtime but i dont see anywhere that is needed on suggestion.add

~for now this moves the reponsibility for saving the unit to the calling code~

adding a signal handler to update_data when a suggestion is added