### PR TITLE
Use langcode.po when initing from templates.pot

### DIFF
--- a/tests/models/translationproject.py
+++ b/tests/models/translationproject.py
@@ -78,6 +78,71 @@ def test_tp_create_templates(project0_nongnu, project0,
 
 
 @pytest.mark.django_db
+def test_tp_init_from_template_po(project0_nongnu, project0,
+                                  templates, no_templates_tps, complex_ttk):
+    # When initing a tp from a file called `template.pot` the resulting
+    # store should be called `langcode.po`
+    template_tp = TranslationProject.objects.create(
+        language=templates, project=project0)
+    template = Store.objects.create(
+        name="template.pot",
+        translation_project=template_tp,
+        parent=template_tp.directory)
+    template.update(complex_ttk)
+    tp = TranslationProject.objects.create(
+        project=project0, language=LanguageDBFactory())
+    tp.init_from_templates()
+    store = tp.stores.get()
+    assert store.name == "%s.po" % tp.language.code
+
+
+@pytest.mark.django_db
+def test_tp_init_from_templates_po(project0_nongnu, project0,
+                                   templates, no_templates_tps, complex_ttk):
+    # When initing a tp from a file called `templates.pot` the resulting
+    # store should be called `langcode.po`
+    template_tp = TranslationProject.objects.create(
+        language=templates, project=project0)
+    template = Store.objects.create(
+        name="templates.pot",
+        translation_project=template_tp,
+        parent=template_tp.directory)
+    template.update(complex_ttk)
+    tp = TranslationProject.objects.create(
+        project=project0, language=LanguageDBFactory())
+    tp.init_from_templates()
+    store = tp.stores.get()
+    assert store.name == "%s.po" % tp.language.code
+
+
+@pytest.mark.django_db
+def test_tp_init_from_templates_both(project0_nongnu, project0,
+                                     templates, no_templates_tps,
+                                     complex_ttk, store0):
+    # When initing a tp and there is both `template.pot` and
+    # `templates.pot` the first one added is used
+    template_tp = TranslationProject.objects.create(
+        language=templates, project=project0)
+    template1 = Store.objects.create(
+        name="templates.pot",
+        translation_project=template_tp,
+        parent=template_tp.directory)
+    template1.update(complex_ttk)
+    template2 = Store.objects.create(
+        name="template.pot",
+        translation_project=template_tp,
+        parent=template_tp.directory)
+    template2.update(store0.deserialize(store0.serialize()))
+    tp = TranslationProject.objects.create(
+        project=project0, language=LanguageDBFactory())
+    tp.init_from_templates()
+    store = tp.stores.get()
+    assert store.name == "%s.po" % tp.language.code
+    assert complex_ttk.units[1].target == store.units.first().target
+    assert store.units.count() == len(complex_ttk.units) - 1
+
+
+@pytest.mark.django_db
 def test_tp_create_with_files(project0_directory, project0, store0, settings):
     # lets add some files by hand
 


### PR DESCRIPTION
currently in init_from_templates if the template is called templates.pot (ie gnu-style layout) it will create a store called templates.po - this means all files will called templates.po and wont be able to sync to disk.

this PR uses langcode.po when initing from a template with this name, which is the expected behaviour for gnu-style projects