### PR TITLE
Add render_as_template function to pootle.core.utils.templates

### DIFF
--- a/pootle/core/utils/templates.py
+++ b/pootle/core/utils/templates.py
@@ -6,8 +6,14 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.template import TemplateDoesNotExist
+from django.template import Context, Template, TemplateDoesNotExist
 from django.template.engine import Engine
+
+
+def render_as_template(string, context=None):
+    context = context or {}
+    context = Context(context)
+    return Template(string).render(context=context)
 
 
 def get_template_source(name, dirs=None):

--- a/tests/pootle_fs/templatetags.py
+++ b/tests/pootle_fs/templatetags.py
@@ -8,28 +8,21 @@
 
 import pytest
 
-from django.template import Context, Template
-
 from pootle.core.contextmanagers import keep_data
 from pootle.core.delegate import upstream
 from pootle.core.plugin import provider
+from pootle.core.utils.templates import render_as_template
 from pootle_project.models import Project
 
 
-def _render_template(string, context=None):
-    context = context or {}
-    context = Context(context)
-    return Template(string).render(context=context)
-
-
 def _render_upstream(ctx):
-    return _render_template(
+    return render_as_template(
         "{% load fs_tags %}{% upstream_link project %}",
         context=ctx)
 
 
 def _render_upstream_short(ctx):
-    return _render_template(
+    return render_as_template(
         "{% load fs_tags %}{% upstream_link_short project location %}",
         context=ctx)
 


### PR DESCRIPTION
handy function for rendering strings as template