### PR TITLE
Bump django contact form

### DIFF
--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -49,42 +49,10 @@ class ContactForm(MathCaptchaForm, OriginalContactForm):
             del self.fields['captcha_answer']
             del self.fields['captcha_token']
 
-    def message(self):
-        """Render the body of the message to a string.
-
-        FIXME: this copies and adjusts upstream code to support Django 1.10+.
-        Remove once django-contact-form is fixed.
-        """
-        template_name = (
-            self.template_name()
-            if callable(self.template_name)
-            else self.template_name)
-        return loader.render_to_string(template_name,
-                                       context=self.get_context(),
-                                       request=self.request)
-
-    def subject(self):
-        """Render the subject of the message to a string.
-
-        FIXME: this copies and adjusts upstream code to support Django 1.10+.
-        Remove once django-contact-form is fixed.
-        """
-        template_name = (
-            self.subject_template_name()
-            if callable(self.subject_template_name)
-            else self.subject_template_name)
-        subject = loader.render_to_string(template_name,
-                                          context=self.get_context(),
-                                          request=self.request)
-        return ''.join(subject.splitlines())
-
     def get_context(self):
-        """Get the context to render the templates for email subject and body.
+        """Get context to render the templates for email subject and body."""
+        ctx = super(ContactForm, self).get_context()
 
-        FIXME: this copies and adjusts upstream code to support Django 1.10+.
-        Adjust properly once django-contact-form is fixed.
-        """
-        ctx = dict(self.cleaned_data)
         ctx['server_name'] = settings.POOTLE_TITLE
         return ctx
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ Django~=1.10.5  # rq.filter: <1.11
 django-allauth==0.32.0
 django-assets==0.12
 django-bulk-update==2.1.0
-django-contact-form==1.3
+django-contact-form==1.4.1
 django-contrib-comments==1.7.3,!=1.8.0  # rq.filter: !=1.8.0
 django-overextends==0.4.3
 django-redis==4.8.0


### PR DESCRIPTION
django-contact-form 1.4.1 is already out with some code cleanups that would allow to remove some patching we have.