### PR TITLE
Only use last 30 days to calculate user score

### DIFF
--- a/pootle/apps/pootle_score/updater.py
+++ b/pootle/apps/pootle_score/updater.py
@@ -327,10 +327,12 @@ class UserScoreUpdater(ScoreUpdater):
         self.users = users
 
     def calculate(self, start=localdate(), end=None, **kwargs):
-        return self.filter_users(
-            self.tp_score_model.objects,
-            kwargs.get("users")).order_by("user").values_list(
-                "user").annotate(score=Sum("score"))
+        scores = self.filter_users(
+            self.tp_score_model.objects.filter(
+                date__gte=(localdate() - timedelta(days=30))),
+            kwargs.get("users"))
+        return scores.order_by("user").values_list(
+            "user").annotate(score=Sum("score"))
 
     def set_scores(self, calculated_scores, existing=None):
         update.send(

--- a/tests/pootle_score/updater.py
+++ b/tests/pootle_score/updater.py
@@ -283,10 +283,20 @@ def test_score_user_updater(tp0, admin, member):
     updater = user_updater(users=[admin, member])
     assert updater.users == [admin, member]
     result = updater.calculate()
-    admin_score = round(
-        sum(admin.scores.values_list("score", flat=True)), 2)
-    member_score = round(
-        sum(member.scores.values_list("score", flat=True)), 2)
+    admin_score = admin.scores.filter(
+        date__gte=(
+            localdate()
+            - timedelta(days=30)))
+    admin_score = round(sum(
+        admin_score.values_list(
+            "score", flat=True)), 2)
+    member_score = member.scores.filter(
+        date__gte=(
+            localdate()
+            - timedelta(days=30)))
+    member_score = round(sum(
+        member_score.values_list(
+            "score", flat=True)), 2)
     assert round(dict(result)[admin.pk], 2) == admin_score
     assert round(dict(result)[member.pk], 2) == member_score
     updater.set_scores(result)


### PR DESCRIPTION
atm score is calculated from all tpscores, which are stored by date

if we score on all then calculating scores becomes increasingly expensive

also, this restores previous behaviour