### PR TITLE
Retrieve checker for every unit if no TP is specified

### DIFF
--- a/pootle/apps/pootle_checks/utils.py
+++ b/pootle/apps/pootle_checks/utils.py
@@ -298,7 +298,7 @@ class QualityCheckUpdater(object):
             if self.translation_project is not None:
                 # if TP is set then manually add TP.id to the Unit value dict
                 unit[tp_key] = self.translation_project.id
-            elif checker is None:
+            else:
                 checker = self.get_checker(unit[tp_key])
             if checker and self.update_translated_unit(unit, checker=checker):
                 updated_count += 1


### PR DESCRIPTION
Previously the checker was retrieved only for the first unit and it was used
for calculating the checks for all the units, no matter which TP they belonged to.

Fixes #6519.