### PR TITLE
Version caches

### DIFF
--- a/pootle/apps/pootle_app/apps.py
+++ b/pootle/apps/pootle_app/apps.py
@@ -24,6 +24,7 @@ from pootle.core.utils import deprecation
 class PootleConfig(AppConfig):
     name = "pootle_app"
     verbose_name = "Pootle"
+    version = "0.0.1"
 
     def ready(self):
         checks.register(deprecation.check_deprecated_settings, "settings")

--- a/pootle/apps/pootle_app/panels.py
+++ b/pootle/apps/pootle_app/panels.py
@@ -15,8 +15,12 @@ from pootle.core.decorators import persistent_property
 from pootle.core.views.panels import TablePanel
 from pootle.i18n.dates import timesince
 
+from .apps import PootleConfig
+
 
 class ChildrenPanel(TablePanel):
+    ns = "pootle.app"
+    sw_version = PootleConfig.version
     panel_name = "children"
     _table_fields = (
         'name', 'progress', 'activity',

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -349,6 +349,8 @@ def project_admin_permissions(request, project):
 
 
 class ProjectsMixin(object):
+    ns = "pootle.project"
+    sw_version = PootleProjectConfig.version
     template_extends = 'projects/all/base.html'
     browse_url_path = "pootle-projects-browse"
     translate_url_path = "pootle-projects-translate"


### PR DESCRIPTION
allows caches to be properly expired for new versions