### PR TITLE
Cache entire site-packages dir in travis workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ cache:
     - $HOME/virtualenv/python2.7.9/lib
     - $HOME/virtualenv/python2.7/bin
 before_install:
-    - cp -a $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/py/ $HOME/py-workaround/
-    - cp -a $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/_pytest/ $HOME/_pytest-workaround/
-    - cp -a $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/pytest.pyc $HOME/pytest_pyc-workaround
+    - cp -a $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/ $HOME/py-workaround/
 install:
   - if [[ ( "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "stable/*" ) && "$TRAVIS_PULL_REQUEST" == "false" ]]; then upgrade="--upgrade"; fi;
       pip install 'setuptools>=18.5';
@@ -53,11 +51,8 @@ before_cache:
   # travis is so dumb - https://github.com/travis-ci/travis-ci/issues/4873
   - pip uninstall py pytest -y
   - pip install py==1.4.26 pytest==2.6.4
-  - rm -rf $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/py/
-  - rm -rf $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/_pytest/
-  - cp -a $HOME/py-workaround/ $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/py/
-  - cp -a  $HOME/pytest_pyc-workaround $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/pytest.pyc
-  - cp -a $HOME/_pytest-workaround/ $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/_pytest/
+  - pyclean $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/
+  - cp -a $HOME/py-workaround/* $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages/
   # Force rebuilds by removing cache for 'master' and 'stable/*' builds
   - if [[ ( "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "stable/*" ) && "$TRAVIS_PULL_REQUEST" == "false" ]]; then rm -rf pootle/static/js/node_modules/* pootle/assets/* pootle/assets/.webassets-cache;  fi
 services:


### PR DESCRIPTION
existing cache workaround to prevent travis uploading nochange on every test run seems to be broke - this attempts to fix it...