### PR TITLE
Migration: Use replaces to prevent it from being run again

### DIFF
--- a/pootle/apps/pootle_store/migrations/0051_remove_unit_reviewed.py
+++ b/pootle/apps/pootle_store/migrations/0051_remove_unit_reviewed.py
@@ -9,6 +9,10 @@ import pootle.core.user
 
 class Migration(migrations.Migration):
 
+    replaces = [
+        ('pootle_store', '0051_remove_unit_commented'),
+    ]
+
     dependencies = [
         ('pootle_store', '0050_set_change_reviewed'),
     ]


### PR DESCRIPTION
The replaced migration landed recently, but lets prevent failures
for everybody.