### PR TITLE
Dont score suggestions with no creation_time

### DIFF
--- a/pootle/apps/pootle_log/utils.py
+++ b/pootle/apps/pootle_log/utils.py
@@ -78,7 +78,7 @@ class Log(object):
 
     @property
     def suggestion_qs(self):
-        return Suggestion.objects
+        return Suggestion.objects.exclude(creation_time__isnull=True)
 
     @property
     def submission_qs(self):
@@ -379,7 +379,9 @@ class UserLog(Log):
 
     @property
     def suggestion_qs(self):
-        return (self.user.suggestions.all() | self.user.reviews.all())
+        return (
+            self.user.suggestions.exclude(creation_time__isnull=True).all()
+            | self.user.reviews.all())
 
     @property
     def submission_qs(self):

--- a/pootle/apps/pootle_store/unit/timeline.py
+++ b/pootle/apps/pootle_store/unit/timeline.py
@@ -42,7 +42,9 @@ ACTION_ORDER = {
 
 
 class UnitTimelineLog(UnitLog):
-    pass
+    @property
+    def suggestion_qs(self):
+        return Suggestion.objects
 
 
 class SuggestionEvent(object):


### PR DESCRIPTION
this resolves an issue where suggestions are being scored for current day after refresh_scores and affects historical suggestions