### PR TITLE
Removed duplicated mapping keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,5 +120,3 @@ volumes:
   production-logs:
   production-ssl:
   web-logs:
-  postgres-data:
-  redis-data:


### PR DESCRIPTION
`docker-compose up` failed due to duplicated keys. Thus, removed duplicated mapping keys in order to to fix it