### PR TITLE
Req: bump allauth pin to 0.31.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 Django~=1.10.5  # rq.filter: <1.11
 
 # Django apps
-django-allauth==0.30.0
+django-allauth==0.31.0
 django-assets==0.12
 django-bulk-update==1.1.10
 django-contact-form==1.3


### PR DESCRIPTION
Need some second opinions.  Here is the ChangeLog https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst#0310-2017-02-28

I can't see anything problematic but I fear our test coverage is slim.