### PR TITLE
Add update_data_after param to checks updater

### DIFF
--- a/pootle/apps/pootle_app/management/commands/calculate_checks.py
+++ b/pootle/apps/pootle_app/management/commands/calculate_checks.py
@@ -35,7 +35,9 @@ class Command(PootleCommand):
         update_checks.send(
             TranslationProject,
             check_names=check_names,
-            instance=translation_project)
+            instance=translation_project,
+            clear_unknown=True,
+            update_data_after=True)
 
     def handle_all_stores(self, translation_project, **options):
         self.stdout.write(u"Running %s for %s" %

--- a/pootle/apps/pootle_checks/receivers.py
+++ b/pootle/apps/pootle_checks/receivers.py
@@ -49,4 +49,6 @@ def tp_checks_handler(**kwargs):
     tp = kwargs["instance"]
     check_updater.get(TranslationProject)(
         translation_project=tp,
-        check_names=kwargs.get("check_names")).update()
+        check_names=kwargs.get("check_names")).update(
+            clear_unknown=kwargs.get("clear_unknown", False),
+            update_data_after=kwargs.get("update_data_after", False))

--- a/tests/pootle_checks/checks.py
+++ b/tests/pootle_checks/checks.py
@@ -28,7 +28,7 @@ def test_tp_qualitycheck_updater(tp0):
     check = checks[0]
     unit = check.unit
     unit.__class__.objects.filter(pk=unit.pk).update(state=OBSOLETE)
-    updater.update()
+    updater.update(update_data_after=True)
     assert check.__class__.objects.filter(pk=check.pk).count() == 0
     new_revision = tp0.directory.revisions.filter(
         key="stats").values_list("value", flat=True).first()


### PR DESCRIPTION
we only really want to update data from this api when its called from the cli - so its not the default

also adds a flag for calling clear unknown checks - altho im thinking we might want to get rid of this as its not necessary and doesnt record store change correctly