### PR TITLE
Add extra attr overrides to Markdown cleaning

### DIFF
--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -269,6 +269,14 @@ Configuration settings for applications used by Pootle.
     POOTLE_MARKUP_FILTER = ('markdown', {
                                 'clean': {
                                     'extra_tags': ['div'],
+                                    'extra_attrs': {
+                                        '*': ['style']
+                                        'img': ['alt'],
+                                    },
+                                    'extra_styles': [
+                                        'color',
+                                        'font-weight'
+                                    ],
                                 },
                             })
 

--- a/pootle/core/markup/filters.py
+++ b/pootle/core/markup/filters.py
@@ -137,22 +137,34 @@ def apply_markup_filter(text):
             import bleach
             import markdown
 
-            # See ALLOWED_TAGS in
-            # https://github.com/mozilla/bleach/blob/master/bleach/__init__.py
+            # See ALLOWED_TAGS, ALLOWED_ATTRIBUTES and ALLOWED_STYLES
+            # https://github.com/mozilla/bleach/blob/master/bleach/sanitizer.py
             tags = bleach.ALLOWED_TAGS + [
                 u'h1', u'h2', u'h3', u'h4', u'h5',
                 u'p', u'pre',
                 u'img',
                 u'hr',
             ]
+            attrs = bleach.ALLOWED_ATTRIBUTES
+            styles = bleach.ALLOWED_STYLES
 
             tags_provided = ('clean' in markup_kwargs
                              and 'extra_tags' in markup_kwargs['clean'])
             if tags_provided:
                 tags += markup_kwargs['clean']['extra_tags']
 
+            attrs_provided = ('clean' in markup_kwargs
+                              and 'extra_attrs' in markup_kwargs['clean'])
+            if attrs_provided:
+                attrs.update(markup_kwargs['clean']['extra_attrs'])
+
+            styles_provided = ('clean' in markup_kwargs
+                               and 'extra_styles' in markup_kwargs['clean'])
+            if styles_provided:
+                styles += markup_kwargs['clean']['extra_styles']
+
             html = bleach.clean(markdown.markdown(text, **markup_kwargs),
-                                tags=tags)
+                                tags=tags, attributes=attrs, styles=styles)
 
         elif markup_filter_name == 'restructuredtext':
             from docutils import core

--- a/pootle/core/markup/filters.py
+++ b/pootle/core/markup/filters.py
@@ -144,6 +144,7 @@ def apply_markup_filter(text):
                 u'p', u'pre',
                 u'img',
                 u'hr',
+                u'span',
             ]
             attrs = bleach.ALLOWED_ATTRIBUTES
             styles = bleach.ALLOWED_STYLES

--- a/pootle/core/markup/filters.py
+++ b/pootle/core/markup/filters.py
@@ -146,7 +146,10 @@ def apply_markup_filter(text):
                 u'hr',
                 u'span',
             ]
-            attrs = bleach.ALLOWED_ATTRIBUTES
+            attrs = bleach.ALLOWED_ATTRIBUTES.copy()
+            attrs.update({
+                'img': ['alt', 'src'],
+            })
             styles = bleach.ALLOWED_STYLES
 
             tags_provided = ('clean' in markup_kwargs

--- a/tests/core/markup/filter.py
+++ b/tests/core/markup/filter.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle.core.markup.filters import apply_markup_filter
+
+
+@pytest.mark.parametrize('markdown_text, expected_html, config', [
+    # Blank
+    ('', '', {}),
+    (' \t', '', {}),
+    # Standard markdown
+    ('Paragraph', '<p>Paragraph</p>', {}),
+    ('## Header', '<h2>Header</h2>', {}),
+    ('* List', '<ul><li>List</li></ul>', {}),
+    ('<hr>', '<hr>', {}),
+    # Accept img tags since markdown is rubbish at images
+    ('Show icon <img alt="image" src="pic.png">',
+     '<p>Show icon <img alt="image" src="pic.png"></p>', {}),
+    # Escape a <script> tag
+    ('Bad hacker <script>alert("Bang!")</script>',
+     '<p>Bad hacker &lt;script&gt;alert("Bang!")&lt;/script&gt;</p>', {}),
+    # Extra tags
+    ('Unknown <tag>Escaped</tag>',
+     '<p>Unknown &lt;tag&gt;Escaped&lt;/tag&gt;</p>', {}),
+    ('Extra <tag>Included</tag>',
+     '<p>Extra <tag>Included</tag></p>',
+     {'clean': {
+         'extra_tags': ['tag'],
+     }}),
+    # Extra attributes
+    ('Unknown <a attr="no">Escaped</a>',
+     '<p>Unknown <a>Escaped</a></p>', {}),
+    ('Extra <a attr="yes">Included</a>',
+     '<p>Extra <a attr="yes">Included</a></p>',
+     {'clean': {
+         'extra_attrs': {'a': ['attr']},
+     }}),
+    # Extra styles
+    ('Unknown <a style="color: remove;">Escaped</a>',
+     '<p>Unknown <a>Escaped</a></p>', {}),
+    ('Extra <a style="color: accept;">Included</a>',
+     '<p>Extra <a style="color: accept;">Included</a></p>',
+     {'clean': {
+         'extra_attrs': {'*': ['style']},
+         'extra_styles': ['color'],
+     }}),
+])
+def test_apply_markup_filter(settings, markdown_text, expected_html, config):
+    settings.POOTLE_MARKUP_FILTER = ('markdown', config)
+    output_html = apply_markup_filter(markdown_text)
+    output_html = output_html[5:-6]  # Remove surrounding <div>...</div>
+    output_html = output_html.replace('\n', '')  # Remove pretty print newlines
+    assert output_html == expected_html


### PR DESCRIPTION
* Allows users to add extra default bleach attr filtering.
* Adds tests for Markdown parsing and cleaning