### PR TITLE
Remove __repr_ as it is not needed

### DIFF
--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -172,9 +172,6 @@ class Language(models.Model, TreeItem):
     def __init__(self, *args, **kwargs):
         super(Language, self).__init__(*args, **kwargs)
 
-    def __repr__(self):
-        return u'<%s: %s>' % (self.__class__.__name__, self.fullname)
-
     def save(self, *args, **kwargs):
         # create corresponding directory object
         from pootle_app.models.directory import Directory

--- a/tests/models/language.py
+++ b/tests/models/language.py
@@ -18,7 +18,7 @@ from pootle_language.models import Language
 def test_language_repr():
     language = Language.objects.first()
     assert (
-        "<Language: %s>" % language.name
+        "<Language: %s - %s>" % (language.name, language.code)
         == repr(language))
 
 


### PR DESCRIPTION
If `__repr__` is present X.objects.all() will use it.  But in that case
you are resppnsible to create a printable string, i.e. UTF8 NOT Unicode.

Without `__repr__` X.objects.all() will use `__unicode__` and will handle
all the UTF8 decode/encode required.

Moral of the story, just don't create a `__repr__` for any objects, rather
create `__unicode__` and all will be happy and well.