### PR TITLE
Adjust refresh_scores cli command for new scoring API

### DIFF
--- a/pootle/apps/pootle_app/management/commands/refresh_scores.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_scores.py
@@ -14,69 +14,25 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
-from pootle_statistics.models import ScoreLog
+from pootle.core.delegate import score_updater
+from pootle_store.models import Store
 
 
 class Command(BaseCommand):
-    help = "Refresh score"
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--reset',
-            action='store_true',
-            dest='reset',
-            default=False,
-            help='Reset all scores to zero',
-        )
-        parser.add_argument(
-            '--user',
-            action='append',
-            dest='users',
-            help='User to refresh',
-        )
+    help = "Refresh scores"
 
     def handle(self, **options):
         self.stdout.write('Start running of refresh_scores command...')
 
         User = get_user_model()
         users = User.objects.all()
-        if options['users']:
-            users = users.filter(username__in=options['users'])
-
         users.update(score=0)
 
-        if options['reset']:
-            scorelogs = ScoreLog.objects.all()
-            if options['users']:
-                scorelogs = scorelogs.filter(user__in=users)
-
-            scorelogs.delete()
-
-            if options['users']:
-                self.stdout.write('Scores for specified users were reset to 0.')
-            else:
-                self.stdout.write('Scores for all users were reset to 0.')
-            return
-
         start = datetime.datetime.now()
-        for user_pk, username in users.values_list("pk", "username"):
-            self.stdout.write("Processing user %s..." % username)
-            scorelog_qs = ScoreLog.objects.filter(user=user_pk) \
-                .select_related(
-                    'submission',
-                    'submission__suggestion',
-                    'submission__unit')
-            user_score = 0
-            for scorelog in scorelog_qs.iterator():
-                score_delta = scorelog.get_score_delta()
-                translated = scorelog.get_paid_wordcounts()[0]
-                user_score += score_delta
-                ScoreLog.objects.filter(id=scorelog.id).update(
-                    score_delta=score_delta,
-                    translated_wordcount=translated
-                )
-            self.stdout.write("Score for user %s set to %.3f" %
-                              (username, user_score))
-            User.objects.filter(id=user_pk).update(score=user_score)
+
+        for store in Store.objects.all().iterator():
+            updater = score_updater.get(Store)(store)
+            updater.update()
+
         end = datetime.datetime.now()
         self.stdout.write('All done in %s.' % (end - start))

--- a/tests/commands/refresh_scores.py
+++ b/tests/commands/refresh_scores.py
@@ -13,38 +13,8 @@ from django.core.management import call_command
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_refresh_scores_recalculate(capfd, admin, member):
+def test_refresh_scores(capfd):
     """Recalculate scores."""
-    # delete the 2 most prolific contribs to speed up
-    member.delete()
-    admin.delete()
     call_command('refresh_scores')
     out, err = capfd.readouterr()
-    assert 'Score for user system set to' in out
-
-
-@pytest.mark.cmd
-@pytest.mark.django_db
-def test_refresh_scores_recalculate_user(capfd):
-    """Recalculate scores for given users."""
-    call_command('refresh_scores', '--user=system')
-    out, err = capfd.readouterr()
-    assert 'Score for user system set to' in out
-
-
-@pytest.mark.cmd
-@pytest.mark.django_db
-def test_refresh_scores_reset_user(capfd):
-    """Set scores to zero for given users."""
-    call_command('refresh_scores', '--reset', '--user=system')
-    out, err = capfd.readouterr()
-    assert 'Scores for specified users were reset to 0.' in out
-
-
-@pytest.mark.cmd
-@pytest.mark.django_db
-def test_refresh_scores_reset(capfd):
-    """Set scores to zero."""
-    call_command('refresh_scores', '--reset')
-    out, err = capfd.readouterr()
-    assert 'Scores for all users were reset to 0.' in out
+    assert 'All done' in out


### PR DESCRIPTION
This PR uses new scoring API to refresh user scores.
It recalculates aggregated scores by stores and then updates user scores properly.