### PR TITLE
Set revision for submission log events

### DIFF
--- a/pootle/apps/pootle_log/utils.py
+++ b/pootle/apps/pootle_log/utils.py
@@ -188,7 +188,8 @@ class Log(object):
                 submission.submitter,
                 submission.creation_time,
                 event_name,
-                submission)
+                submission,
+                revision=submission.revision)
 
     def get_suggestion_events(self, **kwargs):
         users = kwargs.get("users")

--- a/tests/pootle_log/log.py
+++ b/tests/pootle_log/log.py
@@ -459,6 +459,7 @@ def test_log_get_submissions(member, store0):
         assert event.timestamp == sub.creation_time
         assert event.action == event_name
         assert event.value == sub
+        assert event.revision == sub.revision
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
LogEvent revision attribute wasn't set when an object was created. This PR adds the fix.
