### PR TITLE
Minor Sphinx build fixes

### DIFF
--- a/docs/_ext/pootle_docs.py
+++ b/docs/_ext/pootle_docs.py
@@ -19,7 +19,7 @@ def setup(app):
         rolename="setting",
         indextemplate="pair: %s; setting",
     )
-    app.add_description_unit(
+    app.add_object_type(
         directivename="django-admin",
         rolename="djadmin",
         indextemplate="pair: %s; django-admin command",

--- a/docs/server/installation.rst
+++ b/docs/server/installation.rst
@@ -125,15 +125,13 @@ Use :command:`pip` to install Pootle into the virtual environment:
 .. highlight:: console
 .. parsed-literal::
 
-  (env) $ pip install |--process-dependency-links --pre| Pootle
+  (env) $ pip install --pre Pootle
 
 
 This will also fetch and install Pootle's dependencies.
 
 .. note:: pip requires :ref:`--pre <pip:install_--pre>` to install pre-release
-   versions of Pootle, i.e. alpha, beta and rc versions. You may require
-   :ref:`--process-dependency-links <pip:--process-dependency-links>` if Pootle
-   depends on unreleased versions of third-party software.
+   versions of Pootle, i.e. alpha, beta and rc versions.
 
 To verify that everything installed correctly, you should be able to access the
 :command:`pootle` command line tool within your environment.


### PR DESCRIPTION
Minor patches to remove following warnings from docs build using Sphinx 1.8.3. 

pootle/docs/server/installation.rst:133: WARNING: undefined label: pip:--process-dependency-links (if the link has no caption the label must precede a section header)

pootle/docs/_ext/pootle_docs.py:26: RemovedInSphinx20Warning: app.add_description_unit() is now deprecated. Use app.add_object_type() instead.
  parse_node=parse_django_admin_node,


