### PR TITLE
Requirement updates test

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,8 +1,7 @@
 # Testing
 
-factory_boy==2.9.2
-pytest==3.2.2
-pytest-catchlog==1.2.2
+factory-boy==2.10.0
+pytest==3.3.0
 pytest-cov==2.5.1
 pytest-django==3.1.2
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,7 +4,7 @@
 -r _docs.txt
 -r _lint.txt
 
-tox==2.8.2
+tox==3.0.0
 
 # Databases
 -r _db_mysql.txt
@@ -14,6 +14,6 @@ tox==2.8.2
 -r _es_5.txt
 
 # Test coverage
-codecov==2.0.9
-coverage==4.4.1
-coveralls==1.2.0
+codecov==2.0.15
+coverage==4.5.1
+coveralls==1.3.0


### PR DESCRIPTION
update test requirements - use pytest == 3.3.0 as pytest > 3.3 seems to break stuff (eg the `mark.django_db` for some reason in some places)