### PR TITLE
Various optimizations

### DIFF
--- a/pootle/apps/pootle_format/utils.py
+++ b/pootle/apps/pootle_format/utils.py
@@ -10,6 +10,8 @@ import logging
 import os
 from collections import OrderedDict
 
+from django.utils.functional import cached_property
+
 from pootle_fs.utils import PathFilter
 
 from .exceptions import UnrecognizedFiletype
@@ -60,19 +62,19 @@ class ProjectFiletypes(object):
                self.project.fullname,
                ", ".join(str(ft) for ft in self.filetypes)))
 
-    @property
+    @cached_property
     def filetype_extensions(self):
         return list(
             self.filetypes.values_list(
                 "extension__name", flat=True))
 
-    @property
+    @cached_property
     def template_extensions(self):
         return list(
             self.filetypes.values_list(
                 "template_extension__name", flat=True))
 
-    @property
+    @cached_property
     def valid_extensions(self):
         """this is the equiv of combining 2 sets"""
         exts = []
@@ -92,6 +94,16 @@ class ProjectFiletypes(object):
                 "Adding filetype '%s' to project '%s'",
                 filetype, self.project)
             self.project.filetypes.add(filetype)
+            self.clear_cache()
+
+    def clear_cache(self):
+        cached = [
+            "filetype_extensions",
+            "template_extensions",
+            "valid_extensions"]
+        for cachetype in cached:
+            if cachetype in self.__dict__:
+                del self.__dict__[cachetype]
 
     def set_store_filetype(self, store, filetype):
         """Sets a Store to given filetype

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -547,6 +547,7 @@ def dummy_store_syncer():
 def store0(tp0):
     stores = tp0.stores.select_related(
         "data",
+        "parent",
         "filetype__extension",
         "filetype__template_extension")
     return stores.get(name="store0.po")

--- a/pytest_pootle/fixtures/models/translation_project.py
+++ b/pytest_pootle/fixtures/models/translation_project.py
@@ -64,21 +64,21 @@ def tp_checker_tests(request, english, checkers):
 @pytest.fixture
 def templates_project0(request, templates, project0):
     """Require the templates/project0/ translation project."""
-    from pootle_translationproject.models import TranslationProject
-
-    return TranslationProject.objects.get(
-        language=templates, project=project0)
+    tps = project0.translationproject_set.select_related(
+        "data",
+        "directory")
+    template_tp = tps.get(language=templates)
+    template_tp.language = templates
+    return template_tp
 
 
 @pytest.fixture
 def tp0(language0, project0):
     """Require English Project0."""
-    from pootle_translationproject.models import TranslationProject
-
-    tp0 = TranslationProject.objects.select_related("data").get(
-        language=language0,
-        project=project0)
-    tp0.project = project0
+    tps = project0.translationproject_set.select_related(
+        "data",
+        "directory")
+    tp0 = tps.get(language=language0)
     tp0.language = language0
     return tp0
 

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -32,7 +32,8 @@ def test_update_stores_noargs(capfd, project0_nongnu, project1, language1):
 def test_update_stores_project_tree_none(capfd, project0):
     project0.treestyle = 'pootle_fs'
     project0.save()
-    call_command("update_stores", "--project", project0.code)
+    call_command(
+        "update_stores", "--atomic=all", "--project", project0.code)
     out, err = capfd.readouterr()
     assert not out
     assert not err

--- a/tests/formats/util.py
+++ b/tests/formats/util.py
@@ -28,9 +28,21 @@ def test_format_util(project0):
 
     xliff = Format.objects.get(name="xliff")
     project0.filetypes.add(xliff)
+    del project0.__dict__["filetype_tool"]
+    filetype_tool = project0.filetype_tool
     assert filetype_tool.filetype_extensions == [u"po", u"xliff"]
     assert filetype_tool.template_extensions == [u"pot", u"xliff"]
     assert filetype_tool.valid_extensions == [u"po", u"xliff", u"pot"]
+
+    ts = Format.objects.get(name="ts")
+    filetype_tool.add_filetype(ts)
+    del project0.__dict__["filetype_tool"]
+    filetype_tool = project0.filetype_tool
+    assert filetype_tool.filetype_extensions == [u"po", u"xliff", u"ts"]
+    assert filetype_tool.template_extensions == [u"pot", u"xliff", u"ts"]
+    assert (
+        sorted(filetype_tool.valid_extensions)
+        == [u"po", u"pot", u"ts", u"xliff"])
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- refactor pootle commands to recurse project > tp thus reducing db load  and making use of caching
- cache filetype tools to prevent repeated db calls to check avail filetypes for a project