### PR TITLE
Fix displaying "reviewed by" label below current editor area

### DIFF
--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -38,7 +38,7 @@ from pootle.core.utils.aggregate import max_column
 from pootle.core.utils.multistring import PLURAL_PLACEHOLDER, SEPARATOR
 from pootle.core.utils.timezone import datetime_min, make_aware
 from pootle_checks.constants import CHECK_NAMES
-from pootle_statistics.models import SubmissionTypes
+from pootle_statistics.models import SubmissionFields, SubmissionTypes
 
 from .abstracts import (
     AbstractUnit, AbstractQualityCheck, AbstractStore, AbstractSuggestion,
@@ -751,6 +751,12 @@ class Unit(AbstractUnit):
 # # # # # # # # # # # Suggestions # # # # # # # # # # # # # # # # #
     def get_suggestions(self):
         return self.suggestion_set.pending().select_related('user').all()
+
+    def get_latest_target_submission(self):
+        return (self.submission_set.select_related('suggestion__user')
+                                   .filter(field=SubmissionFields.TARGET)
+                                   .order_by('-creation_time', '-id')
+                                   .first())
 
     def has_critical_checks(self):
         return self.qualitycheck_set.filter(

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -478,8 +478,13 @@ class UnitEditJSON(PootleUnitJSON):
             if 'virtualfolder' in settings.INSTALLED_APPS
             else None)
         suggestions = self.object.get_suggestions()
+        latest_target_submission = self.object.get_latest_target_submission()
+        accepted_suggestion = None
+        if latest_target_submission is not None:
+            accepted_suggestion = latest_target_submission.suggestion
         return {
             'unit': self.object,
+            'accepted_suggestion': accepted_suggestion,
             'form': self.get_unit_edit_form(),
             'comment_form': self.get_unit_comment_form(),
             'priority': priority,

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -217,10 +217,10 @@
               <time
                 title="{{ unit.change.submitted_on|dateformat }}"
                 datetime="{{ unit.change.submitted_on.isoformat }}">{{ unit.change.submitted_on|relative_datetime_format }}</time>
-              {% with reviewer=unit.change.reviewed_by %}
+              {% with reviewer=accepted_suggestion.reviewer %}
               {% if reviewer %}
               <br>
-              <span>({% blocktrans with profile_url=reviewer.get_absolute_url%}reviewed by <a href="{{ profile_url }}">{{ reviewer }}</a>{% endblocktrans %})</span>
+              <span>({% blocktrans with profile_url=reviewer.get_absolute_url %}reviewed by <a href="{{ profile_url }}">{{ reviewer }}</a>{% endblocktrans %})</span>
               {% endif %}
               {% endwith %}
             </div>

--- a/tests/views/get_edit_unit.py
+++ b/tests/views/get_edit_unit.py
@@ -60,6 +60,11 @@ def test_get_edit_unit(project0_nongnu, get_edit_unit, client,
     assert result["is_obsolete"] is False
     assert result["sources"] == sources
     assert response.context["unit"] == unit
+    accepted_suggestion = None
+    submission = unit.get_latest_target_submission()
+    if submission:
+        accepted_suggestion = submission.suggestion
+    assert response.context["accepted_suggestion"] == accepted_suggestion
     assert response.context["priority"] == store.priority
     assert response.context["store"] == store
     assert response.context["filetype"] == filetype


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/682845/26102092/3c8401de-3a3c-11e7-9d64-5ee96336619f.png)
Current submitter is displayed as avatar from the left side. Thus the only case when we need to show is when another user is accepting a suggestion.
Probs it can be done better similar to GH
![image](https://cloud.githubusercontent.com/assets/682845/26102232/de083ea8-3a3c-11e7-8150-98176083847b.png)
However for now this PR brings the previous behaviour.



 