### PR TITLE
Direct users to Markdown for staticpages

### DIFF
--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -242,11 +242,15 @@ Configuration settings for applications used by Pootle.
 
   Two-tuple defining the markup filter to apply in certain textareas.
 
-  - Accepted values for the first element are ``textile``, ``markdown``,
-    ``restructuredtext``, ``html`` and None
+  - Acceptable values for the first element are ``markdown`` and ``html``
+    (deprecated).
 
   - The second element should be a dictionary of keyword arguments that
     will be passed to the markup function
+
+  .. versionchanged:: 2.8
+     Support for ``textile``, ``restructuredtext`` and ``html`` formats has
+     been deprecated.
 
   Examples::
 

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -243,7 +243,7 @@ Configuration settings for applications used by Pootle.
   Two-tuple defining the markup filter to apply in certain textareas.
 
   - Accepted values for the first element are ``textile``, ``markdown``,
-    ``restructuredtext`` and None
+    ``restructuredtext``, ``html`` and None
 
   - The second element should be a dictionary of keyword arguments that
     will be passed to the markup function

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -254,20 +254,12 @@ Configuration settings for applications used by Pootle.
 
   Examples::
 
-    POOTLE_MARKUP_FILTER = (None, {})
-
     POOTLE_MARKUP_FILTER = ('markdown', {})
 
     POOTLE_MARKUP_FILTER = ('markdown', {
                                 'clean': {
                                     'extra_tags': ['div'],
                                 },
-                            })
-
-    POOTLE_MARKUP_FILTER = ('restructuredtext', {
-                                'settings_overrides': {
-                                    'report_level': 'quiet',
-                                 }
                             })
 
 

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -263,46 +263,6 @@ def check_settings(app_configs=None, **kwargs):
             id="pootle.W010",
         ))
 
-    try:
-        markup_filter = settings.POOTLE_MARKUP_FILTER[0]
-    except AttributeError:
-        errors.append(checks.Warning(
-            _("POOTLE_MARKUP_FILTER is missing."),
-            hint=_("Set POOTLE_MARKUP_FILTER."),
-            id="pootle.W012",
-        ))
-    except (IndexError, TypeError, ValueError):
-        errors.append(checks.Warning(
-            _("Invalid value in POOTLE_MARKUP_FILTER."),
-            hint=_("Set a valid value for POOTLE_MARKUP_FILTER."),
-            id="pootle.W013",
-        ))
-    else:
-        if markup_filter is not None:
-            try:
-                if markup_filter == 'textile':
-                    import textile  # noqa
-                elif markup_filter == 'markdown':
-                    import markdown  # noqa
-                elif markup_filter == 'restructuredtext':
-                    import docutils  # noqa
-                elif markup_filter == 'html':
-                    pass
-                else:
-                    errors.append(checks.Warning(
-                        _("Invalid markup in POOTLE_MARKUP_FILTER."),
-                        hint=_("Set a valid markup for POOTLE_MARKUP_FILTER."),
-                        id="pootle.W014",
-                    ))
-            except ImportError:
-                errors.append(checks.Warning(
-                    _("POOTLE_MARKUP_FILTER is set to '%s' markup, but the "
-                      "package that provides can't be found.", markup_filter),
-                    hint=_("Install the package or change "
-                           "POOTLE_MARKUP_FILTER."),
-                    id="pootle.W015",
-                ))
-
     if settings.POOTLE_TM_SERVER:
         tm_indexes = []
 
@@ -379,6 +339,54 @@ def check_settings(app_configs=None, **kwargs):
                         "Set a valid value for %s "
                         "in POOTLE_SCORES.", coefficient_name),
                     id="pootle.C015"))
+    return errors
+
+
+@checks.register()
+def check_settings_markup(app_configs=None, **kwargs):
+    from django.conf import settings
+
+    errors = []
+
+    try:
+        markup_filter = settings.POOTLE_MARKUP_FILTER[0]
+    except AttributeError:
+        errors.append(checks.Warning(
+            _("POOTLE_MARKUP_FILTER is missing."),
+            hint=_("Set POOTLE_MARKUP_FILTER."),
+            id="pootle.W012",
+        ))
+    except (IndexError, TypeError, ValueError):
+        errors.append(checks.Warning(
+            _("Invalid value in POOTLE_MARKUP_FILTER."),
+            hint=_("Set a valid value for POOTLE_MARKUP_FILTER."),
+            id="pootle.W013",
+        ))
+    else:
+        if markup_filter is not None:
+            try:
+                if markup_filter == 'textile':
+                    import textile  # noqa
+                elif markup_filter == 'markdown':
+                    import markdown  # noqa
+                elif markup_filter == 'restructuredtext':
+                    import docutils  # noqa
+                elif markup_filter == 'html':
+                    pass
+                else:
+                    errors.append(checks.Warning(
+                        _("Invalid markup in POOTLE_MARKUP_FILTER."),
+                        hint=_("Set a valid markup for POOTLE_MARKUP_FILTER."),
+                        id="pootle.W014",
+                    ))
+            except ImportError:
+                errors.append(checks.Warning(
+                    _("POOTLE_MARKUP_FILTER is set to '%s' markup, but the "
+                      "package that provides can't be found.", markup_filter),
+                    hint=_("Install the package or change "
+                           "POOTLE_MARKUP_FILTER."),
+                    id="pootle.W015",
+                ))
     return errors
 
 

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -387,6 +387,12 @@ def check_settings_markup(app_configs=None, **kwargs):
                            "POOTLE_MARKUP_FILTER."),
                     id="pootle.W015",
                 ))
+        if markup_filter is None:
+                errors.append(checks.Warning(
+                    _("POOTLE_MARKUP_FILTER set to 'None' is deprecated."),
+                    hint=_("Set your markup to 'html' explicitly."),
+                    id="pootle.W025",
+                ))
     return errors
 
 

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -393,6 +393,15 @@ def check_settings_markup(app_configs=None, **kwargs):
                     hint=_("Set your markup to 'html' explicitly."),
                     id="pootle.W025",
                 ))
+        if markup_filter in ('html', 'textile', 'restructuredtext'):
+                errors.append(checks.Warning(
+                    _("POOTLE_MARKUP_FILTER is using '%s' markup, which is "
+                      "deprecated and will be removed in future.",
+                      markup_filter),
+                    hint=_("Convert your staticpages to Markdown and set your "
+                           "markup to 'markdown'."),
+                    id="pootle.W026",
+                ))
     return errors
 
 

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -286,6 +286,8 @@ def check_settings(app_configs=None, **kwargs):
                     import markdown  # noqa
                 elif markup_filter == 'restructuredtext':
                     import docutils  # noqa
+                elif markup_filter == 'html':
+                    pass
                 else:
                     errors.append(checks.Warning(
                         _("Invalid markup in POOTLE_MARKUP_FILTER."),

--- a/pootle/core/markup/filters.py
+++ b/pootle/core/markup/filters.py
@@ -59,7 +59,8 @@ def get_markup_filter_display_name():
         'textile': u'Textile',
         'markdown': u'Markdown',
         'restructuredtext': u'reStructuredText',
-    }.get(name, u'HTML')
+        'html': u'HTML',
+    }.get(name)
 
 
 def get_markup_filter():
@@ -77,6 +78,8 @@ def get_markup_filter():
             import markdown  # noqa
         elif markup_filter == 'restructuredtext':
             import docutils  # noqa
+        elif markup_filter == 'html':
+            pass
         else:
             return (None, '')
     except Exception:

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -25,10 +25,6 @@ POOTLE_CUSTOM_TEMPLATE_CONTEXT = {}
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
-# IMPORTANT: If you want to use one of these markup filters you must install
-# the required packages as follows:
-#   `pip install Pootle[markdown]`
-#
 # Examples:
 #    POOTLE_MARKUP_FILTER = ('html', {})
 #    POOTLE_MARKUP_FILTER = ('markdown', {})

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -21,7 +21,7 @@ POOTLE_CUSTOM_TEMPLATE_CONTEXT = {}
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
 # - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext' and None.
+#   'restructuredtext', 'html' and None.
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
@@ -31,6 +31,7 @@ POOTLE_CUSTOM_TEMPLATE_CONTEXT = {}
 #
 # Examples:
 #    POOTLE_MARKUP_FILTER = (None, {})
+#    POOTLE_MARKUP_FILTER = ('html', {})
 #    POOTLE_MARKUP_FILTER = ('markdown', {})
 #    POOTLE_MARKUP_FILTER = ('restructuredtext', {
 #                                'settings_overrides': {

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -21,7 +21,7 @@ POOTLE_CUSTOM_TEMPLATE_CONTEXT = {}
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
 # - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext', 'html' and None.
+#   'restructuredtext', 'html' and None (deprecated).
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
@@ -30,7 +30,6 @@ POOTLE_CUSTOM_TEMPLATE_CONTEXT = {}
 #   `pip install Pootle[markdown]`
 #
 # Examples:
-#    POOTLE_MARKUP_FILTER = (None, {})
 #    POOTLE_MARKUP_FILTER = ('html', {})
 #    POOTLE_MARKUP_FILTER = ('markdown', {})
 #    POOTLE_MARKUP_FILTER = ('restructuredtext', {

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -147,7 +147,7 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
 # - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext', 'html' and None.
+#   'restructuredtext' and 'html'.
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
@@ -156,7 +156,6 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 #   `pip install Pootle[markdown]`
 #
 # Examples:
-#    POOTLE_MARKUP_FILTER = (None, {})
 #    POOTLE_MARKUP_FILTER = ('markdown', {})
 #    POOTLE_MARKUP_FILTER = ('restructuredtext', {
 #                                'settings_overrides': {

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -146,8 +146,8 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
-# - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext' and 'html'.
+# - Accepted values for the first element are 'markdown' and
+#   'html' (deprecated).
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
@@ -157,11 +157,6 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 #
 # Examples:
 #    POOTLE_MARKUP_FILTER = ('markdown', {})
-#    POOTLE_MARKUP_FILTER = ('restructuredtext', {
-#                                'settings_overrides': {
-#                                    'report_level': 'quiet',
-#                                }
-#                            })
 POOTLE_MARKUP_FILTER = (None, {})
 
 # Suggestions through Machine Translation services (service name, API key).

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -151,13 +151,7 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
-# IMPORTANT: If you want to use one of these markup filters you must install
-# the required packages as follows:
-#   `pip install Pootle[markdown]`
-#
-# Examples:
-#    POOTLE_MARKUP_FILTER = ('markdown', {})
-POOTLE_MARKUP_FILTER = (None, {})
+POOTLE_MARKUP_FILTER = ('markdown' {})
 
 # Suggestions through Machine Translation services (service name, API key).
 POOTLE_MT_BACKENDS = [

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -147,7 +147,7 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
 # - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext' and None.
+#   'restructuredtext', 'html' and None.
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -189,8 +189,8 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
-# - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext' and 'html'.
+# - Accepted values for the first element are 'markdown' and
+#   'html' (deprecated).
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
@@ -200,11 +200,6 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 #
 # Examples:
 #    POOTLE_MARKUP_FILTER = ('markdown', {})
-#    POOTLE_MARKUP_FILTER = ('restructuredtext', {
-#                                'settings_overrides': {
-#                                    'report_level': 'quiet',
-#                                }
-#                            })
 POOTLE_MARKUP_FILTER = (None, {})
 
 # Set the backends you want to use to enable translation suggestions through

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -190,7 +190,7 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
 # - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext' and None.
+#   'restructuredtext', 'html' and None.
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -190,7 +190,7 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # Two-tuple defining the markup filter to apply in certain textareas.
 #
 # - Accepted values for the first element are 'textile', 'markdown',
-#   'restructuredtext', 'html' and None.
+#   'restructuredtext' and 'html'.
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
@@ -199,7 +199,6 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 #   `pip install Pootle[markdown]`
 #
 # Examples:
-#    POOTLE_MARKUP_FILTER = (None, {})
 #    POOTLE_MARKUP_FILTER = ('markdown', {})
 #    POOTLE_MARKUP_FILTER = ('restructuredtext', {
 #                                'settings_overrides': {

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -194,13 +194,7 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # - The second element should be a dictionary of keyword arguments that will be
 #   passed to the markup function.
 #
-# IMPORTANT: If you want to use one of these markup filters you must install
-# the required packages as follows:
-#   `pip install Pootle[markdown]`
-#
-# Examples:
-#    POOTLE_MARKUP_FILTER = ('markdown', {})
-POOTLE_MARKUP_FILTER = (None, {})
+POOTLE_MARKUP_FILTER = ('markdown', {})
 
 # Set the backends you want to use to enable translation suggestions through
 # several online services. To disable this feature completely just comment all

--- a/requirements/_markup_markdown.txt
+++ b/requirements/_markup_markdown.txt
@@ -1,3 +1,0 @@
-# Markup: Markdown filter for POOTLE_MARKUP_FILTER
-bleach==2.0.0
-Markdown==2.6.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,6 +31,10 @@ rq==0.7.1
 scandir==1.5
 stemming==1.0.1
 
+# Markup: Markdown filter for POOTLE_MARKUP_FILTER
+bleach==2.0.0
+Markdown==2.6.8
+
 # Translate Toolkit
 # Note: also adjust pootle/checks::TTK_MINIMUM_REQUIRED_VERSION
 translate-toolkit==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -318,9 +318,6 @@ dependency_links += parse_dependency_links('requirements/_db_postgresql.txt')
 # Pootle FS plugins
 extras_require['git'] = parse_requirements('requirements/_pootle_fs_git.txt')
 dependency_links += parse_dependency_links('requirements/_pootle_fs_git.txt')
-# Markdown
-extras_require['markdown'] = parse_requirements('requirements/_markup_markdown.txt')
-dependency_links += parse_dependency_links('requirements/_markup_markdown.txt')
 # Testing
 extras_require['travis'] = parse_requirements('requirements/travis.txt',
                                               recurse=True)


### PR DESCRIPTION
Goal is to allow us to migrate users off anything else onto Markdown for staticpages.  Reason, raw HTML is a vector, other formats require lots of support with limited value.

* Introduce explicit 'html' format type
* Warn people about None format type.  So they will make it 'html' and we can deprecate that, or they will move to markdown.
* Warn that html, textile and restructuredtext are now deprecated.
* Make markdown default for new installs, default config is still None (so that we can communicate the deprecation changes)

Lots of checks introduced to make this a reality.

For a future release we will finally remove actual support for these