### PR TITLE
Skip memusage tests by default

### DIFF
--- a/tests/import_export/export.py
+++ b/tests/import_export/export.py
@@ -14,6 +14,7 @@ from import_export.utils import TPTMXExporter
 from pootle.core.debug import memusage
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_tp_export_garbage(client, tp0, language1, request_users):
     url = (

--- a/tests/pootle_app/views.py
+++ b/tests/pootle_app/views.py
@@ -67,6 +67,7 @@ def test_view_welcome(client, member, system, project_set):
                get_language())))
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_welcome_garbage(client):
     url = reverse("pootle-home")

--- a/tests/pootle_language/views.py
+++ b/tests/pootle_language/views.py
@@ -338,6 +338,7 @@ def test_view_language_children(language0, rf, request_users):
     _test_view_language_children(view, language0)
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_language_garbage(language0, store0, client, request_users):
     url = reverse(

--- a/tests/pootle_profile/views.py
+++ b/tests/pootle_profile/views.py
@@ -27,6 +27,7 @@ def test_view_user_detail(client, member, system):
     assert profile.user == member
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_user_detail_garbage(member, client, request_users):
     user = request_users["user"]

--- a/tests/pootle_project/views.py
+++ b/tests/pootle_project/views.py
@@ -188,6 +188,7 @@ def test_view_project_paths(project0, store0, client, request_users):
     assert "store0.po" not in result["items"]["results"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_project_garbage(project0, client, request_users):
     url = reverse(
@@ -209,6 +210,7 @@ def test_view_project_garbage(project0, client, request_users):
         assert not usage["used"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_project_subdir_garbage(subdir0, client, request_users):
     url = reverse(
@@ -231,6 +233,7 @@ def test_view_project_subdir_garbage(subdir0, client, request_users):
         assert not usage["used"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_project_store_garbage(store0, client, request_users):
     url = reverse(

--- a/tests/pootle_store/views.py
+++ b/tests/pootle_store/views.py
@@ -4,6 +4,7 @@ from pootle.core.debug import memusage
 from pootle_store.constants import UNTRANSLATED
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_submit_unit_memusage(client, store0, admin, settings, system):
     settings.POOTLE_CAPTCHA_ENABLED = False
@@ -32,6 +33,7 @@ def test_submit_unit_memusage(client, store0, admin, settings, system):
         assert not usage["used"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_get_units_memusage(client, tp0, request_users, settings, system):
     user = request_users["user"]
@@ -53,6 +55,7 @@ def test_get_units_memusage(client, tp0, request_users, settings, system):
         assert not usage["used"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_get_edit_unit_memusage(client, store0, request_users, settings, system):
     user = request_users["user"]

--- a/tests/pootle_translationproject/views.py
+++ b/tests/pootle_translationproject/views.py
@@ -160,6 +160,7 @@ def test_view_tp_paths(tp0, store0, client, request_users):
     assert "store0.po" not in result["items"]["results"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_tp_garbage(tp0, store0, client, request_users):
     args = [tp0.language.code, tp0.project.code]
@@ -182,6 +183,7 @@ def test_view_tp_garbage(tp0, store0, client, request_users):
     assert not failed
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_tp_directory_garbage(subdir0, client, request_users):
     tp = subdir0.translation_project
@@ -200,6 +202,7 @@ def test_view_tp_directory_garbage(subdir0, client, request_users):
         assert not usage["used"]
 
 
+@pytest.mark.pootle_memusage
 @pytest.mark.django_db
 def test_view_tp_store_garbage(store0, client, request_users):
     tp = store0.translation_project


### PR DESCRIPTION
these tests are quite useful, but are taking a lot of time, and some fail occasionally - so making them skip by default