### PR TITLE
Use 'pootle init' always instead of 90-*local.conf

### DIFF
--- a/docs/developers/setup_linux.rst
+++ b/docs/developers/setup_linux.rst
@@ -54,10 +54,10 @@ available, we can create our virtual environment.
 
 .. code-block:: console
 
-    $ mkvirtualenv <env-name>
+    $ mkvirtualenv pootle_env
 
 
-Replace ``<env-name>`` with a meaningful name that describes the environment
+Replace ``pootle_env`` with a meaningful name that describes the environment
 you are creating. :ref:`mkvirtualenv <virtualenvwrapper:command-mkvirtualenv>`
 accepts any options that :command:`virtualenv` accepts. We could for example
 specify to use the Python 3.3 interpreter by passing the `-p python3.3
@@ -69,7 +69,7 @@ specify to use the Python 3.3 interpreter by passing the `-p python3.3
 
    .. code-block:: console
 
-      (env-name) $ deactivate
+      (pootle_env) $ deactivate
 
 
    To activate a virtual environment again use :ref:`workon
@@ -77,7 +77,7 @@ specify to use the Python 3.3 interpreter by passing the `-p python3.3
 
    .. code-block:: console
 
-      $ workon <env-name>
+      $ workon pootle_env
 
 
 First, upgrade the version of :command:`pip` and :command:`setuptools` as
@@ -85,7 +85,7 @@ follows:
 
 .. code-block:: console
 
-   (env-name) $ pip install --upgrade pip setuptools
+   (pootle_env) $ pip install --upgrade pip setuptools
 
 
 Time to clone Pootle's source code repository. The main repository lives under
@@ -96,7 +96,7 @@ Time to clone Pootle's source code repository. The main repository lives under
 
 .. code-block:: console
 
-    (env-name) $ git clone https://github.com/translate/pootle.git
+    (pootle_env) $ git clone https://github.com/translate/pootle.git
 
 
 Install Pootle and its development dependencies into your virtualenv.  This
@@ -107,7 +107,7 @@ development (you can examine these in :file:`requirements/dev.txt`).
 
 .. code-block:: console
 
-    (env-name) $ pip install -e .[dev]
+    (pootle_env) $ pip install -e .[dev]
 
 
 .. note:: Some requirements may depend on external packages.  For these you may
@@ -125,7 +125,7 @@ this file and rename it by removing the *.sample* extension:
 
 .. code-block:: console
 
-    (env-name) $ cp pootle/settings/90-dev-local.conf.sample ~/.pootle/pootle.conf
+    (pootle_env) $ cp pootle/settings/90-dev-local.conf.sample ~/.pootle/pootle.conf
 
 
 .. note:: To learn more about how settings work in Pootle read the
@@ -137,8 +137,8 @@ schema and add initial data.
 
 .. code-block:: console
 
-    (env-name) $ pootle migrate
-    (env-name) $ pootle initdb
+    (pootle_env) $ pootle migrate
+    (pootle_env) $ pootle initdb
 
 
 Now ensure that you have built the assets by following the instructions for
@@ -148,7 +148,7 @@ Finally, run the development server.
 
 .. code-block:: console
 
-    (env-name) $ pootle runserver
+    (pootle_env) $ pootle runserver
 
 
 Once all is done, you can start the development server anytime by enabling the

--- a/docs/developers/setup_linux.rst
+++ b/docs/developers/setup_linux.rst
@@ -117,15 +117,11 @@ development (you can examine these in :file:`requirements/dev.txt`).
 
 With all the dependencies installed within the virtual environment, Pootle is
 almost ready to run. In development environments you will want to use settings
-that vastly differ from those used in production environments.
-
-For that purpose there is a sample configuration file with settings adapted for
-development scenarios, :file:`pootle/settings/90-dev-local.conf.sample`. Copy
-this file and rename it by removing the *.sample* extension:
+that differ from those used in production environments.
 
 .. code-block:: console
 
-    (pootle_env) $ cp pootle/settings/90-dev-local.conf.sample ~/.pootle/pootle.conf
+    (pootle_env) $ pootle init --dev
 
 
 .. note:: To learn more about how settings work in Pootle read the

--- a/docs/developers/setup_windows.rst
+++ b/docs/developers/setup_windows.rst
@@ -51,10 +51,6 @@ Clone your fork of the Pootle master using your favourite Windows
 implementation of Git so that you have a working copy somewhere accessible on
 your computer (e.g. ``C:\git\pootle``).
 
-First, rename ``90-dev-local.conf.sample`` to ``90-dev-local.conf`` (in
-``pootle\settings``) to enable a basic configuration suitable for local
-hacking.
-
 Then go to the Pootle ``requirements\base.txt`` and comment out the following
 packages:
 
@@ -115,6 +111,7 @@ Linux system.
 
 .. code-block:: console
 
+    (venv)> pootle init --dev
     (venv)> pootle migrate
     (venv)> pootle initdb
 

--- a/docs/developers/setup_windows.rst
+++ b/docs/developers/setup_windows.rst
@@ -22,8 +22,8 @@ Detailed setup
 ^^^^^^^^^^^^^^
 
 .. note:: For convenience these instructions consistently specify paths
-    ``C:\venv``, ``C:\git\pootle`` and ``C:\temp``, but you can change these to
-    suit your environment and needs.
+    ``C:\pootle_venv``, ``C:\git\pootle`` and ``C:\temp``, but you can change
+    these to suit your environment and needs.
 
 .. note:: Depending on how correctly your environment is set up (depending on
    factors beyond your control such as virus scanners, Windows system health,
@@ -38,14 +38,14 @@ virtualenv.
 .. code-block:: console
 
     > pip install virtualenv
-    > virtualenv C:\venv
+    > virtualenv C:\pootle_venv
 
 Activate the new virtualenv and upgrade pip:
 
 .. code-block:: console
 
-    > C:\venv\Scripts\activate
-    (venv)> pip install --upgrade pip setuptools
+    > C:\pootle_venv\Scripts\activate
+    (pootle_venv)> pip install --upgrade pip setuptools
 
 Clone your fork of the Pootle master using your favourite Windows
 implementation of Git so that you have a working copy somewhere accessible on
@@ -71,9 +71,9 @@ Now install them explicitly:
 
 .. code-block:: console
 
-    (venv)> pip install C:\temp\lxml-3.6.4-cp27-cp27m-win32.whl
-    (venv)> pip install C:\temp\python_Levenshtein-0.12.0-cp27-none-win32.whl
-    (venv)> pip install C:\temp\scandir-1.2-cp27-none-win32.whl
+    (pootle_venv)> pip install C:\temp\lxml-3.6.4-cp27-cp27m-win32.whl
+    (pootle_venv)> pip install C:\temp\python_Levenshtein-0.12.0-cp27-none-win32.whl
+    (pootle_venv)> pip install C:\temp\scandir-1.2-cp27-none-win32.whl
 
 At this point, you may be able to install Pootle and its requirements using the
 following command. However, pip installation of requirements may fail with
@@ -82,8 +82,8 @@ use the commands in the next note block.
 
 .. code-block:: console
 
-    (venv)> cd C:\git\pootle
-    (venv)> pip install -e .[dev]
+    (pootle_venv)> cd C:\git\pootle
+    (pootle_venv)> pip install -e .[dev]
 
 .. note:: "Directory was not empty" and "file not found" issues come from
    modern versions of Windows' tighter control over permissions for special
@@ -94,10 +94,10 @@ use the commands in the next note block.
     
     .. code-block:: console
     
-        (venv)> pip download -d C:\temp -r requirements\dev.txt -b C:\temp
-        (venv)> pip install -r requirements\dev.txt -b C:\temp -t C:\venv\Lib\site-packages\ --no-index --find-links="C:\temp"
-        (venv)> cd C:\git\pootle
-        (venv)> pip install -e .
+        (pootle_venv)> pip download -d C:\temp -r requirements\dev.txt -b C:\temp
+        (pootle_venv)> pip install -r requirements\dev.txt -b C:\temp -t C:\pootle_venv\Lib\site-packages\ --no-index --find-links="C:\temp"
+        (pootle_venv)> cd C:\git\pootle
+        (pootle_venv)> pip install -e .
 
 
 Now that all the requirements are lined up, we are ready to initialise Pootle.
@@ -111,9 +111,9 @@ Linux system.
 
 .. code-block:: console
 
-    (venv)> pootle init --dev
-    (venv)> pootle migrate
-    (venv)> pootle initdb
+    (pootle_venv)> pootle init --dev
+    (pootle_venv)> pootle migrate
+    (pootle_venv)> pootle initdb
 
 Next, you will need to set up the client-side bundles with NPM. It might be
 necessary to deactivate the virtual environment or use a separate command
@@ -129,8 +129,8 @@ Once NPM install has completed, the actual javascript bundles can be compiled:
 
 .. code-block:: console
 
-    (venv)> cd C:\git\pootle
-    (venv)> pootle webpack --dev
+    (pootle_venv)> cd C:\git\pootle
+    (pootle_venv)> pootle webpack --dev
 
 The :djadmin:`webpack` command will keep running after it's completed, to
 monitor your javascript files for changes so that it can auto-recompile as you
@@ -143,15 +143,15 @@ preparations:
 
 .. code-block:: console
 
-    (venv)> pootle compilejsi18n
+    (pootle_venv)> pootle compilejsi18n
 
 Now create and verify a super-user as normal:
 
 .. code-block:: console
 
-    (venv)> pootle createsuperuser
+    (pootle_venv)> pootle createsuperuser
     [Follow on-screen prompts.]
-    (venv)> pootle verify_user [username]
+    (pootle_venv)> pootle verify_user [username]
 
 Pootle is now ready to be fired up!
 
@@ -161,11 +161,11 @@ server):
 
 .. code-block:: console
 
-    (venv)> pootle rqworker
+    (pootle_venv)> pootle rqworker
 
 .. code-block:: console
 
-    (venv)> pootle runserver
+    (pootle_venv)> pootle runserver
 
 Congratulations, Pootle should now be running comfortably! Happy hacking on
 Windows!!

--- a/docs/server/apache-virtualhost.conf
+++ b/docs/server/apache-virtualhost.conf
@@ -23,17 +23,8 @@ WSGIPythonOptimize 1
     ServerName my-pootle.example.com
 
     # Set the 'POOTLE_SETTINGS' environment variable pointing at your custom
-    # Pootle settings file.
-    #
-    # If you don't know which settings to include in this file you can use
-    # the file '90-local.conf.sample' as a starting point. This file can be
-    # found at '/var/www/pootle/env/lib/python2.7/site-packages/pootle/settings/'.
-    #
-    # Another way to specify your custom settings is to comment this
-    # directive and add a new '90-local.conf' file (by copying the file
-    # '90-local.conf.sample' and changing the desired settings) in
-    # '/var/www/pootle/env/lib/python2.7/site-packages/pootle/settings/'
-    # (default location for a pip-installed Pootle, having Python 2.7).
+    # Pootle settings file.  An initial settings file can be created using
+    # 'pootle init'
     #
     # This might require enabling the 'env' module.
     SetEnv POOTLE_SETTINGS /var/www/pootle/your_custom_settings.conf

--- a/docs/server/cache.rst
+++ b/docs/server/cache.rst
@@ -45,8 +45,7 @@ Django supports :ref:`multiple cache backends <django:setting-up-the-cache>`
 (methods of storing cache data).  However, Redis is the only cache backend
 supported by Pootle.  We use some custom features of Redis so cannot support
 other backends. You can customise the Redis cache settings by overriding the
-value of :setting:`CACHES` in your configuration file, an example exists in
-file:`90-local.conf.sample`.
+value of :setting:`CACHES` in your configuration file.
 
 
 .. _Django's caching system: https://docs.djangoproject.com/en/1.10/topics/cache/

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -25,13 +25,6 @@ set the :envvar:`POOTLE_SETTINGS` environment variable to specify the path to
 the custom configuration file. The environment variable will take precedence
 over the command-line flag.
 
-If instead of an installation you deployed Pootle straight from the git
-repository, you can either set the :envvar:`POOTLE_SETTINGS` environment
-variable or put a file under the :file:`pootle/settings/` directory. Note that
-the files in this directory are read in alphabetical order, and **creating a
-90-local.conf file is recommended** (files ending in *-local.conf* will be
-ignored by git).
-
 
 .. _settings#available:
 

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -123,7 +123,7 @@ def init_command(parser, args):
                         default=os.path.join(src_dir,
                                              'settings/90-local.conf.template'),
                         const=os.path.join(src_dir,
-                                           'settings/90-dev-local.conf.sample'),
+                                           'settings/90-dev-local.conf.template'),
                         action='store_const',
                         help=(u"Use a development configuration."))
     parser.add_argument("--db",

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -51,7 +51,8 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
             ],
             # .filesystem.Loader is enabled to allow easy customisation
-            # with custom templates. See TEMPLATES[0] in 90-local.conf.template
+            # with custom templates. See TEMPLATES[0] in pootle.conf for an
+            # example.
             'loaders': [
                 #: Must be before .app_directories.Loader
                 'django.template.loaders.filesystem.Loader',

--- a/pootle/settings/60-translation.conf
+++ b/pootle/settings/60-translation.conf
@@ -54,7 +54,7 @@ AMAGAMA_URL = 'https://amagama-live.translatehouse.org/api/v1/'
 # List of available source languages in AMAGAMA
 AMAGAMA_SOURCE_LANGUAGES = ('en', 'en_US', 'en-US')
 
-# See 90-local.conf.template for example configuration for local TM server
+# See pootle.conf example configuration for local TM server
 POOTLE_TM_SERVER = {}
 
 # Wordcounts

--- a/pootle/settings/90-dev-local.conf.template
+++ b/pootle/settings/90-dev-local.conf.template
@@ -4,9 +4,6 @@
 
 This file includes settings that are suited for hacking Pootle. For further
 customizations, you can find the defaults in the ``*.conf`` files.
-
-In order for this configuration changes to take effect, bear in mind that you
-need to change the extension of this file from ``.conf.sample`` to ``.conf``.
 """
 
 #

--- a/pootle/settings/90-dev-local.conf.template
+++ b/pootle/settings/90-dev-local.conf.template
@@ -18,8 +18,8 @@ POOTLE_TITLE = u'Pootle Development Server'
 
 POOTLE_INSTANCE_ID = 'development'
 
-# Some dummy secret key fine for dev
-SECRET_KEY = '__P00TL3d3vS3CR3T__'
+# A dummy secret key fine for dev
+SECRET_KEY = %(default_key)s
 
 # General Django debugging settings
 
@@ -42,21 +42,29 @@ ALLOWED_HOSTS = [
 # Database backend settings
 DATABASES = {
     'default': {
-        # Although has issues with locking, SQLite is handy for development
-        'ENGINE': 'django.db.backends.sqlite3',
+        # Replace 'sqlite3' with 'postgresql' or 'mysql'.
+        'ENGINE': %(db_engine)s,
         # Database name or path to database file if using sqlite3.
-        'NAME': working_path('dbs/pootle.db'),
+        'NAME': %(db_name)s,
         # Not used with sqlite3.
-        'USER': '',
+        'USER': %(db_user)s,
         # Not used with sqlite3.
-        'PASSWORD': '',
+        'PASSWORD': %(db_password)s,
         # Set to empty string for localhost. Not used with sqlite3.
-        'HOST': '',
+        'HOST': %(db_host)s,
         # Set to empty string for default. Not used with sqlite3.
-        'PORT': '',
+        'PORT': %(db_port)s,
         # See https://docs.djangoproject.com/en/1.10/topics/db/transactions/
         # required for Django + sqlite
         'ATOMIC_REQUESTS': True,
+        #'OPTIONS' : {
+        #    # MySQL:
+        #    # https://docs.djangoproject.com/en/1.10/ref/databases/#setting-sql-mode
+        #    'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        #},
+        'TEST': {
+            'NAME': 'test_pootle',
+        }
     }
 }
 

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -4,9 +4,6 @@
 
 This file includes the settings that administrators will likely change.
 You can find the defaults in the ``*.conf`` files for more advanced settings.
-
-In order for this configuration changes to take effect, bear in mind that you
-need to change the extension of this file from ``.conf.sample`` to ``.conf``.
 """
 
 from pootle.i18n.gettext import ugettext_lazy as _


### PR DESCRIPTION
There are some more of these.  But it might mean adding a `pootle init --dev` option so we can get rid of `cp 90-local-dev.conf.sample pootle.conf`

@phlax might be best for me to idle this till your where is `pootle.conf` change lands.

Fixes #5210 