### PR TITLE
Add pluggable wordcount

### DIFF
--- a/pootle/apps/pootle_store/getters.py
+++ b/pootle/apps/pootle_store/getters.py
@@ -6,18 +6,34 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from pootle.core.delegate import (
     deserializers, frozen, lifecycle, review, search_backend, serializers,
-    uniqueid)
+    uniqueid, wordcount)
 from pootle.core.plugin import getter
 from pootle_config.delegate import (
     config_should_not_be_set, config_should_not_be_appended)
+from pootle_misc.util import import_func
 
 from .models import Suggestion, Unit
 from .unit.search import DBSearchBackend
-from .utils import FrozenUnit, SuggestionsReview, UnitLifecycle, UnitUniqueId
+from .utils import (
+    FrozenUnit, SuggestionsReview, UnitLifecycle, UnitUniqueId, UnitWordcount)
+
+
+wordcounter = None
+
+
+@getter(wordcount, sender=Unit)
+def get_unit_wordcount(**kwargs_):
+    global wordcounter
+
+    if not wordcounter:
+        wordcounter = UnitWordcount(
+            import_func(settings.POOTLE_WORDCOUNT_FUNC))
+    return wordcounter
 
 
 @getter(frozen, sender=Unit)

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -16,7 +16,6 @@ from collections import OrderedDict
 
 from translate.filters.decorators import Category
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models import F
@@ -28,7 +27,8 @@ from django.utils.http import urlquote
 
 from pootle.core.contextmanagers import update_data_after
 from pootle.core.delegate import (
-    data_tool, format_syncers, format_updaters, frozen, terminology_matcher)
+    data_tool, format_syncers, format_updaters, frozen, terminology_matcher,
+    wordcount)
 from pootle.core.log import (
     STORE_ADDED, STORE_DELETED, STORE_OBSOLETE, log, store_log)
 from pootle.core.models import Revision
@@ -41,7 +41,6 @@ from pootle.core.utils.aggregate import max_column
 from pootle.core.utils.multistring import PLURAL_PLACEHOLDER, SEPARATOR
 from pootle.core.utils.timezone import datetime_min, make_aware
 from pootle_misc.checks import check_names
-from pootle_misc.util import import_func
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 
@@ -144,16 +143,10 @@ class Suggestion(AbstractSuggestion):
 
 # # # # # # # # Unit # # # # # # # # # #
 
-wordcount_f = import_func(settings.POOTLE_WORDCOUNT_FUNC)
-
 
 def count_words(strings):
-    wordcount = 0
-
-    for string in strings:
-        wordcount += wordcount_f(string)
-
-    return wordcount
+    counter = wordcount.get(Unit)
+    return sum(counter.count(string) for string in strings)
 
 
 def stringcount(string):

--- a/pootle/apps/pootle_store/utils.py
+++ b/pootle/apps/pootle_store/utils.py
@@ -30,6 +30,15 @@ from .util import SuggestionStates
 User = get_user_model()
 
 
+class UnitWordcount(object):
+
+    def __init__(self, counter):
+        self.counter = counter
+
+    def count(self, string):
+        return self.counter(string)
+
+
 class DefaultUnitid(object):
 
     def __init__(self, unit):

--- a/pootle/core/delegate.py
+++ b/pootle/core/delegate.py
@@ -49,6 +49,7 @@ subcommands = Provider()
 uniqueid = Getter()
 unitid = Provider()
 url_patterns = Provider()
+wordcount = Getter()
 
 # view.context_data
 context_data = Provider(providing_args=["view", "context"])


### PR DESCRIPTION
This allows wordcount to be pluggable, loads it lazily, and by default uses the wordcount function specified in the pootle setting