### PR TITLE
Dont null submitter for untranslated units

### DIFF
--- a/pootle/apps/pootle_store/receivers.py
+++ b/pootle/apps/pootle_store/receivers.py
@@ -98,17 +98,6 @@ def handle_unit_pre_save(**kwargs):
         unit.setid(unitid.getid())
 
 
-@receiver(pre_save, sender=UnitChange)
-def handle_unit_pre_change(**kwargs):
-    unit_change = kwargs["instance"]
-    unit = unit_change.unit
-    if unit.state == UNTRANSLATED:
-        # clear reviewer and translator data if translation
-        # has been deleted
-        unit_change.submitted_by = None
-        unit_change.submitted_on = None
-
-
 @receiver(post_save, sender=UnitChange)
 def handle_unit_change(**kwargs):
     unit_change = kwargs["instance"]

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -172,13 +172,15 @@
           </div>
           <!-- Translation -->
           <div id="orig{{ unit.index }}" class="js-translate-translation translate-translation" lang="{{ LANGUAGE_CODE }}" dir="{% locale_dir %}">
-            {% if unit.change.submitted_by %}
+            {% if unit.istranslated or unit.isfuzzy %}
+	    {% if unit.change.submitted_by %}
             <div id="target-item-gravatar">
 	      <a href="{% url 'pootle-user-profile' unit.change.submitted_by.username %}"
 		 title="{{ unit.change.submitted_by.display_name|force_escape|force_escape }}">
 		{% avatar unit.change.submitted_by.username unit.change.submitted_by.email_hash 24 %}
 	      </a>
             </div>
+            {% endif %}
             {% endif %}
 
             {% block target_field %}
@@ -210,7 +212,8 @@
               {% endblock %}
               <a class="js-toggle-raw"><i class="icon-raw-mode" title="{% trans 'Raw View' %}"></i></a>
             </div>
-            {% if unit.change.submitted_by and unit.change.submitted_on %}
+            {% if unit.istranslated or unit.isfuzzy %}
+	    {% if unit.change.submitted_by and unit.change.submitted_on %}
             <div class="unit-meta">
               <time
                 title="{{ unit.change.submitted_on|dateformat }}"
@@ -222,6 +225,7 @@
               {% endif %}
               {% endwith %}
             </div>
+            {% endif %}
             {% endif %}
             {% if special_characters %}
               {% if cantranslate or cansuggest %}

--- a/tests/pootle_store/models.py
+++ b/tests/pootle_store/models.py
@@ -8,6 +8,8 @@
 
 import pytest
 
+from pootle_store.constants import UNTRANSLATED
+
 
 @pytest.mark.django_db
 def test_store_update_new_unit_revision(store0):
@@ -28,3 +30,16 @@ def test_store_update_new_unit_revision(store0):
         pk=new_unit.unit_source.pk)
     assert new_unit.revision > unit_source.creation_revision
     assert unit_source.creation_revision == creation_revision
+
+
+@pytest.mark.django_db
+def test_store_update_source_change_subs(store0, member, system):
+    unit = store0.units.filter(state=UNTRANSLATED).first()
+    unit.source = "NEW SOURCE"
+    unit.save()
+    created_sub = unit.submission_set.latest()
+    assert created_sub.submitter == system
+    unit.source = "SOURCE CHANGED BY USER"
+    unit.save(user=member)
+    created_sub = unit.submission_set.latest()
+    assert created_sub.submitter == member


### PR DESCRIPTION
we currently set submitter to none if the unit is untranslated

this means we lose the info about who made whatever change, and breaks
submissions. this change prevents that from happening