### PR TITLE
l10n: Simplify translatable strings

### DIFF
--- a/pootle/apps/pootle_misc/templatetags/common_tags.py
+++ b/pootle/apps/pootle_misc/templatetags/common_tags.py
@@ -13,6 +13,7 @@ from django.utils.translation import get_language
 
 from pootle.i18n import formatter
 from pootle.i18n.dates import timesince
+from pootle.i18n.gettext import ugettext_lazy as _
 
 
 register = template.Library()
@@ -49,13 +50,16 @@ def progress_bar(total, fuzzy, translated):
         fuzzy_frac = float(fuzzy)/total
         translated_frac = float(translated)/total
         cldrformat = "#,##0.0%"
+    untranslated_display = (_("{percentage} untranslated")).format(
+        percentage=formatter.percent(untranslated_frac, cldrformat))
+    fuzzy_display = (_("{percentage} needs work")).format(
+        percentage=formatter.percent(fuzzy_frac, cldrformat))
+    translated_display = (_("{percentage} translated")).format(
+        percentage=formatter.percent(translated_frac, cldrformat))
     return dict(
-        untranslated_percent_display=formatter.percent(
-            untranslated_frac, cldrformat),
-        fuzzy_percent_display=formatter.percent(
-            fuzzy_frac, cldrformat),
-        translated_percent_display=formatter.percent(
-            translated_frac, cldrformat),
+        untranslated_percent_display=untranslated_display,
+        fuzzy_percent_display=fuzzy_display,
+        translated_percent_display=translated_display,
         untranslated_bar=round(untranslated_frac * 100, 1),
         fuzzy_bar=round(fuzzy_frac * 100, 1),
         translated_bar=round(translated_frac * 100, 1))

--- a/pootle/static/css/style.css
+++ b/pootle/static/css/style.css
@@ -1405,6 +1405,12 @@ span.legend
     margin-bottom: -0.1em;
 }
 
+html[dir="rtl"] span.legend
+{
+    margin-right: auto;
+    margin-left: 0.3em;
+}
+
 span.legend.translated
 {
     background-color: #090;

--- a/pootle/templates/browser/_progressbar.html
+++ b/pootle/templates/browser/_progressbar.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <table class="graph" original-title="
-<span class='legend translated'></span>{{ translated_percent_display }}<br />
-<span class='legend fuzzy'></span>{{ fuzzy_percent_display }}<br />
-<span class='legend untranslated'></span>{{ untranslated_percent_display }}">
+<span class='legend translated'></span>{{ translated_percent_display|force_escape }}<br />
+<span class='legend fuzzy'></span>{{ fuzzy_percent_display|force_escape }}<br />
+<span class='legend untranslated'></span>{{ untranslated_percent_display|force_escape }}">
   <tr>
     <td class="translated" style="width: {{ translated_bar }}%"><span></span></td>
     <td class="fuzzy" style="width: {{ fuzzy_bar }}%"><span></span></td>

--- a/pootle/templates/browser/_progressbar.html
+++ b/pootle/templates/browser/_progressbar.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <table class="graph" original-title="
-<span class='legend translated'></span>{% blocktrans %}<span class='value translated'>{{ translated_percent_display }}</span> translated{% endblocktrans %}<br />
-<span class='legend fuzzy'></span>{% blocktrans %}<span class='value fuzzy'>{{ fuzzy_percent_display }}</span> needs work{% endblocktrans %}<br />
-<span class='legend untranslated'></span>{% blocktrans %}<span class='value untranslated'>{{ untranslated_percent_display }}</span> untranslated{% endblocktrans %}">
+<span class='legend translated'></span>{% blocktrans %}{{ translated_percent_display }} translated{% endblocktrans %}<br />
+<span class='legend fuzzy'></span>{% blocktrans %}{{ fuzzy_percent_display }} needs work{% endblocktrans %}<br />
+<span class='legend untranslated'></span>{% blocktrans %}{{ untranslated_percent_display }} untranslated{% endblocktrans %}">
   <tr>
     <td class="translated" style="width: {{ translated_bar }}%"><span></span></td>
     <td class="fuzzy" style="width: {{ fuzzy_bar }}%"><span></span></td>

--- a/pootle/templates/browser/_progressbar.html
+++ b/pootle/templates/browser/_progressbar.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <table class="graph" original-title="
-<span class='legend translated'></span>{% blocktrans %}{{ translated_percent_display }} translated{% endblocktrans %}<br />
-<span class='legend fuzzy'></span>{% blocktrans %}{{ fuzzy_percent_display }} needs work{% endblocktrans %}<br />
-<span class='legend untranslated'></span>{% blocktrans %}{{ untranslated_percent_display }} untranslated{% endblocktrans %}">
+<span class='legend translated'></span>{{ translated_percent_display }}<br />
+<span class='legend fuzzy'></span>{{ fuzzy_percent_display }}<br />
+<span class='legend untranslated'></span>{{ untranslated_percent_display }}">
   <tr>
     <td class="translated" style="width: {{ translated_bar }}%"><span></span></td>
     <td class="fuzzy" style="width: {{ fuzzy_bar }}%"><span></span></td>

--- a/tests/pootle_misc/templatetags.py
+++ b/tests/pootle_misc/templatetags.py
@@ -21,14 +21,14 @@ def _render_str(string, context=None):
 
 def test_templatetag_progress_bar():
     rendered = _render_str("{% load common_tags %}{% progress_bar 0 0 0 %}")
-    assert "<span class=\'value translated\'>0%</span>" in rendered
-    assert '<span class=\'value fuzzy\'>0%</span>' in rendered
-    assert '<span class=\'value untranslated\'>0%</span>' in rendered
+    assert "<span class='legend translated'></span>0%" in rendered
+    assert "<span class='legend fuzzy'></span>0%" in rendered
+    assert "<span class='legend untranslated'></span>0%" in rendered
     rendered = _render_str(
         "{% load common_tags %}{% progress_bar 123 23 73 %}")
-    assert "<span class=\'value translated\'>59.3%</span>" in rendered
-    assert "<span class=\'value fuzzy\'>18.7%</span>" in rendered
-    assert "<span class=\'value untranslated\'>22.0%</span>" in rendered
+    assert "<span class='legend translated'></span>59.3%" in rendered
+    assert "<span class='legend fuzzy'></span>18.7%" in rendered
+    assert "<span class='legend untranslated'></span>22.0%" in rendered
     assert '<td class="translated" style="width: 59.3%">' in rendered
     assert '<td class="fuzzy" style="width: 18.7%">' in rendered
     assert '<td class="untranslated" style="width: 22.0%">' in rendered


### PR DESCRIPTION
This avoids translators breaking the UI with translations, and also
presents them simpler strings to translate.

The removed tags and CSS is not needed to render the tooltips.