### PR TITLE
Disable SuggestionReviewForm editor area if the main editor is disabled

### DIFF
--- a/pootle/static/js/editor/index.js
+++ b/pootle/static/js/editor/index.js
@@ -124,7 +124,7 @@ const ReactEditor = {
         currentLocaleCode={this.props.currentLocaleCode}
         currentLocaleDir={this.props.currentLocaleDir}
         targetNplurals={this.props.targetNplurals}
-        isDisabled={false}
+        isDisabled={this.props.isDisabled}
         {...props}
       />,
       mountNode


### PR DESCRIPTION
This PR fixes #6433 issue and disables SuggestionReviewForm editor area if the main editor is disabled.
User with review permissions only can accept/reject suggestions and leave comments.