### PR TITLE
Avoid changing of value in the editor for users with no suggest/translate permissions

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -2159,7 +2159,8 @@ PTL.editor = {
 
     // FIXME: move this side-effect elsewhere
     if (results.length > 0 && results[0].source === sourceText) {
-      if (ReactEditor.stateValues[0] === '') {
+      const allowAutofill = this.settings.canSuggest || this.settings.canTranslate;
+      if (ReactEditor.stateValues[0] === '' && allowAutofill) {
         // save unit editor state to restore it after autofill changes
         const isUnitDirty = this.isUnitDirty;
         const text = results[0].target;

--- a/pootle/static/js/editor/index.js
+++ b/pootle/static/js/editor/index.js
@@ -177,6 +177,9 @@ const ReactEditor = {
    * Sets a new textarea value.
    */
   setValueFor(indexOrElement, value) {
+    if (this.props.isDisabled) {
+      return;
+    }
     const textareas = this.editorInstance.getAreas();
     const index = (
       typeof indexOrElement === 'object' ?

--- a/pootle/templates/editor/_scripts.html
+++ b/pootle/templates/editor/_scripts.html
@@ -30,6 +30,8 @@ $(function() {
     userId: {{ request.user.id }},
     localeDir: '{{ language.direction }}',
     canReview: {{ canreview|yesno:"true,false" }},
+    canSuggest: {{ cansuggest|yesno:"true,false" }},
+    canTranslate: {{ cantranslate|yesno:"true,false" }},
   };
   {% if cansuggest or cantranslate %}
   options.mt = [


### PR DESCRIPTION
Don't change of value in the editor for users with no suggest/translate permissions when:
- 100% match is found in similar translations;
- click on any area with `js-editor-copy-text` class;

Fixes #6421