### PR TITLE
Remove unused and dead code from update_stores and PootleCommand

### DIFF
--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -87,12 +87,6 @@ class PootleCommand(BaseCommand):
         if hasattr(self, "handle_all_stores"):
             logging.info(u"Running %s over %s's files", self.name, tp)
             self.handle_all_stores(tp, **options)
-        elif hasattr(self, "handle_store"):
-            store_query = tp.stores.live()
-            for store in store_query.iterator():
-                logging.info(u"Running %s over %s",
-                             self.name, store.pootle_path)
-                self.handle_store(store, **options)
 
     def check_projects(self, project_codes):
         existing_projects = Project.objects.filter(

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -58,18 +58,6 @@ class Command(PootleCommand):
 
         return False
 
-    def handle_store(self, store, **options):
-        if not store.file:
-            return
-        disk_mtime = store.get_file_mtime()
-        if not options["force"] and disk_mtime == store.file_mtime:
-            # The file on disk wasn't changed since the last sync
-            logging.debug(u"File didn't change since last sync, "
-                          "skipping %s", store.pootle_path)
-            return
-
-        store.update_from_disk(overwrite=options["overwrite"])
-
     def handle_all(self, **options):
         scan_translation_projects(languages=self.languages,
                                   projects=self.projects)


### PR DESCRIPTION
- `handle_store` in update_stores is not used and contain dead code (using already removed method);
- so `handle_store` method is not used at all;
