### PR TITLE
Fix: dont save store.data if no change

### DIFF
--- a/pootle/apps/pootle_checks/utils.py
+++ b/pootle/apps/pootle_checks/utils.py
@@ -12,7 +12,6 @@ from translate.filters import checks
 from translate.filters.decorators import Category
 from translate.lang import data
 
-from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.lru_cache import lru_cache
 
@@ -240,7 +239,6 @@ class QualityCheckUpdater(object):
             self.check_names)
         if checker.update():
             self.expire_store_cache(unit.store)
-            self.units.filter(id=unit.id).update(mtime=timezone.now())
             return True
         return False
 

--- a/pootle/apps/pootle_data/utils.py
+++ b/pootle/apps/pootle_data/utils.py
@@ -230,7 +230,7 @@ class DataUpdater(object):
         if not hasattr(self.data, k):
             return
         existing_value = getattr(self.data, k)
-        if existing_value is None or existing_value != v:
+        if existing_value != v:
             setattr(self.data, k, v)
             return True
         return False


### PR DESCRIPTION
this prevents setting data and triggering other updates unnecessarily

also removes mtime setting in checker, as this doesnt really serve any purpose and is not consistent with other behaviour