### PR TITLE
Updates README to note that Pootle is not actively maintained

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
 |logo| Pootle
 =============
 
+Maintainers needed
+------------------
+
+Pootle is in the process of looking for potential maintainers to take over.
+If you are interested in maintaining Pootle please open an issue at `Pootle Issues <https://github.com/translate/pootle/issues>`_.
+
+Until then, users can use `Weblate <https://github.com/WeblateOrg/weblate>`_ as an alternative.
+
 |chat| |build| |health| |coverage| |requirements|
 
 


### PR DESCRIPTION
- Fixes #6920 .
- Updates README to note that Pootle is not actively maintained. See https://github.com/translate/pootle/issues/6920#issuecomment-1525567199 and https://github.com/translate/pootle/issues/6920#issuecomment-1525596832 .