### PR TITLE
Set checks context in UnitSuggestionJSON/UnitSubmitJSON explicitly

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -146,6 +146,8 @@ def _get_critical_checks_snippet(request, unit):
     ctx = {
         'canreview': can_review,
         'unit': unit,
+        'critical_checks': list(unit.get_critical_qualitychecks()),
+        'warning_checks': list(unit.get_warning_qualitychecks()),
     }
     template = loader.get_template('editor/units/xhr_checks.html')
     return template.render(context=ctx, request=request)


### PR DESCRIPTION
`_get_critical_checks_snippet()` requires `critical_checks, warning_checks` in context to render critical checks after submit/accept suggestion immediately. This PR adds it and fixes #6476.