### PR TITLE
Replaced force_unicode by force_text

### DIFF
--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -12,7 +12,7 @@ import json
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
 from ..markup import Markup
@@ -21,14 +21,14 @@ from ..markup import Markup
 class PootleJSONEncoder(DjangoJSONEncoder):
     """Custom JSON encoder for Pootle.
 
-    This is mostly implemented to avoid calling `force_unicode` all the time on
+    This is mostly implemented to avoid calling `force_text` all the time on
     certain types of objects.
     https://docs.djangoproject.com/en/1.10/topics/serialization/#djangojsonencoder
     """
 
     def default(self, obj):
         if isinstance(obj, (Promise, Markup)):
-            return force_unicode(obj)
+            return force_text(obj)
 
         return super(PootleJSONEncoder, self).default(obj)
 

--- a/pootle/core/views/widgets.py
+++ b/pootle/core/views/widgets.py
@@ -1,5 +1,5 @@
 from django.forms import CheckboxInput, SelectMultiple
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.safestring import SafeText, mark_safe
 
@@ -45,7 +45,7 @@ class TableSelectMultiple(SelectMultiple):
         final_attrs = self.build_attrs(attrs, name=name)
         output = []
         # Normalize to strings.
-        str_values = set([force_unicode(v) for v in value])
+        str_values = set([force_text(v) for v in value])
         for i, (option_value, item) in enumerate(self.choices):
             # If an ID attribute was given, add a numeric index as a suffix,
             # so that the checkboxes don't all have the same ID attribute.
@@ -54,7 +54,7 @@ class TableSelectMultiple(SelectMultiple):
             cb = CheckboxInput(
                 final_attrs,
                 check_test=lambda value: value in str_values)
-            option_value = force_unicode(option_value)
+            option_value = force_text(option_value)
             rendered_cb = cb.render(name, option_value)
             output.append(u'<tr>')
             output.append(u'<td class="row-select">%s</td>' % rendered_cb)

--- a/pootle/middleware/errorpages.py
+++ b/pootle/middleware/errorpages.py
@@ -18,7 +18,7 @@ from django.http import Http404, HttpResponseForbidden, HttpResponseServerError
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 
 try:
     from raven.contrib.django.models import sentry_exception_handler
@@ -67,7 +67,7 @@ def handle_exception(request, exception, template_name):
     try:
         log_exception(request, exception, tb)
 
-        msg = force_unicode(exception)
+        msg = force_text(exception)
 
         if request.is_ajax():
             return JsonResponseServerError({'msg': msg})
@@ -96,7 +96,7 @@ class ErrorPagesMiddleware(MiddlewareMixin):
     """Friendlier error pages."""
 
     def process_exception(self, request, exception):
-        msg = force_unicode(exception)
+        msg = force_text(exception)
         if isinstance(exception, Http404):
             if request.is_ajax():
                 return JsonResponseNotFound({'msg': msg})


### PR DESCRIPTION
Those are aliases, but force_text is compatible with Python 3.