### PR TITLE
Use pycountry for langnames

### DIFF
--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -8,11 +8,15 @@
 
 from collections import OrderedDict
 
+from translate.lang.data import get_language_iso_fullname
+
+from django.conf import settings
 from django.db import models
 from django.urls import reverse
+from django.utils import translation
 from django.utils.functional import cached_property
 
-from pootle.core.delegate import data_tool
+from pootle.core.delegate import data_tool, language_code, site_languages
 from pootle.core.mixins import TreeItem
 from pootle.core.url_helpers import get_editor_filter
 from pootle.i18n.gettext import language_dir, tr_lang, ugettext_lazy as _
@@ -77,8 +81,24 @@ class Language(models.Model, TreeItem):
 
     @property
     def name(self):
-        """Localized fullname for the language."""
-        return tr_lang(self.fullname)
+        """localised ISO name for the language or fullname
+        if request lang == server lang, and fullname is set. Uses code
+        as the ultimate fallback
+        """
+        site_langs = site_languages.get()
+        server_code = language_code.get()(settings.LANGUAGE_CODE)
+        request_code = language_code.get()(translation.get_language())
+        use_db_name = (
+            not translation.get_language()
+            or (self.fullname
+                and server_code.matches(request_code)))
+        if use_db_name:
+            return self.fullname
+        iso_name = get_language_iso_fullname(self.code) or self.fullname
+        return (
+            site_langs.capitalize(tr_lang(iso_name))
+            if iso_name
+            else self.code)
 
     @property
     def direction(self):

--- a/pootle/apps/pootle_language/views.py
+++ b/pootle/apps/pootle_language/views.py
@@ -23,7 +23,7 @@ from pootle.core.views.decorators import requires_permission, set_permissions
 from pootle.core.views.formtable import Formtable
 from pootle.core.views.mixins import PootleJSONMixin
 from pootle.i18n import formatter
-from pootle.i18n.gettext import tr_lang, ugettext_lazy as _, ungettext_lazy
+from pootle.i18n.gettext import ugettext_lazy as _, ungettext_lazy
 from pootle_misc.util import cmp_by_last_activity
 from pootle_store.constants import STATES_MAP
 
@@ -90,7 +90,7 @@ class LanguageBrowseView(LanguageMixin, PootleBrowseView):
     def language(self):
         return {
             'code': self.object.code,
-            'name': tr_lang(self.object.fullname)}
+            'name': self.object.name}
 
     def get(self, *args, **kwargs):
         response = super(LanguageBrowseView, self).get(*args, **kwargs)

--- a/pootle/core/language.py
+++ b/pootle/core/language.py
@@ -9,6 +9,13 @@
 from django.utils.translation import to_locale
 
 
+# these languages need to have their cldr name adjusted for use in ui
+# http://cldr.unicode.org/development/development-process/design-proposals/\
+#   grammar-and-capitalization-for-date-time-elements
+UPPERCASE_UI = [
+    "sv", "ca", "es", "ru", "uk", "it", "nl", "pt", "pt_PT", "cs", "hr"]
+
+
 class LanguageCode(object):
 
     def __init__(self, code):

--- a/pootle/i18n/gettext.py
+++ b/pootle/i18n/gettext.py
@@ -55,12 +55,10 @@ ungettext_lazy = lazy(ungettext, unicode)
 
 def tr_lang(language_name):
     """Translates language names."""
-    language_code = translation.get_language()
-    if language_code is None:
-        language_code = settings.LANGUAGE_CODE
-    language_code = translation.to_locale(language_code)
-
-    return langdata.tr_lang(language_code)(language_name)
+    return langdata.tr_lang(
+        translation.to_locale(
+            translation.get_language()
+            or settings.LANGUAGE_CODE))(language_name)
 
 
 def language_dir(language_code):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,6 +31,7 @@ pytz==2017.2
 rq==0.8.0
 scandir==1.5
 stemming==1.0.1
+pycountry==17.5.14
 
 # Markup: Markdown filter for POOTLE_MARKUP_FILTER
 bleach==2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,4 +40,4 @@ Markdown==2.6.8
 # Note: also adjust pootle/checks::TTK_MINIMUM_REQUIRED_VERSION
 translate-toolkit==2.2.0
 # If you want to use Translate Toolkit 'master'
-#-e git://github.com/translate/translate.git#egg=translate-toolkit-2.0.0
+#-e git+https://github.com/translate/translate.git#egg=translate-toolkit-2.2.0

--- a/tests/models/language.py
+++ b/tests/models/language.py
@@ -8,6 +8,12 @@
 
 import pytest
 
+from translate.lang.data import get_language_iso_fullname
+
+from django.utils import translation
+
+from pootle.core.delegate import site_languages
+from pootle.i18n.gettext import tr_lang
 from pootle_language.models import Language
 
 
@@ -28,3 +34,39 @@ def test_language_specialchars_uniqueness():
     language.specialchars = u" Čč Ḍḍ Ɛɛ Ǧǧ Ɣɣ  Ḥḥ Ṣṣ ṬṬṭ Ẓẓ Ţţ Ṛṛ‌Ṛṛ‌"
     language.save()
     assert language.specialchars == u" ČčḌḍƐɛǦǧƔɣḤḥṢṣṬṭẒẓŢţṚṛ‌"
+
+
+@pytest.mark.django_db
+def test_language_display_name(english):
+    english.fullname = ""
+    english.save()
+
+    # as fullname is not set - this should default to the pycountry name
+    assert (
+        english.name
+        == get_language_iso_fullname(english.code))
+
+    # lets give english a custom name in db
+    english.fullname = "English (bristol twang)"
+    english.save()
+
+    # as we are translating to server lang, we use lang.fullname
+    # and not the one from pycountry/iso translation
+    assert (
+        english.name
+        == english.fullname)
+
+    with translation.override("fr"):
+        # now request lang has changed (and != server lang)
+        # so we get the translated name
+        assert (
+            english.name
+            == site_languages.get().capitalize(
+                tr_lang(get_language_iso_fullname(english.code))))
+
+    with translation.override("en-GB"):
+        # as request lang is also a dialect of english
+        # it uses the lang.fullname
+        assert (
+            english.name
+            == english.fullname)


### PR DESCRIPTION
It is more standard and ensures there are less problems retrieving a translation for it.

Along with https://github.com/translate/translate/pull/3636, it fixes #6218.