### PR TITLE
Add bulk_operations in pytest env

### DIFF
--- a/pootle/apps/pootle_language/teams.py
+++ b/pootle/apps/pootle_language/teams.py
@@ -75,6 +75,8 @@ class LanguageTeam(object):
             state__name="pending",
             unit__state__gt=OBSOLETE,
             unit__store__translation_project__language=self.language)
+        suggestions = suggestions.exclude(
+            unit__store__translation_project__project__disabled=True)
         suggestions = suggestions.select_related(
             "unit",
             "unit__store",

--- a/tests/pootle_language/teams.py
+++ b/tests/pootle_language/teams.py
@@ -156,7 +156,8 @@ def test_language_team_suggestions(language0):
     suggestions = Suggestion.objects.filter(
         state__name="pending",
         unit__state__gt=OBSOLETE,
-        unit__store__translation_project__language=language0)
+        unit__store__translation_project__language=language0).exclude(
+            unit__store__translation_project__project__disabled=True)
     assert (
         list(team.suggestions)
         == list(suggestions.order_by("-creation_time", "-pk")))


### PR DESCRIPTION
cleans up obj creation in test env and uses update_tp_after to speed up