### PR TITLE
Add explicit message for auto-translate matched TM

### DIFF
--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -348,6 +348,12 @@ div.translate-container
     clear: both;
 }
 
+
+div.translate-container.error
+{
+    background-color: blue;
+}
+
 div.translate-container.error
 {
     background-color: #fdd;
@@ -1060,7 +1066,7 @@ html[dir="rtl"] .suggestion-original
     border-bottom: 1px solid #d9d9d9;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
-    margin: 0 auto 0.5em;
+    margin: 0 auto 0.1em;
 }
 
 .editor-area-wrapper:first-child
@@ -1727,4 +1733,17 @@ td.translate-delete-terminology input
 .right
 {
     float: right;
+}
+
+
+.js-auto-matched-translation textarea
+{
+    color: #aaa;
+}
+
+.auto-match-msg
+{
+    font-weight: bold;
+    margin-bottom: 0.5em;
+    font-style: italic;
 }

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -252,6 +252,13 @@ PTL.editor = {
       $.history.load('');
     });
 
+    $('#editor').on('keydown', '.js-auto-matched-translation', (e) => {
+      if (e.keyCode !== 17) {
+        $('.js-auto-matched-translation').toggleClass('js-auto-matched-translation', false);
+        $('.js-auto-match-msg').slideUp(200, 'easeOutQuad');
+      }
+    });
+
     /* Write TM results, special chars... into the currently focused element */
     $('#editor').on('click', '.js-editor-copytext', (e) => this.copyText(e));
     $('#editor').on('click', '.js-editor-copy-tm-text', (e) => this.copyTMText(e));
@@ -2186,8 +2193,9 @@ PTL.editor = {
         const isUnitDirty = this.isUnitDirty;
         const text = results[0].target;
         ReactEditor.setValueFor(this.focused || 0, text);
-        this.goFuzzy();
         this.isUnitDirty = isUnitDirty;
+        $('.js-mount-editor').toggleClass('js-auto-matched-translation', true);
+        $('.js-auto-match-msg').slideDown(200, 'easeOutQuad');
       }
     }
 

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -185,6 +185,9 @@
 
             {% block target_field %}
             <div class="js-mount-editor"></div>
+	    <div class="js-auto-match-msg auto-match-msg hide">
+	      {% trans "Showing match from similar translations" %}
+	    </div>
 
             <script type="text/javascript">
               PTL.reactEditor.init({


### PR DESCRIPTION
currently untranslated units with 100% matches in TM are shown as fuzzy and the matched translation is inserted into the editor.

this is confusing, and doesnt reflect the units state in the db

this PR ~~prevents the translation from being copied to the editor, but instead changes the colour of the editor widget to reflect that there is a matched translation~~ adds a message on auto-translated units

fixes #5824 