### PR TITLE
Rid us of manage.py

### DIFF
--- a/docs/developers/setup_windows.rst
+++ b/docs/developers/setup_windows.rst
@@ -110,8 +110,8 @@ Linux system.
 
 .. note:: Depending on how successfully your system has engaged the virtual
    environment, you may have to execute ``pootle`` commands with ``python
-   manage.py`` from the pootle root folder instead (e.g. ``python manage.py
-   migrate`` instead of ``pootle migrate``).
+   pootle/runner.py`` from the pootle root folder instead (e.g. ``python
+   pootle/runner.py migrate`` instead of ``pootle migrate``).
 
 .. code-block:: console
 

--- a/docs/releases/2.8.0.rst
+++ b/docs/releases/2.8.0.rst
@@ -184,8 +184,11 @@ Details of changes
 
   - Updated translations. You can still `contribute translation updates for
     your language <http://pootle.locamotion.org/projects/pootle/>`_.
-  - Now ``compilejsi18n`` is used to compile JavaScript translations into
-    assets, thus requiring ``django-statici18n`` app.
+  - Now `compilejsi18n
+    <http://django-statici18n.readthedocs.io/en/latest/commands.html#compilejsi18n>`_
+    is used to compile JavaScript translations into assets, thus requiring
+    `django-statici18n
+    <http://django-statici18n.readthedocs.io/en/latest/index.html>`_ app.
   - Password reset email is now localizable in Pootle
   - Multiple changes in localizable strings to ease translation
 

--- a/docs/releases/2.8.0.rst
+++ b/docs/releases/2.8.0.rst
@@ -283,7 +283,8 @@ Command changes and additions
 - :djadmin:`export` is now able to export zipped TMX files per translation
   project with the :option:`--tmx <export --tmx>` option.
   :option:`--rotate <export --rotate>` option allows old files to be removed.
-- Added `schema` command that allows to dump the database schema.
+- Added :djadmin:`schema` command that allows to dump the database schema on
+  MySQL which is useful for diagnosing differences in database schema.
 
 
 Changes in settings

--- a/docs/releases/2.8.0.rst
+++ b/docs/releases/2.8.0.rst
@@ -256,6 +256,8 @@ Development changes
 Command changes and additions
 -----------------------------
 
+- Running Pootle commands using `manage.py` is no longer supported, use
+  `pootle` instead.
 - :djadmin:`run_cherrypy` has been removed.
 - :djadmin:`start` has been removed, use :djadmin:`runserver` instead.
 - :djadmin:`verify_user` and :djadmin:`purge_user` now accept multiple

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -579,6 +579,17 @@ Gets, sets, lists, appends and clears pootle configuration settings.
   Treat data as JSON when getting, setting, or appending values.
 
 
+.. django-admin:: schema
+
+schema
+^^^^^^
+
+.. versionadded:: 2.8
+
+Dumps a JSON representation for the Pootle database schema, currently only
+MySQL, for debugging and comparison to a reference database schema.
+
+
 .. _commands#translation-memory:
 
 Translation Memory

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -14,12 +14,6 @@ will run:
 
     $ pootle help
 
-.. note::
-
-  If you run Pootle from a repository checkout you can use the *manage.py* file
-  found in the root of the repository.  Note that this approach is deprecated
-  and may not be supported in future.
-
 
 .. _commands#managing_pootle_projects:
 
@@ -1443,7 +1437,7 @@ For the full details on how to configure cron, read your platform documentation
 (for example ``man crontab``). Here is an example that runs the
 :djadmin:`calculate_checks` command daily at 02:00 AM::
 
-    00 02 * * * www-data /var/www/sites/pootle/manage.py calculate_checks
+    00 02 * * * www-data source /var/www/sites/pootle/env/bin/activate; pootle calculate_checks
 
 Test your command with the parameters you want from the command line. Insert it
 in the cron table, and ensure that it is executed as the correct user (the same

--- a/docs/server/logging.rst
+++ b/docs/server/logging.rst
@@ -20,7 +20,7 @@ store changes, command execution and other activities.
 The generic log message is as follows (though some actions do produce slightly
 different log entries)::
 
-  [2015-05-04T15:06:39]   system  X   ./manage.py update_tmserver
+  [2015-05-04T15:06:39]   system  X   pootle update_tmserver
 
 That is::
 
@@ -59,7 +59,7 @@ Current action types are as follows:
 +----------+--------------+-------------------------------------------------+
 |  SD      | Store        | An existing store was deleted                   |
 +----------+--------------+-------------------------------------------------+
-|  X       | Command      | A ``./manage.py`` command was executed          |
+|  X       | Command      | A ``pootle`` command was executed               |
 +----------+--------------+-------------------------------------------------+
 |  QM      | Quality      | A quality check was muted (marked as a false    |
 |          | check        | positive)                                       |
@@ -132,8 +132,8 @@ Various of the action groups have different message structures as outlined here:
 *Command*::
 
   date  user  action command
-  [2015-05-06T11:24:28]	system	X	./manage.py update_stores --project=vfolders
-  [2015-05-05T20:22:46]	system	X	./manage.py migrate
+  [2015-05-06T11:24:28]	system	X	pootle update_stores --project=vfolders
+  [2015-05-05T20:22:46]	system	X	pootle migrate
 
 *Quality check*::
 

--- a/manage.py
+++ b/manage.py
@@ -9,14 +9,16 @@
 
 import os
 import sys
+import warnings
 
 from django.core.management import execute_from_command_line
 
 from pootle import syspath_override  # noqa
+from pootle.core.log import cmd_log
 
 
 if __name__ == "__main__":
-    from pootle.core.log import cmd_log
+    warnings.warn("Deprecated. Use 'pootle' command instead", DeprecationWarning)
     cmd_log(*sys.argv)
     os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
     execute_from_command_line()

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -19,6 +19,7 @@ from django.core import management
 
 import syspath_override  # noqa
 from pootle.core.cache import PERSISTENT_STORES
+from pootle.core.log import cmd_log
 
 
 logger = logging.getLogger(__name__)
@@ -305,6 +306,7 @@ def run_app(project, default_settings_path, settings_template,
     if args.noinput:
         command += ["--noinput"]
 
+    cmd_log(runner_name, *sys.argv[1:])
     management.execute_from_command_line(command)
     sys.exit(0)
 

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -124,8 +124,8 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 ASSETS_DEBUG = True
 
 # Controls whether bundles should be automatically built and rebuilt. If set to
-# ``False`` you'll need to manually generate the bundles with ``manage.py
-# assets build``.
+# `False` you'll need to manually generate the bundles with `pootle assets
+# build`.
 ASSETS_AUTO_BUILD = True
 
 

--- a/pootle/tools/docs_check_commands.sh
+++ b/pootle/tools/docs_check_commands.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
-# Checks that all our ./manage.py commands have at last a django-admin
+# Checks that all our pootle runner commands have at last a django-admin
 # marker. Really a simple hack to see that they are documented.
 
 BASE_DIR=$(dirname $0)/../..
 DOCS_DIR=$BASE_DIR/docs
 EGREP_EXCLUDE_DIR="--exclude-dir=$DOCS_DIR/_build"
 
-# ./manage.py $command
+# pootle $command
 
 pootle_commands=$(
 for app in pootle_app import_export virtualfolder
 do
-    $BASE_DIR/manage.py --help | \
+    pootle | \
     sed -E -n "/^\[$app\]$/,/^\[/ p" | \
     sed "/^\[/d" | \
     sed "s/^[ ]*//g"
 done)
 
 django_commands=$(
-    $BASE_DIR/manage.py --help | \
+    pootle | \
     sed -E -n "/^\[.*\]$/,$ p" | \
     sed "/^\[/d" | \
     sed "s/^[ ]*//g" | \

--- a/pootle/tools/docs_check_commands.sh
+++ b/pootle/tools/docs_check_commands.sh
@@ -57,6 +57,15 @@ do
     fi
 done
 
+echo
+echo "We don't want manage.py \$command we want pootle \$command"
+for command in $django_commands
+do
+    if [[ ! $(echo "$pootle_commands" | egrep $command) ]]; then
+        egrep -r $EGREP_EXCLUDE_DIR "manage.py $command ?[^<]" $DOCS_DIR
+    fi
+done
+
 
 # POOTLE_* settings
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -179,7 +179,7 @@ known_standard_library=
 known_third_party=elasticsearch,translate,pytest_pootle
 known_django=django
 known_djangoexternal=allauth,contact_form,django_rq,django_comments,sortedm2m
-known_first_party=staticpages,import_export,pootle_fs
+known_first_party=staticpages,import_export,pootle_fs,pootle
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,DJANGOEXTERNAL,FIRSTPARTY,LOCALFOLDER
 # Number of spaces you would like to indent by


### PR DESCRIPTION
* Remove from docs as much as possible
* Warning in ./manage.py - sadly suppressed by default in Python
* Various other docs fixes picked up in doing this cleanup