### PR TITLE
Bulk operations

### DIFF
--- a/pootle/core/contextmanagers.py
+++ b/pootle/core/contextmanagers.py
@@ -8,10 +8,24 @@
 
 from contextlib import contextmanager, nested
 
+from django.dispatch import receiver
 from django.dispatch.dispatcher import _make_id
 
 from pootle.core.signals import (
+    create, delete, update,
     update_checks, update_data, update_revisions, update_scores)
+
+
+class BulkUpdated(object):
+    create = None
+    delete_qs = None
+    delete = None
+    delete_ids = set()
+    update_qs = None
+    update = None
+    updates = None
+    update_fields = set()
+    update_objects = None
 
 
 @contextmanager
@@ -44,4 +58,122 @@ def keep_data(keep=True, signals=None, suppress=None):
         with nested(*[suppress_signal(s, suppress) for s in signals]):
             yield
     else:
+        yield
+
+
+def _create_handler(updated, **kwargs):
+    to_create = kwargs.get("objects") or []
+    to_create += (
+        [kwargs.get("instance")]
+        if kwargs.get("instance")
+        else [])
+    if to_create:
+        updated.create = (updated.create or []) + to_create
+
+
+def _delete_handler(updated, **kwargs):
+    if "objects" in kwargs:
+        if updated.delete_qs is None:
+            updated.delete_qs = kwargs["objects"]
+        else:
+            updated.delete_qs = (
+                updated.delete_qs
+                | kwargs["objects"])
+    if "instance" in kwargs:
+        updated.delete_ids.add(kwargs["instance"].pk)
+
+
+def _update_handler(updated, **kwargs):
+    if "update_fields" in kwargs:
+        # update these fields (~only)
+        updated.update_fields = (
+            updated.update_fields
+            | kwargs["update_fields"])
+    if "updates" in kwargs:
+        # dict of pk: dict(up=date)
+        updated.updates = (
+            kwargs["updates"]
+            if updated.updates is None
+            else (updated.updates.update(kwargs["updates"])
+                  or updated.updates))
+    if "objects" in kwargs:
+        updated.update_objects = (
+            kwargs["objects"]
+            if updated.update_objects is None
+            else (updated.update_objects
+                  + kwargs["objects"]))
+    if "instance" in kwargs:
+        updated.update_objects = (
+            [kwargs["instance"]]
+            if updated.update_objects is None
+            else (updated.update_objects
+                  + [kwargs["instance"]]))
+
+
+def _callback_handler(model, updated):
+
+    # delete
+    to_delete = None
+    if updated.delete_ids is not None:
+        to_delete = model.objects.filter(
+            pk__in=updated.delete_ids)
+    if updated.delete_qs is not None:
+        to_delete = (
+            updated.delete_qs
+            if to_delete is None
+            else to_delete | updated.delete_qs)
+    if to_delete is not None:
+        delete.send(
+            model,
+            objects=to_delete)
+
+    # create
+    if updated.create is not None:
+        create.send(
+            model,
+            objects=updated.create)
+
+    # update
+    should_update = (
+        updated.update_objects is not None
+        or updated.updates is not None)
+    if should_update:
+        update.send(
+            model,
+            objects=updated.update_objects,
+            updates=updated.updates,
+            update_fields=updated.update_fields)
+
+
+@contextmanager
+def bulk_context(model=None, **kwargs):
+    updated = BulkUpdated()
+    signals = [create, delete, update]
+    create_handler = kwargs.pop("create", _create_handler)
+    delete_handler = kwargs.pop("delete", _delete_handler)
+    update_handler = kwargs.pop("update", _update_handler)
+    callback_handler = kwargs.pop("callback", _callback_handler)
+
+    with keep_data(signals=signals, suppress=(model, )):
+
+        @receiver(create, sender=model)
+        def handle_create(**kwargs):
+            create_handler(updated, **kwargs)
+
+        @receiver(delete, sender=model)
+        def handle_delete(**kwargs):
+            delete_handler(updated, **kwargs)
+
+        @receiver(update, sender=model)
+        def handle_update(**kwargs):
+            update_handler(updated, **kwargs)
+        yield
+    callback_handler(model, updated)
+
+
+@contextmanager
+def bulk_operations(model=None, models=None, **kwargs):
+    if models is None and model is not None:
+        models = [model]
+    with nested(*(bulk_context(m, **kwargs) for m in models)):
         yield

--- a/pootle/core/signals.py
+++ b/pootle/core/signals.py
@@ -13,6 +13,15 @@ from django.dispatch import Signal
 changed = Signal(
     providing_args=["instance", "updates"],
     use_caching=True)
+create = Signal(
+    providing_args=["instance", "objects"],
+    use_caching=True)
+delete = Signal(
+    providing_args=["instance", "objects"],
+    use_caching=True)
+update = Signal(
+    providing_args=["instance", "objects"],
+    use_caching=True)
 update_checks = Signal(
     providing_args=["instance", "keep_false_positives"],
     use_caching=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ filterwarnings =
     # loading the deprecated module.
     ignore:.*account_tags.*
     ignore:.*socialaccount_tags.*
+    ignore:With-statements now directly support multiple context managers:DeprecationWarning:.*contextmanagers
 
 [pydocstyle]
 inherit=false

--- a/tests/core/contextmanagers.py
+++ b/tests/core/contextmanagers.py
@@ -10,9 +10,16 @@ import pytest
 
 from django.dispatch import receiver
 
-from pootle.core.contextmanagers import keep_data
-from pootle.core.signals import update_data
-from pootle_store.models import Store
+from pootle.core.contextmanagers import bulk_operations, keep_data
+from pootle.core.signals import create, delete, update, update_data
+from pootle_data.models import StoreChecksData
+from pootle_store.models import QualityCheck, Store, Unit
+
+
+def qs_match(qs1, qs2):
+    return (
+        list(qs1.order_by("id").values_list("id", flat=True))
+        == list(qs2.order_by("id").values_list("id", flat=True)))
 
 
 @pytest.mark.django_db
@@ -38,3 +45,254 @@ def test_contextmanager_keep_data(store0, no_update_data_):
     # works again now
     update_data.send(Store, instance=store0)
     assert result == [store0]
+
+
+def _create_qc_events(unit):
+    create_instances = [
+        QualityCheck(
+            name=("Foo%s" % i), category=2, unit=unit)
+        for i in range(0, 3)]
+    for instance in create_instances:
+        create.send(
+            QualityCheck,
+            instance=instance)
+    create_objects = [
+        QualityCheck(
+            name=("Bar%s" % i),
+            category=2,
+            unit=unit)
+        for i in range(0, 3)]
+    create_more_objects = [
+        QualityCheck(
+            name=("Baz%s" % i),
+            category=2,
+            unit=unit)
+        for i in range(0, 3)]
+    create.send(
+        QualityCheck,
+        objects=create_objects)
+    create.send(
+        QualityCheck,
+        objects=create_more_objects)
+    return create_instances + create_objects + create_more_objects
+
+
+def _create_data_events(unit):
+    create_instances = [
+        StoreChecksData(
+            store=unit.store,
+            name="check-foo-%s" % i,
+            count=i * 23)
+        for i in range(0, 3)]
+    for instance in create_instances:
+        # add instances - these shouldnt appear in bulk operation
+        create.send(
+            StoreChecksData,
+            instance=instance)
+    create_objects = [
+        StoreChecksData(
+            store=unit.store,
+            name="check-bar-%s" % i,
+            count=i * 23)
+        for i in range(0, 3)]
+    create_more_objects = [
+        StoreChecksData(
+            store=unit.store,
+            name="check-baz-%s" % i,
+            count=i * 23)
+        for i in range(0, 3)]
+    # add 2 lots of objects
+    create.send(
+        StoreChecksData,
+        objects=create_objects)
+    create.send(
+        StoreChecksData,
+        objects=create_more_objects)
+    return create_instances + create_objects + create_more_objects
+
+
+@pytest.mark.django_db
+def test_contextmanager_bulk_operations(store0):
+    unit = store0.units.first()
+
+    class Update(object):
+        data_created = None
+        qc_created = None
+        data_called = 0
+        qc_called = 0
+
+    with keep_data(signals=[create]):
+        updated = Update()
+
+        @receiver(create, sender=QualityCheck)
+        def handle_qc_create(**kwargs):
+            assert "instance" not in kwargs
+            updated.qc_created = kwargs["objects"]
+            updated.qc_called += 1
+
+        @receiver(create, sender=StoreChecksData)
+        def handle_data_create(**kwargs):
+            updated.data_called += 1
+            if "objects" in kwargs:
+                updated.data_created = kwargs["objects"]
+            else:
+                assert "instance" in kwargs
+
+        with bulk_operations(QualityCheck):
+            qc_creates = _create_qc_events(unit)
+            data_creates = _create_data_events(unit)
+        assert updated.qc_created == qc_creates
+        assert updated.qc_called == 1
+        assert updated.data_created != data_creates
+        assert updated.data_called == 5
+
+        # nested update
+        updated = Update()
+        with bulk_operations(QualityCheck):
+            with bulk_operations(QualityCheck):
+                qc_creates = _create_qc_events(unit)
+                data_creates = _create_data_events(unit)
+        assert updated.qc_created == qc_creates
+        assert updated.qc_called == 1
+        assert updated.data_created != data_creates
+        assert updated.data_called == 5
+
+        # nested update - different models
+        updated = Update()
+        with bulk_operations(StoreChecksData):
+            with bulk_operations(QualityCheck):
+                qc_creates = _create_qc_events(unit)
+                data_creates = _create_data_events(unit)
+        assert updated.qc_created == qc_creates
+        assert updated.qc_called == 1
+        assert updated.data_created == data_creates
+        assert updated.data_called == 1
+
+        updated = Update()
+        with bulk_operations(models=(StoreChecksData, QualityCheck)):
+            qc_creates = _create_qc_events(unit)
+            data_creates = _create_data_events(unit)
+        assert updated.qc_created == qc_creates
+        assert updated.qc_called == 1
+        assert updated.data_created == data_creates
+        assert updated.data_called == 1
+
+
+@pytest.mark.django_db
+def test_contextmanager_bulk_ops_delete(tp0, store0):
+    unit = store0.units.first()
+    store1 = tp0.stores.filter(name="store1.po").first()
+    store2 = tp0.stores.filter(name="store2.po").first()
+
+    class Update(object):
+        store_deleted = None
+        unit_deleted = None
+        store_called = 0
+        unit_called = 0
+
+    with keep_data(signals=[delete]):
+        updated = Update()
+
+        @receiver(delete, sender=Unit)
+        def handle_unit_delete(**kwargs):
+            assert "instance" not in kwargs
+            updated.unit_deleted = kwargs["objects"]
+            updated.unit_called += 1
+
+        @receiver(delete, sender=Store)
+        def handle_store_delete(**kwargs):
+            updated.store_called += 1
+            if "objects" in kwargs:
+                updated.store_deleted = kwargs["objects"]
+            else:
+                assert "instance" in kwargs
+
+        with bulk_operations(Unit):
+            delete.send(Unit, instance=unit)
+            delete.send(Unit, objects=store1.unit_set.all())
+            delete.send(Unit, objects=store2.unit_set.all())
+            delete.send(Store, instance=store0)
+            delete.send(
+                Store,
+                objects=store1.translation_project.stores.filter(
+                    id=store1.id))
+            delete.send(
+                Store,
+                objects=store2.translation_project.stores.filter(
+                    id=store2.id))
+        assert updated.unit_called == 1
+        assert qs_match(
+            updated.unit_deleted,
+            (store0.unit_set.filter(id=unit.id)
+             | store1.unit_set.all()
+             | store2.unit_set.all()))
+        assert updated.store_called == 3
+
+
+@pytest.mark.django_db
+def test_contextmanager_bulk_ops_update(tp0, store0):
+    unit = store0.units.first()
+    store1 = tp0.stores.filter(name="store1.po").first()
+    store2 = tp0.stores.filter(name="store2.po").first()
+
+    class Update(object):
+        store_updated = None
+        unit_updated = None
+        store_called = 0
+        unit_called = 0
+        unit_updates = None
+
+    with keep_data(signals=[update]):
+        updated = Update()
+
+        @receiver(update, sender=Unit)
+        def handle_unit_update(**kwargs):
+            assert "instance" not in kwargs
+            updated.unit_updated = kwargs["objects"]
+            updated.unit_called += 1
+            updated.unit_update_fields = kwargs.get("update_fields")
+            updated.unit_updates = kwargs.get("updates")
+
+        @receiver(update, sender=Store)
+        def handle_store_update(**kwargs):
+            updated.store_called += 1
+            if "objects" in kwargs:
+                updated.store_updated = kwargs["objects"]
+            else:
+                assert "instance" in kwargs
+
+        with bulk_operations(Unit):
+            update.send(Unit, instance=unit)
+            update.send(Unit, objects=list(store1.unit_set.all()))
+            update.send(Unit, objects=list(store2.unit_set.all()))
+            update.send(Unit, update_fields=set(["foo", "bar"]))
+            update.send(Unit, update_fields=set(["bar", "baz"]))
+            update.send(Store, instance=store0)
+            update.send(
+                Store,
+                objects=list(store1.translation_project.stores.filter(
+                    id=store1.id)))
+            update.send(
+                Store,
+                objects=list(store2.translation_project.stores.filter(
+                    id=store2.id)))
+        assert updated.unit_called == 1
+        assert isinstance(updated.unit_updated, list)
+        assert qs_match(
+            Unit.objects.filter(
+                id__in=(
+                    un.id for un in updated.unit_updated)),
+            (store0.unit_set.filter(id=unit.id)
+             | store1.unit_set.all()
+             | store2.unit_set.all()))
+        assert updated.store_called == 3
+        assert updated.unit_update_fields == set(["bar", "baz", "foo"])
+
+        updated = Update()
+        d1 = {23: dict(foo=True), 45: dict(bar=False)}
+        d2 = {67: dict(baz=89)}
+        with bulk_operations(Unit):
+            update.send(Unit, updates=d1)
+            update.send(Unit, updates=d2)
+        d1.update(d2)
+        assert updated.unit_updates == d1


### PR DESCRIPTION
Adds signals for create, delete and update

Code can use these instead of directly creating, deleting or saving objects

If the code is within a `bulk_operations` context the creating/deleting/updating will be done using bulk operations