### PR TITLE
Use values_list to get supported languages for index page

### DIFF
--- a/pootle/apps/pootle_app/views/index/index.py
+++ b/pootle/apps/pootle_app/views/index/index.py
@@ -91,7 +91,7 @@ class IndexView(View):
                 request,
                 (self.all_languages
                  if request.user.is_superuser
-                 else self.languages))
+                 else self.languages).values_list('code', flat=True))
         if lang is not None and lang not in ('projects', ''):
             url = reverse('pootle-language-browse', args=[lang])
         else:


### PR DESCRIPTION
`get_lang_from_http_header` function which detects lang to redirect from welcome page for logged in users expects list as supported languages (not a QuerySet).
This PR uses `values_list()` to get a list of lang codes from `QuerySet`.