### PR TITLE
Fs placeholder

### DIFF
--- a/pootle/apps/pootle_fs/localfs.py
+++ b/pootle/apps/pootle_fs/localfs.py
@@ -59,5 +59,8 @@ class LocalFSUrlValidator(object):
     help_text = "Enter an absolute path to a directory on your filesystem"
 
     def validate(self, url):
-        if not url.startswith("/"):
+        is_valid = (
+            url.startswith("/")
+            or url.startswith("{POOTLE_TRANSLATION_DIRECTORY}"))
+        if not is_valid:
             raise forms.ValidationError(self.help_text)

--- a/pootle/apps/pootle_fs/plugin.py
+++ b/pootle/apps/pootle_fs/plugin.py
@@ -13,6 +13,7 @@ import uuid
 
 from bulk_update.helper import bulk_update
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils.functional import cached_property
@@ -82,7 +83,16 @@ class Plugin(object):
 
     @property
     def fs_url(self):
-        return self.project.config["pootle_fs.fs_url"]
+        fs_type = self.project.config["pootle_fs.fs_type"]
+        fs_url = self.project.config["pootle_fs.fs_url"]
+        parse_placeholder = (
+            fs_type == "localfs"
+            and fs_url.startswith("{POOTLE_TRANSLATION_DIRECTORY}"))
+        if parse_placeholder:
+            return os.path.join(
+                settings.POOTLE_TRANSLATION_DIRECTORY,
+                fs_url[30:])
+        return fs_url
 
     @property
     def fs_revision(self):

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -70,9 +70,7 @@ class ProjectManager(models.Manager):
         if project.config["pootle_fs.fs_type"] == "localfs":
             project.config["pootle_fs.fs_url"] = kwargs.pop(
                 "fs_url",
-                os.path.join(
-                    settings.POOTLE_TRANSLATION_DIRECTORY,
-                    project.code))
+                "{POOTLE_TRANSLATION_DIRECTORY}%s" % project.code)
         return project
 
     def get_or_create(self, *args, **kwargs):

--- a/tests/pootle_fs/localfs.py
+++ b/tests/pootle_fs/localfs.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+
+import pytest
+
+from pootle_fs.utils import FSPlugin
+
+
+@pytest.mark.django_db
+def test_fs_localfs_path(settings, project0):
+    project0.config["pootle_fs.fs_url"] = (
+        "{POOTLE_TRANSLATION_DIRECTORY}%s"
+        % project0.code)
+    plugin = FSPlugin(project0)
+    assert (
+        plugin.fs_url
+        == os.path.join(
+            settings.POOTLE_TRANSLATION_DIRECTORY,
+            project0.code))

--- a/tests/pootle_project/models.py
+++ b/tests/pootle_project/models.py
@@ -6,8 +6,6 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import os
-
 import pytest
 
 from pootle_project.models import Project
@@ -20,8 +18,4 @@ def test_project_create_defaults(settings, english):
         fullname="Project Foo 0",
         source_language=english)
     assert foo0.config["pootle_fs.fs_type"] == "localfs"
-    assert (
-        foo0.config["pootle_fs.fs_url"]
-        == os.path.join(
-            settings.POOTLE_TRANSLATION_DIRECTORY,
-            foo0.code))
+    assert "{POOTLE_TRANSLATION_DIRECTORY}%s" % foo0.code


### PR DESCRIPTION
if a `localfs` path starts with `{POOTLE_TRANSLATION_DIRECTORY}` it will interpolate the appropriate setting value.

this means that for a site that has several localfs projects, the translation directory setting can be changed without having to go back through all of the projects and update the paths