### PR TITLE
Add proper handling for units in store check events

### DIFF
--- a/pootle/apps/pootle_checks/utils.py
+++ b/pootle/apps/pootle_checks/utils.py
@@ -402,7 +402,6 @@ class StoreQCUpdater(QualityCheckUpdater):
             unit["store__translation_project__language__code"] = lang_code
             if self.update_translated_unit(unit, checker=checker):
                 updated_count += 1
-        # clear the cache of the remaining Store
         return updated_count
 
 

--- a/pootle/apps/pootle_translationproject/contextmanagers.py
+++ b/pootle/apps/pootle_translationproject/contextmanagers.py
@@ -59,7 +59,7 @@ def _handle_update_stores(sender, updated):
                 for to_check in updated.checks.values():
                     store = to_check["store"]
                     units = (
-                        [unit.id for unit in to_check["units"]]
+                        [unit for unit in to_check["units"]]
                         if to_check["units"]
                         else None)
                     update_checks.send(
@@ -151,9 +151,10 @@ def update_tp_after(sender, **kwargs):
             units = None
             if isinstance(kwargs.get("instance"), Store):
                 store = kwargs["instance"]
+                units = set(kwargs.get("units") or [])
             else:
                 store = kwargs["instance"].store
-                units = set([kwargs["instance"]])
+                units = set([kwargs["instance"].id])
             updated.checks[store.id] = updated.checks.get(
                 store.id,
                 dict(store=store, units=set()))


### PR DESCRIPTION
atm after store update, all units are checked - this opti means only changed units are checked

fixes #6340 