### PR TITLE
Redis test env

### DIFF
--- a/pytest_pootle/fixtures/revision.py
+++ b/pytest_pootle/fixtures/revision.py
@@ -9,10 +9,10 @@
 import pytest
 
 
-@pytest.fixture
-def revision(clear_cache):
+@pytest.fixture(autouse=True)
+def revision(request, clear_cache):
     """Sets up the cached revision counter for each test call."""
     from pootle.core.models import Revision
     from pootle_store.models import Unit
-
-    Revision.set(Unit.max_revision())
+    if request.node.get_marker('django_db'):
+        Revision.set(Unit.max_revision())

--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -231,12 +231,13 @@ def translations_directory(request):
 @pytest.fixture
 def clear_cache():
     """Currently tests only use one cache so this clears all"""
-
     from django.core.cache import caches
 
     from django_redis import get_redis_connection
 
     get_redis_connection('default').flushdb()
+    get_redis_connection('lru').flushdb()
+    get_redis_connection('redis').flushdb()
     caches["exports"].clear()
 
 

--- a/tests/commands/manage_dot.py
+++ b/tests/commands/manage_dot.py
@@ -19,6 +19,7 @@ def test_manage_noargs(capfd):
     assert "Available subcommands:" in out
 
 
+@pytest.mark.django_db
 @pytest.mark.cmd
 def test_manage_revision(capfd):
     """./manage.py revision, just to see that a simple command works."""

--- a/tests/core/decorators.py
+++ b/tests/core/decorators.py
@@ -167,7 +167,7 @@ def test_deco_persistent_property():
     assert Foo.bar.__doc__ == "Get a bar man"
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.core..foo-cache.bar') == "Baz"
+    assert get_cache("lru").get('pootle.core..foo-cache.bar') == "Baz"
     # cached version this time
     assert foo.bar == "Baz"
 
@@ -180,7 +180,7 @@ def test_deco_persistent_property():
         bar = persistent_property(_bar, key_attr="special_key")
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.core..special-foo-cache._bar') == "Baz"
+    assert get_cache("lru").get('pootle.core..special-foo-cache._bar') == "Baz"
 
     # cache_key set with custom key attr and name - cached with it
     class Foo(object):
@@ -192,7 +192,7 @@ def test_deco_persistent_property():
             _bar, name="bar", key_attr="special_key")
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.core..special-foo-cache.bar') == "Baz"
+    assert get_cache("lru").get('pootle.core..special-foo-cache.bar') == "Baz"
 
     # cache_key set with custom namespace
     class Foo(object):
@@ -206,7 +206,7 @@ def test_deco_persistent_property():
 
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.foo..foo-cache.bar') == "Baz"
+    assert get_cache("lru").get('pootle.foo..foo-cache.bar') == "Baz"
     # cached version this time
     assert foo.bar == "Baz"
 
@@ -223,6 +223,6 @@ def test_deco_persistent_property():
 
     foo = Foo()
     assert foo.bar == "Baz"
-    assert get_cache().get('pootle.foo.0.2.3.foo-cache.bar') == "Baz"
+    assert get_cache("lru").get('pootle.foo.0.2.3.foo-cache.bar') == "Baz"
     # cached version this time
     assert foo.bar == "Baz"

--- a/tests/pootle_language/views.py
+++ b/tests/pootle_language/views.py
@@ -128,8 +128,8 @@ def test_view_language_team_admin(client, language0, request_users):
         if k.endswith("_display"):
             del response.context["stats"][k]
     assert (
-        list(response.context["stats"])
-        == list(
+        sorted(response.context["stats"])
+        == sorted(
             language0.data_tool.get_stats(
                 include_children=False,
                 user=user)))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -59,18 +59,18 @@ CACHES = {
     # place that will abort everything otherwise
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://127.0.0.1:6379/15',
-        'TIMEOUT': None,
+        'LOCATION': 'redis://127.0.0.1:6379/13',
+        'TIMEOUT': 604800,  # 1 week
     },
     'redis': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://127.0.0.1:6379/15',
+        'LOCATION': 'redis://127.0.0.1:6379/14',
         'TIMEOUT': None,
     },
-    'stats': {
+    'lru': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://127.0.0.1:6379/15',
-        'TIMEOUT': None,
+        'TIMEOUT': 604800,  # 1 week
     },
     'exports': {
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',


### PR DESCRIPTION
flush redis between every test (and reset revision)

this should ensure that tests are testing more real-life scenarios, altho will probs slow down tests

ideally we should reset redis to post-pytest-env-setup state