### PR TITLE
Pin "requests" to version 2.18.0 to prevent dep issue with urllib

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,6 +28,7 @@ pathlib==1.0.1
 python-dateutil==2.6.0
 python-levenshtein==0.12.0
 pytz==2017.2
+requests==2.18.0
 rq==0.8.0
 scandir==1.5
 stemming==1.0.1


### PR DESCRIPTION
fixes broken commands with `pkg_resources.ContextualVersionConflict`