### PR TITLE
Added create_project pootle command

### DIFF
--- a/pootle/apps/pootle_app/management/commands/create_project.py
+++ b/pootle/apps/pootle_app/management/commands/create_project.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+import traceback
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
+
+from django.db import transaction
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ValidationError
+from django.core.management import CommandError
+from django.core.validators import validate_email
+
+from pootle.core.delegate import formats
+from pootle_fs.delegate import fs_plugins
+from pootle_fs.presets import FS_PRESETS
+from pootle_language.models import Language
+from pootle_project.models import Project, PROJECT_CHECKERS
+
+
+class Command(BaseCommand):
+    help = "Creates a new project from command line."
+
+    def add_arguments(self, parser):
+        format_names = formats.get().keys()
+        fs_plugins_names = fs_plugins.gather().keys()
+
+        parser.add_argument(
+            'code',
+            action='store',
+            help='Project code',
+        )
+        parser.add_argument(
+            "--name",
+            action="store",
+            dest="name",
+            help="Project name",
+        )
+        parser.add_argument(
+            "--filetype",
+            action="append",
+            dest="filetypes",
+            choices=format_names,
+            default=[],
+            help="File types: {0}. Default: po".format(
+                 " | ".join(format_names)),
+        )
+        mapping_group = parser.add_mutually_exclusive_group(required=True)
+        mapping_group.add_argument(
+            "--preset-mapping",
+            action="store",
+            dest="preset_mapping",
+            choices=FS_PRESETS.keys(),
+            help="Filesystem layout preset: {0}".format(
+                 " | ".join(FS_PRESETS.keys())),
+        )
+        mapping_group.add_argument(
+            "--mapping",
+            action="store",
+            dest="mapping",
+            help="Custom filesystem layout",
+        )
+        parser.add_argument(
+            "--fs-type",
+            action="store",
+            dest="fs_type",
+            default="localfs",
+            choices=fs_plugins_names,
+            help="Filesystem type: {0}".format(" | ".join(fs_plugins_names)),
+        )
+        parser.add_argument(
+            "--fs-url",
+            action="store",
+            dest="fs_url",
+            default="",
+            help="Filesystem path or URL.",
+        )
+        parser.add_argument(
+            "--source-language",
+            action="store",
+            dest="sourcelang",
+            default="en",
+            help=("Source language. Examples: [en | es | fr | ...]."
+                  "Default: %(default)s"),
+        )
+        parser.add_argument(
+            "--report-email",
+            action="store",
+            default="",
+            dest="contact",
+            help="Contact email for reports. Example: admin@mail.com.",
+        )
+        parser.add_argument(
+            "--disabled",
+            action="store_true",
+            dest="disabled",
+            help="Does the project start disabled?",
+        )
+        parser.add_argument(
+            "--checkstyle",
+            action="store",
+            dest="checkstyle",
+            choices=PROJECT_CHECKERS.keys(),
+            default="standard",
+            help="Quality check styles. Example: {0}. Default: %(default)s"
+                 .format(" | ".join(PROJECT_CHECKERS.keys())),
+        )
+
+    @transaction.atomic
+    def handle(self, **options):
+        """Imitates the behaviour of the admin interface
+        for creating a project from command line.
+        """
+        self.check_project_options(**options)
+        self.set_project_config(
+            self.create_project(**options), **options)
+
+    def check_project_options(self, **options):
+        if options["contact"]:
+            try:
+                validate_email(options["contact"])
+            except ValidationError as e:
+                if options["traceback"]:
+                    traceback.print_exc()
+                raise CommandError(e)
+        if options["fs_type"] != "localfs" and options["fs_url"] == "":
+            raise CommandError("Parameter --fs-url is mandatory "
+                               "when --fs-type is not `localfs`")
+
+    def create_project(self, **options):
+        try:
+            return Project.objects.create(
+                code=options["code"],
+                fullname=options["name"] or options["code"].capitalize(),
+                checkstyle=options["checkstyle"],
+                source_language=self.get_source_language(**options),
+                filetypes=options["filetypes"] or ["po"],
+                report_email=options["contact"],
+                disabled=options["disabled"])
+        except ValidationError as e:
+            if options["traceback"]:
+                traceback.print_exc()
+            raise CommandError(e)
+
+    def get_source_language(self, **options):
+        try:
+            return Language.objects.get(code=options["sourcelang"])
+        except Language.DoesNotExist:
+            raise CommandError("Source language %s does not exist"
+                               % options["sourcelang"])
+
+    def set_project_config(self, project, **options):
+        mapping = (
+            dict(default=FS_PRESETS[options["preset_mapping"]][0])
+            if options["preset_mapping"]
+            else dict(default=options["mapping"]))
+        try:
+            project.config["pootle_fs.translation_mapping"] = mapping
+            project.config["pootle_fs.fs_type"] = options["fs_type"]
+            if options["fs_url"]:
+                project.config["pootle_fs.fs_url"] = options["fs_url"]
+        except ValidationError as e:
+            if options["traceback"]:
+                traceback.print_exc()
+            raise CommandError(e)

--- a/tests/commands/create_project.py
+++ b/tests/commands/create_project.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.core.management import call_command, CommandError
+
+from pootle.core.plugin import provider
+from pootle_fs.delegate import fs_plugins
+from pootle_fs.plugin import Plugin
+from pootle_fs.presets import FS_PRESETS
+from pootle_project.models import Project
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_defaults(settings):
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=gnu")
+    foo0 = Project.objects.get(code="foo0")
+    assert foo0.fullname == "Foo0"
+    assert foo0.checkstyle == "standard"
+    assert foo0.filetypes.first().name == "po"
+    assert foo0.source_language.code == "en"
+    assert foo0.disabled is False
+    assert foo0.report_email == ""
+
+    assert (
+        foo0.config["pootle_fs.translation_mapping"]
+        == dict(default=FS_PRESETS["gnu"][0]))
+    assert foo0.config["pootle_fs.fs_type"] == "localfs"
+    assert (
+        foo0.config["pootle_fs.fs_url"]
+        == ("{POOTLE_TRANSLATION_DIRECTORY}%s"
+            % foo0.code))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_existing_project(settings):
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=gnu")
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo0",
+            "--preset-mapping=gnu")
+    assert (
+        "'code': [u'Project with this Code already exists.'"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_title(capfd):
+    call_command(
+        "create_project",
+        "foo1",
+        "--name=Bar1",
+        "--preset-mapping=gnu")
+    foo1 = Project.objects.get(code="foo1")
+    assert foo1.fullname == "Bar1"
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_checkstyle(capfd):
+    call_command(
+        "create_project",
+        "foo0",
+        "--checkstyle=minimal",
+        "--preset-mapping=gnu")
+    foo0 = Project.objects.get(code="foo0")
+    assert foo0.checkstyle == "minimal"
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo1",
+            "--preset-mapping=gnu",
+            "--checkstyle=DOESNOTEXIST")
+    assert (
+        "Error: argument --checkstyle: invalid choice: u'DOESNOTEXIST'"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_filetypes(capfd):
+    call_command(
+        "create_project",
+        "foo0",
+        "--filetype=ts",
+        "--preset-mapping=gnu")
+    foo0 = Project.objects.get(code="foo0")
+    assert foo0.filetypes.first().name == "ts"
+    call_command(
+        "create_project",
+        "foo1",
+        "--filetype=ts",
+        "--filetype=po",
+        "--preset-mapping=gnu")
+    foo1 = Project.objects.get(code="foo1")
+    assert (
+        list(foo1.filetypes.values_list("name", flat=True))
+        == ["ts", "po"])
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo2",
+            "--preset-mapping=gnu",
+            "--filetype=DOESNOTEXIST")
+    assert (
+        "Error: argument --filetype: invalid choice: u'DOESNOTEXIST'"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_report_email(capfd):
+    call_command(
+        "create_project",
+        "foo0",
+        "--report-email=foo@bar.com",
+        "--preset-mapping=gnu")
+    foo0 = Project.objects.get(code="foo0")
+    assert foo0.report_email == "foo@bar.com"
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo0",
+            "--report-email=foo@bar",
+            "--preset-mapping=gnu")
+    assert (
+        "CommandError: [u'Enter a valid email address.']"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_source_language(language0):
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=gnu",
+        "--source-language=%s" % language0.code)
+    foo0 = Project.objects.get(code="foo0")
+    assert foo0.source_language == language0
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo0",
+            "--preset-mapping=gnu",
+            "--source-language=DOESNOTEXIST")
+    assert (
+        "CommandError: Source language DOESNOTEXIST does not exist"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_disabled():
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=gnu",
+        "--disabled")
+    foo0 = Project.objects.get(code="foo0")
+    assert foo0.disabled is True
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_preset_mapping():
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=nongnu")
+    foo0 = Project.objects.get(code="foo0")
+    assert (
+        foo0.config["pootle_fs.translation_mapping"]
+        == dict(default=FS_PRESETS["nongnu"][0]))
+    with pytest.raises(CommandError) as e:
+        # cant specify both mapping and preset-mapping
+        call_command(
+            "create_project",
+            "foo1",
+            "--preset-mapping=gnu",
+            "--mapping='/<language_code>/<dir_path>/<filename>.<ext>'")
+    assert (
+        "Error: argument --mapping: not allowed with argument --preset-mapping"
+        in str(e))
+    with pytest.raises(CommandError) as e:
+        # must specify one or other mapping or preset
+        call_command(
+            "create_project",
+            "foo1")
+    assert (
+        "Error: one of the arguments --preset-mapping --mapping is required"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_mapping():
+    call_command(
+        "create_project",
+        "foo0",
+        "--mapping=/<language_code>/<dir_path>/<filename>.<ext>")
+    foo0 = Project.objects.get(code="foo0")
+    assert (
+        foo0.config["pootle_fs.translation_mapping"]
+        == dict(default=u'/<language_code>/<dir_path>/<filename>.<ext>'))
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo1",
+            "--mapping=NOTAMAPPING")
+    assert (
+        "Translation mapping 'NOTAMAPPING'"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_fs_type():
+
+    class DummyPlugin(Plugin):
+        pass
+
+    @provider(fs_plugins)
+    def dummy_fs_plugin(**kwargs):
+        return dict(dummyfs=DummyPlugin)
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo0",
+            "--preset-mapping=gnu",
+            "--fs-type=dummyfs")
+    assert (
+        "Parameter --fs-url is mandatory when --fs-type is not `localfs`"
+        in str(e))
+
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=gnu",
+        "--fs-type=dummyfs",
+        "--fs-url=DUMMYURL")
+    foo0 = Project.objects.get(code="foo0")
+    assert (
+        foo0.config["pootle_fs.fs_type"]
+        == "dummyfs")
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo1",
+            "--preset-mapping=gnu",
+            "--fs-type=DOESNOTEXIST")
+    assert (
+        "Error: argument --fs-type: invalid choice"
+        in str(e))
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_cmd_create_project_fs_url():
+    call_command(
+        "create_project",
+        "foo0",
+        "--preset-mapping=gnu",
+        "--fs-url={POOTLE_TRANSLATION_DIRECTORY}special_foo0")
+    foo0 = Project.objects.get(code="foo0")
+    assert (
+        foo0.config["pootle_fs.fs_url"]
+        == "{POOTLE_TRANSLATION_DIRECTORY}special_foo0")
+
+    call_command(
+        "create_project",
+        "foo1",
+        "--preset-mapping=gnu",
+        "--fs-url=/abs/path/to/foo1")
+    foo1 = Project.objects.get(code="foo1")
+    assert (
+        foo1.config["pootle_fs.fs_url"]
+        == "/abs/path/to/foo1")
+
+    with pytest.raises(CommandError) as e:
+        call_command(
+            "create_project",
+            "foo2",
+            "--preset-mapping=gnu",
+            "--fs-url=NOTANABSOLUTEPATH")
+    assert (
+        "Enter an absolute path "
+        in str(e))
+    with pytest.raises(Project.DoesNotExist):
+        Project.objects.get(code="foo2")

--- a/tests/commands/minus_minus_help.py
+++ b/tests/commands/minus_minus_help.py
@@ -16,6 +16,7 @@ CORE_APPS_WITH_COMMANDS = (
 
 
 @pytest.mark.cmd
+@pytest.mark.django_db
 @pytest.mark.parametrize("command,app", [
     (command, app)
     for command, app in get_commands().iteritems()


### PR DESCRIPTION
Added a create_project command (create_project.py in pootle/apps/pootle_app/management/commands/ ) to start analyzing the requirements to make a command for creating projects, without login as an administrator in the website.