### PR TITLE
l10n: Change team roles labels

### DIFF
--- a/pootle/apps/pootle_language/forms.py
+++ b/pootle/apps/pootle_language/forms.py
@@ -77,12 +77,12 @@ class LanguageTeamAdminForm(LanguageTeamBaseAdminForm):
         queryset=User.objects.none())
     rm_submitters = forms.ModelMultipleChoiceField(
         required=False,
-        label=_("Submitters"),
+        label=_("Translators"),
         widget=TableSelectMultiple(item_attrs=["username"]),
         queryset=User.objects.none())
     rm_members = forms.ModelMultipleChoiceField(
         required=False,
-        label=_("Members"),
+        label=_("Suggesters"),
         widget=TableSelectMultiple(item_attrs=["username"]),
         queryset=User.objects.none())
     new_member = forms.ModelChoiceField(


### PR DESCRIPTION
After talking with some translators they found previous naming misleading.
New labels align with the Pootle concepts of translating and suggesting
offered to users in the translation editor.