### PR TITLE
Raise CommandError if project or language don't exist

### DIFF
--- a/pootle/apps/pootle_app/management/commands/set_filetype.py
+++ b/pootle/apps/pootle_app/management/commands/set_filetype.py
@@ -39,14 +39,8 @@ class Command(PootleCommand):
     def get_projects(self):
         if not self.projects:
             return Project.objects.all()
-        projects = []
-        for project in self.projects:
-            # ensure all projects are valid before proceeding
-            try:
-                projects.append(Project.objects.get(code=project))
-            except Project.DoesNotExist:
-                raise CommandError("Unrecognized project '%s'" % project)
-        return projects
+
+        return Project.objects.filter(code__in=self.projects)
 
     def get_filetype(self, name):
         try:

--- a/tests/commands/set_filetype.py
+++ b/tests/commands/set_filetype.py
@@ -103,8 +103,3 @@ def test_cmd_set_project_filetypes_bad():
             "set_filetype",
             "--project=project0",
             "FORMAT_DOES_NOT_EXIST")
-    with pytest.raises(CommandError):
-        call_command(
-            "set_filetype",
-            "--project=PROJECT_DOES_NOT_EXIST",
-            "po")

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -8,7 +8,7 @@
 
 import pytest
 
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 
 
 @pytest.mark.cmd
@@ -42,3 +42,12 @@ def test_update_stores_project_tree_none(capfd, project0):
     out, err = capfd.readouterr()
     assert not out
     assert not err
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_update_stores_non_existent_lang_or_proj():
+    with pytest.raises(CommandError):
+        call_command("update_stores", "--project", "non_existent_project")
+    with pytest.raises(CommandError):
+        call_command("update_stores", "--language", "non_existent_language")


### PR DESCRIPTION
Check for project or language existence in update_stores, sync_stores commands.

Fixes #6009 