### PR TITLE
init: allow --yes option to overwrite existing configs

### DIFF
--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -938,6 +938,12 @@ Available options:
 
   Creates a development configuration instead.
 
+.. django-admin-option:: --yes
+
+  .. versionadded:: 2.9
+
+  Answer 'yes' to any questions blocking overwrite of existing config files.
+
 
 .. django-admin:: initdb
 

--- a/pootle/runner.py
+++ b/pootle/runner.py
@@ -121,6 +121,12 @@ def init_command(parser, args):
 
     src_dir = os.path.abspath(os.path.dirname(__file__))
     add_help_to_parser(parser)
+    parser.add_argument("--yes", "-y",
+                        dest='overwrite_template',
+                        default=False,
+                        action='store_true',
+                        help=(u"Overwrite existing configuration file "
+                              "without asking."))
     parser.add_argument("--dev",
                         dest='settings_template',
                         default=os.path.join(src_dir,
@@ -153,7 +159,9 @@ def init_command(parser, args):
 
     if os.path.exists(config_path):
         resp = None
-        if args.noinput:
+        if args.overwrite_template:
+            resp = "yes"
+        elif args.noinput:
             resp = 'n'
         else:
             resp = input("File already exists at %r, overwrite? [Ny] "


### PR DESCRIPTION
Using 'pootle init --yes' will overwrite any existing configuration
files i.e. by assuming yes to the question normally posed to protect
your existing config.