### PR TITLE
Test opti: remove pre-deletion from tests

### DIFF
--- a/tests/commands/sync_stores.py
+++ b/tests/commands/sync_stores.py
@@ -19,8 +19,6 @@ from pootle_store.models import Store
 @pytest.mark.django_db
 def test_sync_stores_noargs(capfd, project0, project1):
     """Site wide sync_stores"""
-    project0.delete()
-    project1.delete()
     capfd.readouterr()
     call_command('sync_stores')
     out, err = capfd.readouterr()

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -15,9 +15,6 @@ from django.core.management import CommandError, call_command
 @pytest.mark.django_db
 def test_update_stores_noargs(capfd, project0_nongnu, project1, language1):
     """Site wide update_stores"""
-    # speed up test by deleting objects
-    project1.delete()
-    language1.delete()
     call_command('update_stores', '-v3')
     out, err = capfd.readouterr()
     # Store and Unit are deleted as there are no files on disk


### PR DESCRIPTION
once this sped up some of the tests, but no longer