### PR TITLE
Deprecate update/sync stores commands

### DIFF
--- a/pootle/apps/pootle_app/management/commands/sync_stores.py
+++ b/pootle/apps/pootle_app/management/commands/sync_stores.py
@@ -28,9 +28,7 @@ class Command(PootleCommand):
             action='store_true',
             dest='overwrite',
             default=False,
-            help="Don't just save translations, but "
-                 "overwrite files to reflect state in database",
-        )
+            help="This option has been removed.")
         parser.add_argument(
             '--skip-missing',
             action='store_true',
@@ -43,10 +41,20 @@ class Command(PootleCommand):
             action='store_true',
             dest='force',
             default=False,
-            help="Don't ignore stores synced after last change",
-        )
+            help="This option has been removed.")
 
     warn_on_conflict = []
+
+    def handle(self, **options):
+        logger.warn(
+            "The sync_stores command is deprecated, use pootle fs instead")
+        if options["force"]:
+            logger.warn(
+                "The force option no longer has any affect on this command")
+        if options["overwrite"]:
+            logger.warn(
+                "The overwrite option no longer has any affect on this command")
+        super(Command, self).handle(**options)
 
     def handle_all_stores(self, translation_project, **options):
         path_glob = "%s*" % translation_project.pootle_path
@@ -64,12 +72,4 @@ class Command(PootleCommand):
                     translation_project.project.pk)
         if not options["skip_missing"]:
             plugin.add(pootle_path=path_glob, update="fs")
-        if options["overwrite"]:
-            plugin.resolve(
-                pootle_path=path_glob,
-                pootle_wins=True)
         plugin.sync(pootle_path=path_glob, update="fs")
-        if options["force"]:
-            # touch the timestamps on disk for files that
-            # werent updated
-            pass

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -40,9 +40,7 @@ class Command(PootleCommand):
             action='store_true',
             dest='force',
             default=False,
-            help="Unconditionally process all files (even if they "
-                 "appear unchanged).",
-        )
+            help="This option has been removed.")
 
     def handle_translation_project(self, translation_project, **options):
         """
@@ -51,7 +49,9 @@ class Command(PootleCommand):
         plugin = FSPlugin(translation_project.project)
         plugin.add(pootle_path=path_glob, update="pootle")
         plugin.rm(pootle_path=path_glob, update="pootle")
-        plugin.resolve(pootle_path=path_glob)
+        plugin.resolve(
+            pootle_path=path_glob,
+            merge=not options["overwrite"])
         plugin.sync(pootle_path=path_glob, update="pootle")
 
     def _parse_tps_to_create(self, project):
@@ -79,6 +79,11 @@ class Command(PootleCommand):
                 project=project)
 
     def handle_all(self, **options):
+        logger.warn(
+            "The update_stores command is deprecated, use pootle fs instead")
+        if options["force"]:
+            logger.warn(
+                "The force option no longer has any affect on this command")
         projects = (
             Project.objects.filter(code__in=self.projects)
             if self.projects

--- a/tests/commands/sync_stores.py
+++ b/tests/commands/sync_stores.py
@@ -27,7 +27,6 @@ def test_sync_stores_noargs(capfd, tmpdir):
     out, err = capfd.readouterr()
     # FIXME we should work out how to get something here
     assert out == ''
-    assert err == ''
 
 
 @pytest.mark.cmd


### PR DESCRIPTION
also:

- warn that force no longer has any effect
- fix the overwrite option

fixes #6638 
fixes #6690
