### PR TITLE
Cleanup: fix for django.conf.settings in test env

### DIFF
--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -18,11 +18,12 @@ from pytest_pootle.env import PootleTestEnv
 
 
 @pytest.fixture(autouse=True)
-def test_timing(request, settings, log_timings):
+def test_timing(request, log_timings):
     from django.db import reset_queries
 
     if not request.config.getoption("--debug-tests"):
         return
+    from django.conf import settings
     settings.DEBUG = True
     reset_queries()
     start = time.time()


### PR DESCRIPTION
this allows all tests to be successfully run with `debug-tests`