### PR TITLE
i18n: ensure strings are Unicode in mute/unmute timeline messages

### DIFF
--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -69,7 +69,7 @@ class SuggestionAddedEvent(SuggestionEvent):
     def context(self):
         return dict(
             value=self.suggestion.target,
-            description=_("Added suggestion"))
+            description=_(u"Added suggestion"))
 
 
 class SuggestionAcceptedEvent(SuggestionEvent):
@@ -152,7 +152,7 @@ class UnitCreatedEvent(object):
 
     @property
     def context(self):
-        ctx = dict(description=_("Unit created"))
+        ctx = dict(description=_(u"Unit created"))
         if self.target_event is not None:
             if self.target_event.value.old_value != '':
                 ctx['value'] = self.target_event.value.old_value
@@ -183,10 +183,10 @@ class CommentUpdatedEvent(SubmissionEvent):
         if self.submission.new_value:
             return dict(
                 value=self.submission.new_value,
-                sidetitle=_("Comment:"),
+                sidetitle=_(u"Comment:"),
                 comment=True)
 
-        return dict(description=_("Removed comment"))
+        return dict(description=_(u"Removed comment"))
 
 
 class CheckEvent(SubmissionEvent):

--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -202,7 +202,7 @@ class CheckEvent(SubmissionEvent):
 
     @property
     def check_link(self):
-        return format_html("<a href='{}'>{}</a>", self.check_url,
+        return format_html(u"<a href='{}'>{}</a>", self.check_url,
                            CHECK_NAMES[self.check_name])
 
 
@@ -211,7 +211,7 @@ class CheckMutedEvent(CheckEvent):
     def context(self):
         return dict(
             description=format_html(_(
-                "Muted %(check_name)s check",
+                u"Muted %(check_name)s check",
                 {'check_name': self.check_link})))
 
 
@@ -220,7 +220,7 @@ class CheckUnmutedEvent(CheckEvent):
     def context(self):
         return dict(
             description=format_html(_(
-                "Unmuted %(check_name)s check",
+                u"Unmuted %(check_name)s check",
                 {'check_name': self.check_link})))
 
 


### PR DESCRIPTION
Certainly self.check_url, does not interpolate into the Mute, Unmute
strings if it is Unicode, it works for ASCII.  Using u"" solves the
issues and strings interpolate correctly.