### PR TITLE
Raw sync

### DIFF
--- a/pootle/apps/pootle_format/formats/mozilla_lang.py
+++ b/pootle/apps/pootle_format/formats/mozilla_lang.py
@@ -17,7 +17,7 @@ class LangUnitSyncer(UnitSyncer):
 
     @property
     def target(self):
-        if self.isfuzzy:
+        if self.isfuzzy and not self.raw:
             return multistring("")
         return self.unit.target
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -983,8 +983,9 @@ class Store(AbstractStore):
     def deserialize(self, data):
         return StoreDeserialization(self).deserialize(data)
 
-    def serialize(self):
-        return StoreSerialization(self).serialize()
+    def serialize(self, include_obsolete=False):
+        return StoreSerialization(self).serialize(
+            include_obsolete=include_obsolete)
 
 # # # # # # # # # # # #  TranslationStore # # # # # # # # # # # # #
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -983,9 +983,9 @@ class Store(AbstractStore):
     def deserialize(self, data):
         return StoreDeserialization(self).deserialize(data)
 
-    def serialize(self, include_obsolete=False):
+    def serialize(self, include_obsolete=False, raw=False):
         return StoreSerialization(self).serialize(
-            include_obsolete=include_obsolete)
+            include_obsolete=include_obsolete, raw=raw)
 
 # # # # # # # # # # # #  TranslationStore # # # # # # # # # # # # #
 

--- a/pootle/apps/pootle_store/store/serialize.py
+++ b/pootle/apps/pootle_store/store/serialize.py
@@ -46,8 +46,8 @@ class StoreSerialization(object):
             found_serializers.append(available_serializers[serializer])
         return found_serializers
 
-    def tostring(self):
-        store = self.store.syncer.convert()
+    def tostring(self, include_obsolete=False):
+        store = self.store.syncer.convert(include_obsolete=include_obsolete)
         if hasattr(store, "updateheader"):
             # FIXME We need those headers on import
             # However some formats just don't support setting metadata
@@ -63,5 +63,5 @@ class StoreSerialization(object):
             data = serializer(self.store, data).output
         return data
 
-    def serialize(self):
-        return self.pipeline(self.tostring())
+    def serialize(self, include_obsolete=False):
+        return self.pipeline(self.tostring(include_obsolete=include_obsolete))

--- a/pootle/apps/pootle_store/store/serialize.py
+++ b/pootle/apps/pootle_store/store/serialize.py
@@ -6,7 +6,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from django.core.cache import caches
 from django.utils.functional import cached_property
 
 from pootle.core.delegate import config, serializers
@@ -65,14 +64,4 @@ class StoreSerialization(object):
         return data
 
     def serialize(self):
-        cache = caches["exports"]
-        ret = cache.get(
-            self.pootle_path,
-            version=self.max_unit_revision)
-        if not ret:
-            ret = self.pipeline(self.tostring())
-            cache.set(
-                self.pootle_path,
-                ret,
-                version=self.max_unit_revision)
-        return ret
+        return self.pipeline(self.tostring())

--- a/pootle/apps/pootle_store/store/serialize.py
+++ b/pootle/apps/pootle_store/store/serialize.py
@@ -46,8 +46,9 @@ class StoreSerialization(object):
             found_serializers.append(available_serializers[serializer])
         return found_serializers
 
-    def tostring(self, include_obsolete=False):
-        store = self.store.syncer.convert(include_obsolete=include_obsolete)
+    def tostring(self, include_obsolete=False, raw=False):
+        store = self.store.syncer.convert(
+            include_obsolete=include_obsolete, raw=raw)
         if hasattr(store, "updateheader"):
             # FIXME We need those headers on import
             # However some formats just don't support setting metadata
@@ -63,5 +64,6 @@ class StoreSerialization(object):
             data = serializer(self.store, data).output
         return data
 
-    def serialize(self, include_obsolete=False):
-        return self.pipeline(self.tostring(include_obsolete=include_obsolete))
+    def serialize(self, include_obsolete=False, raw=False):
+        return self.pipeline(
+            self.tostring(include_obsolete=include_obsolete, raw=raw))

--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -157,7 +157,7 @@ class StoreSyncer(object):
                          str(self.store.filetype.extension)])))
         return self._getclass(self.store)
 
-    def convert(self, fileclass=None):
+    def convert(self, fileclass=None, include_obsolete=False):
         """export to fileclass"""
         fileclass = fileclass or self.file_class
         logger.debug(
@@ -167,7 +167,11 @@ class StoreSyncer(object):
         output = fileclass()
         output.settargetlanguage(self.language.code)
         # FIXME: we should add some headers
-        for unit in self.store.units.iterator():
+        units = (
+            self.store.unit_set
+            if include_obsolete
+            else self.store.units)
+        for unit in units.iterator():
             output.addunit(
                 self.unit_sync_class(unit).convert(output.UnitClass))
         return output

--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -24,8 +24,9 @@ logger = logging.getLogger(__name__)
 
 class UnitSyncer(object):
 
-    def __init__(self, unit):
+    def __init__(self, unit, raw=False):
         self.unit = unit
+        self.raw = raw
 
     @property
     def context(self):
@@ -157,7 +158,7 @@ class StoreSyncer(object):
                          str(self.store.filetype.extension)])))
         return self._getclass(self.store)
 
-    def convert(self, fileclass=None, include_obsolete=False):
+    def convert(self, fileclass=None, include_obsolete=False, raw=False):
         """export to fileclass"""
         fileclass = fileclass or self.file_class
         logger.debug(
@@ -173,7 +174,7 @@ class StoreSyncer(object):
             else self.store.units)
         for unit in units.iterator():
             output.addunit(
-                self.unit_sync_class(unit).convert(output.UnitClass))
+                self.unit_sync_class(unit, raw=raw).convert(output.UnitClass))
         return output
 
     def _getclass(self, obj):


### PR DESCRIPTION
adds `raw` and `include_obsolete` flags to sync/serialization

this allows to serialize all units including obsolete and prevents any format mangling