### PR TITLE
Add empty _extra_scripts.html for customising JS editor init

### DIFF
--- a/pootle/templates/editor/_scripts.html
+++ b/pootle/templates/editor/_scripts.html
@@ -11,6 +11,7 @@
 {% assets "js_editor" %}
 <script type="text/javascript" src="{{ ASSET_URL }}"></script>
 {% endassets %}
+{% include 'editor/_extra_scripts.html' %}
 <script type="text/javascript">
 $(function() {
   var options = {


### PR DESCRIPTION
`_scripts.html` has been changed in #6079. 
This template is overwritten in https://github.com/translate/mozilla-pootle so there are three options:
1) update https://github.com/translate/mozilla-pootle/blob/d5be57ca5e23a9936c0edd201baad144b9b98dfb/mozilla_pootle/templates/editor/_scripts.html accordantly 
2) apply this PR which allows to overwrite empty _extra_scripts.html
3) make JS more pluggable 

I'm suggestion to go with 2) since 3) is not so easy now.