### PR TITLE
Add back increment_unsynced_revision algo

### DIFF
--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -51,6 +51,7 @@ class Command(PootleCommand):
         plugin = FSPlugin(translation_project.project)
         plugin.add(pootle_path=path_glob, update="pootle")
         plugin.rm(pootle_path=path_glob, update="pootle")
+        plugin.resolve(pootle_path=path_glob)
         plugin.sync(pootle_path=path_glob, update="pootle")
 
     def _parse_tps_to_create(self, project):

--- a/pootle/apps/pootle_fs/files.py
+++ b/pootle/apps/pootle_fs/files.py
@@ -162,7 +162,8 @@ class FSFile(object):
             self.create_store()
         if self.store.obsolete:
             self.store.resurrect()
-        self._sync_to_pootle(merge=merge, pootle_wins=pootle_wins)
+        return self._sync_to_pootle(
+            merge=merge, pootle_wins=pootle_wins)
 
     def push(self, user=None):
         """
@@ -178,7 +179,7 @@ class FSFile(object):
         if not os.path.exists(directory):
             logger.debug("Creating directory: %s", directory)
             os.makedirs(directory)
-        self._sync_from_pootle()
+        return self._sync_from_pootle()
 
     def read(self):
         if not self.file_exists:
@@ -219,6 +220,7 @@ class FSFile(object):
         with open(self.file_path, "w") as f:
             f.write(str(disk_store))
         logger.debug("Pushed file: %s", self.path)
+        return self.store.data.max_unit_revision
 
     def _sync_to_pootle(self, merge=False, pootle_wins=None):
         """
@@ -242,10 +244,11 @@ class FSFile(object):
             # This is analogous to the `overwrite` option in
             # Store.update_from_disk
             revision = Revision.get() + 1
-        self.store.update(
+        update_revision, __ = self.store.update(
             tmp_store,
             submission_type=SubmissionTypes.SYSTEM,
             user=self.latest_user,
             store_revision=revision,
             resolve_conflict=resolve_conflict)
         logger.debug("Pulled file: %s", self.path)
+        return update_revision

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -955,7 +955,7 @@ class Store(AbstractStore):
         :param allow_add_and_obsolete: allow to add new units
             and make obsolete existing units
         """
-        self.updater.update(
+        return self.updater.update(
             store, user=user, store_revision=store_revision,
             submission_type=submission_type, resolve_conflict=resolve_conflict,
             allow_add_and_obsolete=allow_add_and_obsolete)

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -297,9 +297,9 @@ class StoreUpdater(object):
     def __init__(self, target_store):
         self.target_store = target_store
 
-    def increment_unsynced_unit_revision(self, update_revision):
+    def increment_unsynced_unit_revision(self, store_revision, update_revision):
         filter_by = {
-            'revision__gt': self.target_store.last_sync_revision,
+            'revision__gt': store_revision or 0,
             'revision__lt': update_revision,
             'state__gt': OBSOLETE}
         return self.target_store.unit_set.filter(
@@ -423,6 +423,8 @@ class StoreUpdater(object):
 
         # Update units
         changes['updated'], changes['suggested'] = self.update_units(update)
+        self.increment_unsynced_unit_revision(
+            update.store_revision, update.update_revision)
         return changes
 
     def update_units(self, update):

--- a/tests/pootle_fs/plugin.py
+++ b/tests/pootle_fs/plugin.py
@@ -272,7 +272,8 @@ def test_fs_plugin_sync_all():
             self.sync_order.append("plugin_push")
             return response
 
-        def sync_merge(self, state, response, fs_path=None, pootle_path=None):
+        def sync_merge(self, state, response, fs_path=None,
+                       pootle_path=None, update=None):
             self._merged = (state, response, fs_path, pootle_path)
             self.sync_order.append("merge")
 


### PR DESCRIPTION
increment unsynced revisions after fs.sync where update="pootle"

that way the unsynced units should be showing as unsynced and will update the file on next sync

this makes update_stores/sync_stores work independently