### PR TITLE
Fix: language list needs to be a dict

### DIFF
--- a/pootle/apps/pootle_app/views/index/index.py
+++ b/pootle/apps/pootle_app/views/index/index.py
@@ -89,9 +89,9 @@ class IndexView(View):
         if lang is None:
             lang = get_lang_from_http_header(
                 request,
-                (self.all_languages
-                 if request.user.is_superuser
-                 else self.languages).values_list('code', flat=True))
+                dict((self.all_languages
+                      if request.user.is_superuser
+                      else self.languages).values_list('code', 'fullname')))
         if lang is not None and lang not in ('projects', ''):
             url = reverse('pootle-language-browse', args=[lang])
         else:


### PR DESCRIPTION
This fixes #6469 

This path is called at `/`.  Our code tries to redirect you to a `/$lang` if your header says you want that language and we have it hosted on the server.  If not you get directed to `/projects`.  This makes use of a cookie so to replicate you need to set the cookie to None.