### PR TITLE
Allow git command to be missing

### DIFF
--- a/pootle/core/utils/version.py
+++ b/pootle/core/utils/version.py
@@ -236,14 +236,17 @@ def get_git_branch():
 
 @lru_cache()
 def get_git_hash():
-    """Returns the current git commit hash.
+    """Returns the current git commit hash or None.
 
     >>> get_git_hash()
     'ad768e8'
     """
-    return _shell_command(
+    git_hash = _shell_command(
         ['/usr/bin/git', 'rev-parse', '--verify', '--short', 'HEAD']
-    ).strip()
+    )
+    if git_hash:
+        return git_hash.strip()
+    return None
 
 
 if __name__ == "__main__":

--- a/pootle/core/utils/version.py
+++ b/pootle/core/utils/version.py
@@ -185,13 +185,16 @@ def _shell_command(command):
     """Return the first result of a shell ``command``"""
     repo_dir = os.path.dirname(os.path.abspath(__file__))
 
-    command_subprocess = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=repo_dir,
-        universal_newlines=True
-    )
+    try:
+        command_subprocess = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=repo_dir,
+            universal_newlines=True
+        )
+    except OSError:
+        return None
 
     return command_subprocess.communicate()[0]
 

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -347,7 +347,7 @@ def get_version():
         githash = "[%s] " % githash
 
     return ("Pootle %s %s(Django %s, Translate Toolkit %s)" %
-            (__version__, githash, django_version(), tt_version.sver))
+            (__version__, githash or '', django_version(), tt_version.sver))
 
 
 def main():


### PR DESCRIPTION
Since we introduced the git hash into the version we're expecting to have the git command.  On a docker install this might specifically be excluded, so make calling these version helpers more robust.