### PR TITLE
Only use revision to match submissions to accepted suggestion

### DIFF
--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -35,12 +35,9 @@ def handle_suggestion_accepted(**kwargs):
     suggestion = kwargs["instance"]
     if created or not suggestion.is_accepted:
         return
-    suggestion.submission_set.add(
-        *suggestion.unit.submission_set.filter(
-            revision=suggestion.unit.revision,
-            creation_time=suggestion.review_time))
-    store = suggestion.unit.store
-    update_data.send(store.__class__, instance=store)
+    update_data.send(
+        suggestion.unit.store.__class__,
+        instance=suggestion.unit.store)
 
 
 @receiver(pre_save, sender=UnitSource)

--- a/pootle/apps/pootle_store/utils.py
+++ b/pootle/apps/pootle_store/utils.py
@@ -210,6 +210,9 @@ class SuggestionsReview(object):
         suggestion.state_id = self.states["accepted"]
         suggestion.reviewer = self.reviewer
         self.update_unit_on_accept(suggestion, target=target)
+        suggestion.submission_set.add(
+            *suggestion.unit.submission_set.filter(
+                revision=suggestion.unit.revision))
         suggestion.review_time = suggestion.unit.mtime
         suggestion.save()
 


### PR DESCRIPTION
when a suggestion is accepted, the system needs to associate the
submissions that were created.

previously it did this in a post_save handler by matching revision
and review_time, but this seems to be flaky on mysql where it lacks
microsecond support

this moves the association to the suggestion review util, and only
uses the units revision to match the submissions