### PR TITLE
Add character count to edit page

### DIFF
--- a/pootle/core/templatetags/core.py
+++ b/pootle/core/templatetags/core.py
@@ -25,6 +25,13 @@ def to_js(value):
     return mark_safe('JSON.parse("%s")' % escapejs(jsonify(value)))
 
 
+@register.filter
+def map_to_lengths(value):
+    """Maps a list value by replacing each element with its length.
+    """
+    return [len(e) for e in value]
+
+
 @register.inclusion_tag('includes/formtable.html')
 def formtable(formtable):
     return dict(formtable=formtable)

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -915,6 +915,23 @@ PTL.editor = {
       this.checkSimilarTranslations();
       this.similarityTimer = null;  // So we know the code was run
     }, 200);
+
+    this.updateCharacterCount();
+  },
+
+  getCharacterCountString() {
+    if (ReactEditor.stateValues.length === 1) {
+      const counter = ReactEditor.stateValues[0].length;
+      const format = ngettext('%s character', '%s characters', counter);
+      return interpolate(format, [counter]);
+    }
+    const counters = ReactEditor.stateValues.map(e => e.length).join(' \ ');
+    const format = gettext('%s characters');
+    return interpolate(format, [counters]);
+  },
+
+  updateCharacterCount() {
+    $('#js-char-count').html(this.getCharacterCountString());
   },
 
   isTextareaValueDirty() {

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -212,9 +212,23 @@
               {% endblock %}
               <a class="js-toggle-raw"><i class="icon-raw-mode" title="{% trans 'Raw View' %}"></i></a>
             </div>
-            {% if unit.istranslated or unit.isfuzzy %}
-	    {% if unit.change.submitted_by and unit.change.submitted_on %}
             <div class="unit-meta">
+              <span id="js-char-count">
+                {% if unit_values|length == 1 %}
+                  {% blocktrans count counter=unit_values|first|length %}
+                    {{ counter }} character
+                  {% plural %}
+                    {{ counter }} characters
+                  {% endblocktrans %}
+                {% else %}
+                  {% blocktrans with counter=unit_values|map_to_lengths|join:" / " %}
+                    {{ counter }} characters
+                  {% endblocktrans %}
+                {% endif %}
+              </span>
+              {% if unit.istranslated or unit.isfuzzy %}
+              {% if unit.change.submitted_by and unit.change.submitted_on %}
+              <br>
               <time
                 title="{{ unit.change.submitted_on|dateformat }}"
                 datetime="{{ unit.change.submitted_on.isoformat }}">{{ unit.change.submitted_on|relative_datetime_format }}</time>
@@ -224,9 +238,9 @@
               <span>({% blocktrans with profile_url=reviewer.get_absolute_url %}reviewed by <a href="{{ profile_url }}">{{ reviewer }}</a>{% endblocktrans %})</span>
               {% endif %}
               {% endwith %}
+              {% endif %}
+              {% endif %}
             </div>
-            {% endif %}
-            {% endif %}
             {% if special_characters %}
               {% if cantranslate or cansuggest %}
               <div class="editor-specialchars-block" lang="{{ language.code }}">

--- a/tests/core/templatetags/core.py
+++ b/tests/core/templatetags/core.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from pootle.core.templatetags.core import map_to_lengths
+
+
+def test_map_to_length_empty_list():
+    assert map_to_lengths([]) == []
+
+
+def test_map_to_length_one_element():
+    assert map_to_lengths(['foo']) == [3]
+
+
+def test_map_to_length_multiple_elements():
+    assert map_to_lengths(['foobar', 'foo', 'f']) == [6, 3, 1]


### PR DESCRIPTION
This adds an auto-updating label for the current character count to the bottom of the editing text area.

Closes #6725

This obviously needs more polish. I just mean this to be a basis for discussion for what I requested in #6725 and how to achieve it. Here is an example of how it looks.

![Example](https://imgur.com/8F90zAw)