### PR TITLE
Skip timeline groups without events

### DIFF
--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -238,7 +238,8 @@ class Timeline(object):
             event_group = EventGroup(group, target_event)
             if event_group.target_event:
                 target_event = event_group.target_event
-            groups.append(event_group.context)
+            if event_group.events:
+                groups.append(event_group.context)
 
         return groups
 

--- a/tests/views/timeline.py
+++ b/tests/views/timeline.py
@@ -60,7 +60,8 @@ def _calculate_timeline(request, unit):
         event_group = EventGroup(group, target_event)
         if event_group.target_event:
             target_event = event_group.target_event
-        groups.append(event_group.context)
+        if event_group.events:
+            groups.append(event_group.context)
 
     context = dict(event_groups=groups)
     context.setdefault(


### PR DESCRIPTION
If suggestion_accepted event has linked target_updated (submission based) event then this target_event isn't added into EventGroup.
There are cases when `suggetion.review_time` differs from `submission.creation_time` and these events go to different groups. This PR omits group with no events.