### PR TITLE
Fix: dont count obsolete units as un/fuzzied

### DIFF
--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -298,10 +298,8 @@ class StoreUpdater(object):
         finally:
             if old_state < PARSED:
                 self.target_store.state = PARSED
-            else:
-                self.target_store.state = old_state
+                self.target_store.save()
             has_changed = any(x > 0 for x in changes.values())
-            self.target_store.save()
             if has_changed:
                 log(u"[update] %s units in %s [revision: %d]"
                     % (get_change_str(changes),

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -174,8 +174,15 @@ class UnitUpdater(object):
     def state_updated(self):
         # `fuzzy` state change is checked here.
         # `translated` and `obsolete` states are handled separately.
-        return (self.newunit
-                and self.unit.isfuzzy() != self.newunit.isfuzzy())
+        if not self.newunit:
+            return False
+        source_fuzzy = (
+            self.newunit.isfuzzy()
+            and not self.newunit.isobsolete())
+        target_fuzzy = (
+            self.unit.isfuzzy()
+            and not self.newunit.isobsolete())
+        return source_fuzzy != target_fuzzy
 
     @cached_property
     def target_updated(self):


### PR DESCRIPTION
this was causing units to (unsuccessfully) be repeatedly updated