### PR TITLE
Remove action log

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -17,8 +17,6 @@ from django.utils import timezone
 from django.utils.translation import get_language
 
 from pootle.core.contextmanagers import update_data_after
-from pootle.core.log import (TRANSLATION_ADDED, TRANSLATION_CHANGED,
-                             TRANSLATION_DELETED)
 from pootle.core.url_helpers import split_pootle_path
 from pootle.i18n.gettext import ugettext as _
 from pootle_app.models import Directory
@@ -270,20 +268,12 @@ def unit_form_factory(language, snplurals=None, request=None):
                                      'cleared')))
 
             if new_target:
-                if old_state == UNTRANSLATED:
-                    self.cleaned_data["save_action"] = TRANSLATION_ADDED
-                else:
-                    self.cleaned_data["save_action"] = TRANSLATION_CHANGED
-
                 if is_fuzzy:
                     new_state = FUZZY
                 else:
                     new_state = TRANSLATED
             else:
                 new_state = UNTRANSLATED
-                if old_state > FUZZY:
-                    self.cleaned_data["save_action"] = TRANSLATION_DELETED
-
             if old_state not in [new_state, OBSOLETE]:
                 self._updated_fields.append((SubmissionFields.STATE,
                                              old_state, new_state))
@@ -313,8 +303,7 @@ def unit_form_factory(language, snplurals=None, request=None):
                 unit.save(
                     submitted_on=current_time,
                     submitted_by=user,
-                    changed_with=changed_with,
-                    action=self.cleaned_data.get("save_action"))
+                    changed_with=changed_with)
                 translation_project = unit.store.translation_project
                 for field, old_value, new_value in self.updated_fields:
                     if field == SubmissionFields.TARGET and suggestion:

--- a/pootle/core/log.py
+++ b/pootle/core/log.py
@@ -11,46 +11,17 @@ import logging
 
 
 # Log actions
-TRANSLATION_ADDED = 'A'
-TRANSLATION_CHANGED = 'C'
-TRANSLATION_DELETED = 'D'
-UNIT_ADDED = 'UA'
-UNIT_OBSOLETE = 'UO'
-UNIT_RESURRECTED = 'UR'
-UNIT_DELETED = 'UD'
 STORE_ADDED = 'SA'
 STORE_OBSOLETE = 'SO'
 STORE_RESURRECTED = 'SR'
 STORE_DELETED = 'SD'
 CMD_EXECUTED = 'X'
-MUTE_QUALITYCHECK = 'QM'
-UNMUTE_QUALITYCHECK = 'QU'
 SCORE_CHANGED = 'SC'
-
-PAID_TASK_ADDED = 'PTA'
-PAID_TASK_DELETED = 'PTD'
 
 
 def log(message):
     logger = logging.getLogger('action')
     logger.debug(message)
-
-
-def action_log(*args, **kwargs):
-    logger = logging.getLogger('action')
-    d = {}
-    for p in ['user', 'lang', 'action', 'unit', 'path']:
-        d[p] = kwargs.pop(p, '')
-
-    tr = kwargs.pop('translation', '')
-    tr = tr.replace("\\", "\\\\")
-    tr = tr.replace("\n", "\\\n")
-    d['translation'] = tr
-
-    msg = (u"%(user)s\t%(action)s\t%(lang)s\t"
-           "%(unit)s\t%(path)s\t%(translation)s" % d)
-
-    logger.debug(msg)
 
 
 def cmd_log(*args, **kwargs):

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -23,14 +23,11 @@ def test_update_stores_noargs(capfd, project0_nongnu, project1, language1):
     # Store and Unit are deleted as there are no files on disk
     # SO - Store Obsolete
     assert 'system\tSO\t/language0/project0/store0.po' in err
-    # UO - Unit Obsolete
-    assert 'system\tUO\tlanguage0' in err
 
     # Repeat and we should have zero output
     call_command('update_stores', "-v3")
     out, err = capfd.readouterr()
     assert 'system\tSO' not in err
-    assert 'system\tUO' not in err
 
 
 @pytest.mark.cmd


### PR DESCRIPTION
action_log duplicates the functionality provided by submissions, and increases code complexity