### PR TITLE
Add update_checks signal

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -31,7 +31,7 @@ from pootle.core.log import (
     STORE_DELETED, STORE_OBSOLETE, log, store_log)
 from pootle.core.models import Revision
 from pootle.core.search import SearchBroker
-from pootle.core.signals import update_data
+from pootle.core.signals import update_checks, update_data
 from pootle.core.url_helpers import (
     get_editor_filter, split_pootle_path, to_tp_relative_path)
 from pootle.core.utils import dateformat
@@ -714,7 +714,8 @@ class Unit(AbstractUnit):
         else:
             self.state = UNTRANSLATED
 
-        self.update_qualitychecks(keep_false_positives=True)
+        update_checks.send(self.__class__, instance=self,
+                           keep_false_positives=True)
         self.index = self.store.max_index() + 1
 
     def istranslated(self):

--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -14,7 +14,7 @@ from django.utils.encoding import force_bytes
 
 from pootle.core.delegate import lifecycle, uniqueid
 from pootle.core.models import Revision
-from pootle.core.signals import update_data
+from pootle.core.signals import update_checks, update_data
 
 from .constants import FUZZY, TRANSLATED, UNTRANSLATED
 from .models import Suggestion, Unit, UnitChange, UnitSource
@@ -122,6 +122,13 @@ def handle_unit_change(**kwargs):
         return
     new_untranslated = (created and unit.state == UNTRANSLATED)
     if not new_untranslated:
-        unit.update_qualitychecks()
+        update_checks.send(unit.__class__, instance=unit)
     if unit.istranslated():
         unit.update_tmserver()
+
+
+@receiver(update_checks, sender=Unit)
+def handle_unit_checks(**kwargs):
+    unit = kwargs["instance"]
+    keep_false_positives = kwargs.get("keep_false_positives", False)
+    unit.update_qualitychecks(keep_false_positives=keep_false_positives)

--- a/pootle/core/signals.py
+++ b/pootle/core/signals.py
@@ -13,6 +13,9 @@ from django.dispatch import Signal
 changed = Signal(
     providing_args=["instance", "updates"],
     use_caching=True)
+update_checks = Signal(
+    providing_args=["instance", "keep_false_positives"],
+    use_caching=True)
 update_data = Signal(providing_args=["instance"], use_caching=True)
 filetypes_changed = Signal(
     providing_args=["instance", "filetype"],

--- a/tests/pootle_data/data_updater_store.py
+++ b/tests/pootle_data/data_updater_store.py
@@ -18,6 +18,7 @@ from django.db.models import Max
 
 from pootle.core.contextmanagers import update_data_after
 from pootle.core.delegate import review
+from pootle.core.signals import update_checks
 from pootle_data.store_data import StoreDataTool, StoreDataUpdater
 from pootle_statistics.models import Submission
 from pootle_store.constants import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
@@ -260,7 +261,8 @@ def test_data_store_critical_checks(store0):
     other_qc.save()
     # trigger refresh
     with update_data_after(unit.store):
-        unit.update_qualitychecks(keep_false_positives=True)
+        update_checks.send(unit.__class__, instance=unit,
+                           keep_false_positives=True)
     assert (
         store0.data.critical_checks
         == check_count + unit_critical - 1)

--- a/tests/pootle_data/data_updater_tp.py
+++ b/tests/pootle_data/data_updater_tp.py
@@ -14,6 +14,7 @@ from django.db.models import Max
 
 from pootle.core.contextmanagers import update_data_after
 from pootle.core.delegate import review
+from pootle.core.signals import update_checks
 from pootle_data.tp_data import TPDataTool, TPDataUpdater
 from pootle_store.constants import FUZZY, OBSOLETE, TRANSLATED, UNTRANSLATED
 from pootle_store.models import Suggestion
@@ -255,7 +256,8 @@ def test_data_tp_qc_stats(tp0):
     other_qc.save()
     # trigger refresh
     with update_data_after(unit.store):
-        unit.update_qualitychecks(keep_false_positives=True)
+        update_checks.send(unit.__class__, instance=unit,
+                           keep_false_positives=True)
     store_data = tp0.data_tool.updater.get_store_data()
     tp0.data.refresh_from_db()
     assert (


### PR DESCRIPTION
This PR adds `update_checks` signal which is sent instead of calling `unit.update_qualitychecks` method.