### PR TITLE
Don't create tp if tp directory already exists

### DIFF
--- a/pootle/apps/pootle_project/forms.py
+++ b/pootle/apps/pootle_project/forms.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import os
+
 from django import forms
 from django.db import connection
 from django.forms.models import BaseModelFormSet
@@ -83,6 +85,22 @@ class TranslationProjectForm(forms.ModelForm):
                     translationproject__project_id=project_id))
         self.fields["project"].queryset = self.fields[
             "project"].queryset.filter(pk=project_id)
+
+    def clean(self):
+        if not self.cleaned_data.get("id"):
+            exists_on_disk = (
+                self.cleaned_data["language"].code
+                in os.listdir(self.cleaned_data["project"].get_real_path()))
+            if exists_on_disk:
+                errordict = dict(
+                    lang=self.cleaned_data["language"].code,
+                    path=os.path.join(
+                        self.cleaned_data["project"].get_real_path(),
+                        self.cleaned_data["language"].code))
+                raise forms.ValidationError(
+                    _("Cannot create translation project for language "
+                      "'%(lang)s', path '%(path)s' already exists",
+                      errordict))
 
     def save(self, response_url, commit=True):
         tp = self.instance

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -303,8 +303,12 @@ class ProjectAdminView(PootleAdminView):
                     messages.INFO,
                     _("Translation project (%s) has been deleted" % tp))
         else:
-            messages.add_message(self.request, messages.ERROR,
-                                 self.msg_form_error)
+            for form in formset:
+                for error in form.errors.values():
+                    messages.add_message(
+                        self.request,
+                        messages.ERROR,
+                        error)
 
     def render_formset(self, formset):
 


### PR DESCRIPTION
Currently the tp is created but not populated.

This prevents the tp being created, also improves error handling
in the project form.

Fixes #6081