### PR TITLE
fix invalid return type causing `set() | None`

### DIFF
--- a/pootle/apps/accounts/utils.py
+++ b/pootle/apps/accounts/utils.py
@@ -362,7 +362,7 @@ class UserPurger(object):
                 # If the unit has been changed more recently we don't need to
                 # revert the unit state.
                 submission.delete()
-                return
+                continue
             submission.delete()
             other_submissions = (unit.get_state_changes()
                                      .exclude(submitter=self.user))


### PR DESCRIPTION
This code seems like it should be exhausting the iterator rather than returning early