### PR TITLE
Various optimizations

### DIFF
--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -16,6 +16,7 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.functional import cached_property
 
+from pootle.core.contextmanagers import keep_data
 from pootle.core.delegate import data_tool
 from pootle.core.mixins import CachedTreeItem
 from pootle.core.url_helpers import get_editor_filter, split_pootle_path
@@ -433,7 +434,8 @@ def scan_languages(**kwargs):
         return
 
     for language in Language.objects.iterator():
-        tp = create_translation_project(language, instance)
+        with keep_data():
+            tp = create_translation_project(language, instance)
         if tp is not None:
             tp.update_from_disk()
 

--- a/pootle/core/contextmanagers.py
+++ b/pootle/core/contextmanagers.py
@@ -16,6 +16,7 @@ def suppress_signal(signal):
     handlers = signal.receivers
     receiver_cache = signal.sender_receivers_cache.copy()
     signal.receivers = []
+    signal.sender_receivers_cache.clear()
     try:
         yield
     finally:

--- a/pootle/core/contextmanagers.py
+++ b/pootle/core/contextmanagers.py
@@ -8,14 +8,21 @@
 
 from contextlib import contextmanager, nested
 
+from django.dispatch.dispatcher import _make_id
+
 from pootle.core.signals import update_data, update_scores
 
 
 @contextmanager
-def suppress_signal(signal):
+def suppress_signal(signal, suppress=None):
     handlers = signal.receivers
     receiver_cache = signal.sender_receivers_cache.copy()
     signal.receivers = []
+    if suppress:
+        refs = [_make_id(sup) for sup in suppress]
+        signal.receivers = [h for h in handlers if not h[0][1] in refs]
+    else:
+        signal.receivers = []
     signal.sender_receivers_cache.clear()
     try:
         yield
@@ -25,9 +32,9 @@ def suppress_signal(signal):
 
 
 @contextmanager
-def keep_data(keep=True, signals=(update_data, update_scores)):
+def keep_data(keep=True, signals=(update_data, update_scores), suppress=None):
     if keep:
-        with nested(*[suppress_signal(s) for s in signals]):
+        with nested(*[suppress_signal(s, suppress) for s in signals]):
             yield
     else:
         yield
@@ -36,7 +43,7 @@ def keep_data(keep=True, signals=(update_data, update_scores)):
 @contextmanager
 def update_data_after(sender, **kwargs):
     signals = kwargs.get("signals", [update_data, update_scores])
-    with keep_data(signals=signals):
+    with keep_data(signals=signals, suppress=kwargs.get("suppress")):
         yield
     if "kwargs" in kwargs:
         kwargs.update(kwargs.pop("kwargs"))


### PR DESCRIPTION
optimizations from debugging initdb

- adds a param to update_data_after/keep_data to allow suppressing only signals for a certain type of sender
- suppresses tp updates until after scanning disk
- suppresses score updates in initdb