### PR TITLE
Editor: apply gotoUnit(uid) even if uid was not preloaded

### DIFF
--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1139,9 +1139,11 @@ PTL.editor = {
 
   /* Sets the offset in the browser location */
   setOffset(uid) {
-    $.history.load(utils.updateHashPart(
-      'offset', this.getStartOfChunk(this.getOffsetOfUid(uid)))
-    );
+    const offset = this.getOffsetOfUid(uid);
+    if (offset === -1) {
+      return;
+    }
+    $.history.load(utils.updateHashPart('offset', this.getStartOfChunk(offset)));
   },
 
   /* Gets the offset of the last unit currently held by the client */

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1725,11 +1725,12 @@ PTL.editor = {
       return false;
     }
 
+    const $el = e.target.nodeName !== 'TR' ?
+                $(e.target).parents('tr') :
+                $(e.target);
+
     // Ctrl + click / Alt + click / Cmd + click / Middle click opens a new tab
     if (e.ctrlKey || e.altKey || e.metaKey || e.which === 2) {
-      const $el = e.target.nodeName !== 'TR' ?
-                  $(e.target).parents('tr') :
-                  $(e.target);
       window.open($el.data('target'), '_blank');
       return false;
     }
@@ -1751,6 +1752,13 @@ PTL.editor = {
       } else {
         newHash = `unit=${encodeURIComponent(uid)}`;
       }
+
+      const offset = PTL.editor.getOffsetOfUid(uid);
+      if (offset === -1) {
+        window.location.href = $el.data('target');
+        return false;
+      }
+
       $.history.load(newHash);
       PTL.editor.setOffset(uid);
     }


### PR DESCRIPTION
This PR allows `gotoUnit(uid)` go to unit by `uid` if it wasn't loaded into `editor.units.uIds`list.
Fixes #6159. 