### PR TITLE
Fix for unit obsoletion

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -325,8 +325,7 @@ class StoreDiff(object):
         return [unit['id'] for unitid, unit in self.target_units.items()
                 if ((unitid not in self.source_units
                      or self.source_units[unitid]['state'] == OBSOLETE)
-                    and unitid in self.active_target_units
-                    and unitid not in self.updated_target_units)]
+                    and unitid in self.active_target_units)]
 
     def get_units_to_update(self):
         uid_index_map = {}

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -922,26 +922,6 @@ class Store(AbstractStore):
         Unit.objects.filter(store_id=self.id, index__gte=start).update(
             index=operator.add(F('index'), delta))
 
-    def mark_units_obsolete(self, uids_to_obsolete,
-                            update_revision=None, user=None):
-        """Marks a bulk of units as obsolete.
-
-        :param uids_to_obsolete: UIDs of the units to be marked as obsolete.
-        :return: The number of units marked as obsolete.
-        """
-        obsoleted = 0
-        for unit in self.findid_bulk(uids_to_obsolete):
-            # Use the same (parent) object since units will
-            # accumulate the list of cache attributes to clear
-            # in the parent Store object
-            unit.store = self
-            if not unit.isobsolete():
-                unit.makeobsolete()
-                unit.revision = update_revision
-                unit.save(user=user)
-                obsoleted += 1
-        return obsoleted
-
     @cached_property
     def data_tool(self):
         return data_tool.get(self.__class__)(self)

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -1314,15 +1314,6 @@ def test_store_diff_delete_source_unit(diffable_stores):
     assert len(result["add"]) == 0
     assert len(result["index"]) == 0
 
-    # set the source_revision to less that than the target_stores' max_revision
-    # and the unit will be ignored, as its assumed to have been previously
-    # deleted
-    differ = StoreDiff(
-        target_store,
-        source_store,
-        target_store.get_max_unit_revision() - 1)
-    assert not differ.diff()
-
 
 @pytest.mark.django_db
 def test_store_diff_delete_obsoleted_target_unit(diffable_stores):


### PR DESCRIPTION
dont obsolete units that have been updated in diff class, but then do exclude them if not pootle wins in updater