### PR TITLE
Update to work with apache 2.4 out of the box

### DIFF
--- a/docs/server/apache-virtualhost.conf
+++ b/docs/server/apache-virtualhost.conf
@@ -65,8 +65,10 @@ WSGIPythonOptimize 1
     # separate server.
     Alias /assets /var/www/pootle/env/lib/python2.7/site-packages/pootle/assets
     <Directory /var/www/pootle/env/lib/python2.7/site-packages/pootle/assets>
-        Order deny,allow
-        Allow from all
+        Require all granted
+        # For apache 2.2, comment the line directly above, and uncommend the two lines directly below
+        #Order deny,allow
+        #Allow from all
     </Directory>
 
 </VirtualHost>


### PR DESCRIPTION
This update allows static assets to be displayed out of the box when using Apache 2.4.  Apache 2.2 users will receive an error (among the other errors they may already have to fix), which will lead them directly to the comment.

Of course, this might not be the best approach, as the PR process may bring to light.

This was found while installing Pootle on Ubuntu 16.04 with the default version of Apache (2.4.18)