### PR TITLE
Make initial migrations conditional for accounts/pootle_tp

### DIFF
--- a/docs/server/upgrading.rst
+++ b/docs/server/upgrading.rst
@@ -208,18 +208,9 @@ Migrate your database schema
 Once you have updated your settings you can perform the database schema and
 data upgrade by running. This is done as follows:
 
-.. note:: The following fake migrations are required when migrating from
-   Pootle 2.6 or older.  Subsequent versions do not require these steps:
-
-   .. code-block:: console
-
-      (env) $ pootle migrate accounts 0002 --fake
-      (env) $ pootle migrate pootle_translationproject 0002 --fake
-
-
 .. code-block:: console
 
-   (env) $ pootle migrate
+   (env) $ pootle migrate --fake-initial
 
 
 .. _upgrading#refresh-checks:

--- a/pootle/apps/accounts/migrations/0002_user_alt_src_langs.py
+++ b/pootle/apps/accounts/migrations/0002_user_alt_src_langs.py
@@ -2,6 +2,17 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from django.db.utils import OperationalError
+
+
+class AddFieldIfNotExists(migrations.AddField):
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        try:
+            super(AddFieldIfNotExists, self).database_forwards(
+                app_label, schema_editor, from_state, to_state)
+        except OperationalError:
+            pass
 
 
 class Migration(migrations.Migration):
@@ -12,7 +23,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        AddFieldIfNotExists(
             model_name='user',
             name='alt_src_langs',
             field=models.ManyToManyField(to='pootle_language.Language', db_index=True, verbose_name='Alternative Source Languages', blank=True),


### PR DESCRIPTION
this allows us to simplify the docs for migrations from 2.5, which was causing some confusion