### PR TITLE
Updates cleanup/fix

### DIFF
--- a/pootle/apps/pootle_revision/receivers.py
+++ b/pootle/apps/pootle_revision/receivers.py
@@ -51,7 +51,7 @@ def handle_directory_revision_update(**kwargs):
     else:
         updater(
             object_list=kwargs.get("object_list"),
-            paths=kwargs.get("object_list")).update(
+            paths=kwargs.get("paths")).update(
                 keys=kwargs.get("keys"))
 
 


### PR DESCRIPTION
fix for passing through argument to revisions util correctly 

removed tp updater, in favour of `update_tp_after`