### PR TITLE
Create state change submissions when units are marked as obsolete

### DIFF
--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -352,6 +352,8 @@ class StoreUpdater(object):
             # Obsolete units
             changes["obsoleted"] = self.target_store.mark_units_obsolete(
                 to_change["obsolete"],
+                user,
+                submission_type,
                 update_revision)
 
         # Update units


### PR DESCRIPTION
This PR adds bulk creation of state change submissions when units are marked as obsoletes.
There is attempt here not to call `unit.save()` on every object though I'm not sure if we can do it safely.