### PR TITLE
docs: fix simple typo, suggetions -> suggestions

### DIFF
--- a/pootle/apps/pootle_data/store_data.py
+++ b/pootle/apps/pootle_data/store_data.py
@@ -159,7 +159,7 @@ class StoreDataUpdater(DataUpdater):
             return None
 
     def get_pending_suggestions(self, **kwargs):
-        """Return the count of pending suggetions for the store"""
+        """Return the count of pending suggestions for the store"""
         return (
             self.units.filter(suggestion__state__name="pending")
                       .values_list("suggestion").count())


### PR DESCRIPTION
There is a small typo in pootle/apps/pootle_data/store_data.py.

Should read `suggestions` rather than `suggetions`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md