### PR TITLE
Ensure POOTLE_TITLE is Unicode

### DIFF
--- a/pootle/settings/10-base.conf
+++ b/pootle/settings/10-base.conf
@@ -5,7 +5,7 @@
 # Dummy translate function so we can extract text
 _ = lambda x: x
 
-POOTLE_TITLE = _("Pootle Translation Server")
+POOTLE_TITLE = _(u"Pootle Translation Server")
 
 # Instance ID. This is to differentiate multiple instances
 # of the same app (e.g. development, staging and production).

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -14,7 +14,7 @@ need to change the extension of this file from ``.conf.sample`` to ``.conf``.
 #
 
 # Site title
-POOTLE_TITLE = 'Pootle Development Server'
+POOTLE_TITLE = u'Pootle Development Server'
 
 POOTLE_INSTANCE_ID = 'development'
 

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -15,7 +15,7 @@ need to change the extension of this file from ``.conf.sample`` to ``.conf``.
 #
 
 # Site title
-POOTLE_TITLE = 'Pootle Translation Server'
+POOTLE_TITLE = u'Pootle Translation Server'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name


### PR DESCRIPTION
This ensures that setting POOTLE_TITLE to a Unicode string will work in
emails. allauth expects this to be unicode.

Fixes #6193 

This is the initial fix.  We might want to review the other settings we have to see if any are impacted.