### PR TITLE
Fix for updating units

### DIFF
--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -213,6 +213,9 @@ class UnitUpdater(object):
             self.newunit
             and self.fs_state_updated
             and not (
+                self.db_target_updated
+                and not self.should_update_target)
+            and not (
                 self.state_conflict_found
                 and self.update.resolve_conflict == POOTLE_WINS))
 


### PR DESCRIPTION
if unit on fs has changed state, but db unit has changed target (and pootle wins),
dont update the db unit.