### PR TITLE
Silence field.W342 warning

### DIFF
--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -180,4 +180,5 @@ SILENCED_SYSTEM_CHECKS = [
     'pootle.W005',  # DEBUG = True
     'pootle.W010',  # DEFAULT_FROM_EMAIL has default setting
     'pootle.W011',  # POOTLE_CONTACT_EMAIL has default setting
+    'fields.W342',  # pootle_store.UnitSource.unit: doesn't use OneToOneField
 ]

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -245,3 +245,7 @@ POOTLE_MT_BACKENDS = [
 TEMPLATES[0]['DIRS'] = [
     # working_path(os.path.join('custom', 'templates')),
 ]
+
+SILENCED_SYSTEM_CHECKS = [
+    'fields.W342',  # pootle_store.UnitSource.unit: doesn't use OneToOneField
+]


### PR DESCRIPTION
We don't use a OneToOneField for pootle_store.UnitSource.unit fore
technical reasons.  So silnce this to prevent us hiding other warnings.
Unfortunately we can't do this on a per field basis, so the whole check
is blocked.