### PR TITLE
Get units opti

### DIFF
--- a/pootle/apps/pootle_store/unit/results.py
+++ b/pootle/apps/pootle_store/unit/results.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from pootle.core.url_helpers import split_pootle_path
 from pootle.i18n.gettext import language_dir
 from pootle_store.constants import FUZZY
+from pootle_store.models import Unit
 from pootle_store.templatetags.store_tags import (
     pluralize_source, pluralize_target)
 from pootle_store.unit.proxy import UnitProxy
@@ -120,14 +121,20 @@ class GroupedResults(object):
         "store__translation_project__language__code",
         "store__translation_project__language__nplurals"]
 
-    def __init__(self, units_qs):
-        self.units_qs = units_qs
+    def __init__(self, units):
+        self.units = units
 
     @property
     def data(self):
         unit_groups = []
+        units = {
+            unit["id"]: unit
+            for unit
+            in Unit.objects.filter(
+                pk__in=self.units).values(*self.select_fields)}
+        units = [units[pk] for pk in self.units]
         units_by_path = groupby(
-            self.units_qs.values(*self.select_fields),
+            units,
             lambda x: x["store__pootle_path"])
         for pootle_path, units in units_by_path:
             unit_groups.append({pootle_path: StoreResults(units).data})


### PR DESCRIPTION
optimization where get_units initially just retrieves ordered pks, and then retrieves data for those units.

this prevents huge temporary tables being created with all of the associated data