### PR TITLE
Remove _auto_translated from unit

### DIFF
--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -403,3 +403,26 @@ def test_unit_syncer_locations(unit_syncer):
     newunit = syncer.convert(unit_class)
     assert newunit.getlocations() == ["FOO"]
     _test_unit_syncer(unit, newunit)
+
+
+@pytest.mark.django_db
+def test_add_autotranslated_unit(settings, store0, admin):
+    from translate.storage.statsdb import wordcount
+
+    def _test_wordcount(value):
+        return wordcount(value) - value.count('Pootle')
+
+    # monkeypatch the wordcount function
+    from pootle_store import models
+    orig_wc = models.wordcount_f
+    models.wordcount_f = _test_wordcount
+
+    unit = store0.addunit(store0.UnitClass(source_f='Pootle Pootle'),
+                          user=admin)
+
+    dbunit = store0.units.get(id=unit.id)
+    assert dbunit.state == FUZZY
+    assert dbunit.target_f == unit.source_f
+
+    # unmonkeypatch the wordcount function
+    models.wordcount_f = orig_wc


### PR DESCRIPTION
this separates out the update_wordcount method which seemed to be overloaed with auto translation logic