### PR TITLE
Make suppress_signal contextmanager thread_safe

### DIFF
--- a/pytest_pootle/fixtures/getters.py
+++ b/pytest_pootle/fixtures/getters.py
@@ -10,13 +10,14 @@ from contextlib import contextmanager
 
 import pytest
 
-from pootle.core.contextmanagers import keep_data
+from pytest_pootle.utils import suppress_getter
+
 from pootle.core.delegate import context_data, wordcount, tp_tool
 
 
 @contextmanager
 def _no_wordcount():
-    with keep_data(signals=(wordcount, )):
+    with suppress_getter(wordcount):
         yield
 
 
@@ -27,7 +28,7 @@ def no_wordcount():
 
 @contextmanager
 def _no_context_data():
-    with keep_data(signals=(context_data, )):
+    with suppress_getter(context_data):
         yield
 
 
@@ -38,7 +39,7 @@ def no_context_data():
 
 @contextmanager
 def _no_tp_tool():
-    with keep_data(signals=(tp_tool, )):
+    with suppress_getter(tp_tool):
         yield
 
 

--- a/pytest_pootle/fixtures/pootle_fs/getters.py
+++ b/pytest_pootle/fixtures/pootle_fs/getters.py
@@ -10,13 +10,14 @@ from contextlib import contextmanager
 
 import pytest
 
-from pootle.core.contextmanagers import keep_data
+from pytest_pootle.utils import suppress_getter, suppress_provider
+
 from pootle_fs.delegate import fs_file, fs_finder, fs_plugins
 
 
 @contextmanager
 def _no_fs_files():
-    with keep_data(signals=(fs_file, )):
+    with suppress_getter(fs_file):
         yield
 
 
@@ -27,7 +28,7 @@ def no_fs_files():
 
 @contextmanager
 def _no_fs_plugins():
-    with keep_data(signals=(fs_plugins, )):
+    with suppress_provider(fs_plugins):
         yield
 
 
@@ -38,7 +39,7 @@ def no_fs_plugins():
 
 @contextmanager
 def _no_fs_finder():
-    with keep_data(signals=(fs_finder, )):
+    with suppress_getter(fs_finder):
         yield
 
 


### PR DESCRIPTION
seems that signal suppression code was not thread safe, this pr updates so that suppression only occurs in current thread, and signal is bubbled to other threads

