### PR TITLE
Configurable favicons

### DIFF
--- a/docs/releases/2.8.0.rst
+++ b/docs/releases/2.8.0.rst
@@ -309,8 +309,9 @@ Changes in settings
   sessions are always remembered.
 - :setting:`POOTLE_EMAIL_FEEDBACK_ENABLED` was added, to allow disabling
   sending emails to suggesters when suggestions are accepted or rejected.
-- Added new :setting:`POOTLE_CUSTOM_LOGO`, :setting:`POOTLE_FS_WORKING_PATH`
-  and :setting:`POOTLE_CANONICAL_URL` settings.
+- Added new :setting:`POOTLE_CUSTOM_LOGO`, :setting:`POOTLE_FAVICONS_PATH`,
+  :setting:`POOTLE_FS_WORKING_PATH` and
+  :setting:`POOTLE_CANONICAL_URL` settings.
 - Deprecated `POOTLE_QUALITY_CHECKER` setting.
 - Added new :setting:`POOTLE_SQL_MIGRATIONS` setting.
 - :setting:`POOTLE_MARKUP_FILTER` defaults to `'markdown'`, and `None`,

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -182,6 +182,16 @@ Site-specific settings.
   Custom logo URL - this can be an absolute or relative URL.
 
 
+.. setting:: POOTLE_FAVICONS_PATH
+
+``POOTLE_FAVICONS_PATH``
+  Default: ``"/assets/favicon"``
+
+  .. versionadded:: 2.8
+
+  Customisable favicon path. Should not end with trailing slash.
+
+
 40-apps.conf
 ^^^^^^^^^^^^
 

--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -43,6 +43,7 @@ def pootle_context(request):
         'settings': {
             'POOTLE_CUSTOM_LOGO': getattr(settings, "POOTLE_CUSTOM_LOGO", ""),
             'POOTLE_TITLE': settings.POOTLE_TITLE,
+            'POOTLE_FAVICONS_PATH': settings.POOTLE_FAVICONS_PATH,
             'POOTLE_INSTANCE_ID': settings.POOTLE_INSTANCE_ID,
             'POOTLE_CONTACT_ENABLED': (settings.POOTLE_CONTACT_ENABLED and
                                        settings.POOTLE_CONTACT_EMAIL),

--- a/pootle/settings/30-site.conf
+++ b/pootle/settings/30-site.conf
@@ -18,6 +18,7 @@ DEBUG = False
 POOTLE_CANONICAL_URL = "http://localhost"
 
 POOTLE_CUSTOM_LOGO = ""
+POOTLE_FAVICONS_PATH = "/assets/favicon"
 
 # A list of strings representing the host/domain names that this Pootle server
 # can serve. This is a Django's security measure. More details at

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -18,13 +18,13 @@
     {% block css_overrides %}
     {% endblock css_overrides %}
     {% block favicon %}
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'favicon/apple-touch-icon.png' %}">
-    <link rel="icon" type="image/png" href="{% static 'favicon/favicon-32x32.png' %}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{% static 'favicon/favicon-16x16.png' %}" sizes="16x16">
-    <link rel="manifest" href="{% static 'favicon/manifest.json' %}">
-    <link rel="mask-icon" href="{% static 'favicon/safari-pinned-tab.svg' %}" color="#5bbad5">
-    <link rel="shortcut icon" href="{% static 'favicon/favicon.ico' %}">
-    <meta name="msapplication-config" content="{% static 'favicon/browserconfig.xml' %}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ settings.POOTLE_FAVICONS_PATH }}/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="{{ settings.POOTLE_FAVICONS_PATH }}/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ settings.POOTLE_FAVICONS_PATH }}/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="{{ settings.POOTLE_FAVICONS_PATH }}/manifest.json">
+    <link rel="mask-icon" href="{{ settings.POOTLE_FAVICONS_PATH }}/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="shortcut icon" href="{{ settings.POOTLE_FAVICONS_PATH }}/favicon.ico">
+    <meta name="msapplication-config" content="{{ settings.POOTLE_FAVICONS_PATH }}/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     {% endblock favicon %}
     {% block js %}


### PR DESCRIPTION
this PR allows favicons to be customized for each pootle site.

~~it doesnt catch all possible favicons (eg android), but will allow configuration for common desktop browsers.~~

fixes #4948 

~~(still needs some changes to docs before landing)~~
